### PR TITLE
ci: fix Docker buildx cache driver for GHCR publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
## Summary

- Add `docker/setup-buildx-action@v3` step before the build in `publish.yml`

## Problem

The `publish.yml` workflow was failing with:
```
ERROR: failed to build: Cache export is not supported for the docker driver.
```

The `type=gha` cache requires the `docker-container` buildx driver, which is not the default on GitHub-hosted runners.

## Fix

Adding `docker/setup-buildx-action@v3` initialises buildx with the correct driver automatically, enabling GHA cache for faster builds.

## Test plan
- [ ] Verify `Publish Docker image → GHCR` workflow completes without cache errors