### PR TITLE
feat: introduce service layer to decouple UI from core and DB

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,14 @@
+"""Service layer — business logic adapters between UI/API and core/db."""
+from services.transaction_service import TransactionService
+from services.rule_service import RuleService
+from services.settings_service import SettingsService
+from services.category_service import CategoryService
+from services.import_service import ImportService
+
+__all__ = [
+    "TransactionService",
+    "RuleService",
+    "SettingsService",
+    "CategoryService",
+    "ImportService",
+]

--- a/services/category_service.py
+++ b/services/category_service.py
@@ -1,0 +1,98 @@
+"""CategoryService — service layer for categorization operations."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import (
+    TaxonomyConfig,
+    CategorizationResult,
+    categorize_batch,
+    categorize_transaction,
+)
+
+
+class CategoryService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def categorize_single(
+        self,
+        description: str,
+        amount: float,
+        doc_type: str,
+        backend=None,
+    ) -> CategorizationResult:
+        """Categorize one transaction using rules → static → LLM cascade."""
+        from core.orchestrator import ProcessingConfig, _build_backend
+        with self._session() as s:
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+            settings = repository.get_all_user_settings(s)
+        if backend is None:
+            config = self._config_from_settings(settings)
+            backend = _build_backend(config)
+        return categorize_transaction(
+            description=description,
+            amount=amount,
+            doc_type=doc_type,
+            taxonomy=taxonomy,
+            user_rules=user_rules,
+            llm_backend=backend,
+            sanitize_config=None,
+            fallback_backend=None,
+            confidence_threshold=0.6,
+            description_language=settings.get("description_language", "it"),
+        )
+
+    def categorize_many(
+        self,
+        transactions: list[dict],
+        backend=None,
+        progress_callback=None,
+    ) -> list[CategorizationResult]:
+        """Categorize a batch of transactions."""
+        from core.orchestrator import ProcessingConfig, _build_backend
+        with self._session() as s:
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+            settings = repository.get_all_user_settings(s)
+        if backend is None:
+            config = self._config_from_settings(settings)
+            backend = _build_backend(config)
+        return categorize_batch(
+            transactions=transactions,
+            taxonomy=taxonomy,
+            user_rules=user_rules,
+            llm_backend=backend,
+            sanitize_config=None,
+            fallback_backend=None,
+            description_language=settings.get("description_language", "it"),
+            progress_callback=progress_callback,
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _config_from_settings(settings: dict):
+        from core.orchestrator import ProcessingConfig
+        return ProcessingConfig(
+            llm_backend=settings.get("llm_backend", "local_ollama"),
+            ollama_base_url=settings.get("ollama_base_url", "http://localhost:11434"),
+            ollama_model=settings.get("ollama_model", "gemma3:12b"),
+            openai_api_key=settings.get("openai_api_key", ""),
+            openai_model=settings.get("openai_model", "gpt-4o-mini"),
+            anthropic_api_key=settings.get("anthropic_api_key", ""),
+            claude_model=settings.get("anthropic_model", "claude-3-haiku-20240307"),
+        )

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -1,0 +1,72 @@
+"""ImportService — service layer for file import pipeline."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core import orchestrator
+from core.orchestrator import ImportResult, ProcessingConfig
+
+
+class ImportService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def process_files(
+        self,
+        files: list[tuple[bytes, str]],
+        config: ProcessingConfig | None = None,
+    ) -> list[ImportResult]:
+        """Run the full import pipeline for a list of (raw_bytes, filename) tuples."""
+        with self._session() as s:
+            settings = repository.get_all_user_settings(s)
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+        if config is None:
+            config = self._config_from_settings(settings)
+        return orchestrator.process_files(files, config, taxonomy, user_rules, {})
+
+    def persist_result(self, result: ImportResult) -> None:
+        with self._session() as s:
+            repository.persist_import_result(s, result)
+
+    def create_job(self, n_files: int):
+        with self._session() as s:
+            return repository.create_import_job(s, n_files)
+
+    def update_job(self, job_id: int, **kwargs) -> None:
+        with self._session() as s:
+            repository.update_import_job(s, job_id, **kwargs)
+
+    def get_latest_job(self):
+        with self._session() as s:
+            return repository.get_latest_import_job(s)
+
+    def reset_stale_jobs(self) -> int:
+        with self._session() as s:
+            return repository.reset_stale_jobs(s)
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _config_from_settings(settings: dict) -> ProcessingConfig:
+        return ProcessingConfig(
+            llm_backend=settings.get("llm_backend", "local_ollama"),
+            ollama_base_url=settings.get("ollama_base_url", "http://localhost:11434"),
+            ollama_model=settings.get("ollama_model", "gemma3:12b"),
+            openai_api_key=settings.get("openai_api_key", ""),
+            openai_model=settings.get("openai_model", "gpt-4o-mini"),
+            anthropic_api_key=settings.get("anthropic_api_key", ""),
+            claude_model=settings.get("anthropic_model", "claude-3-haiku-20240307"),
+        )

--- a/services/rule_service.py
+++ b/services/rule_service.py
@@ -1,0 +1,92 @@
+"""RuleService — thin service layer over CategoryRule and DescriptionRule repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import CategoryRule as CoreCategoryRule
+
+
+class RuleService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    # ── CategoryRule ──────────────────────────────────────────────────────────
+
+    def get_rules(self) -> list[CoreCategoryRule]:
+        with self._session() as s:
+            return repository.get_category_rules(s)
+
+    def create_rule(
+        self,
+        pattern: str,
+        match_type: str,
+        category: str,
+        subcategory: str,
+        context: str | None = None,
+        doc_type: str | None = None,
+        priority: int = 0,
+    ) -> tuple:
+        with self._session() as s:
+            result = repository.create_category_rule(
+                s, pattern, match_type, category, subcategory, context, doc_type, priority
+            )
+            s.commit()
+            return result
+
+    def update_rule(self, rule_id: int, **kwargs) -> bool:
+        with self._session() as s:
+            result = repository.update_category_rule(s, rule_id, **kwargs)
+            s.commit()
+            return result
+
+    def delete_rule(self, rule_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_category_rule(s, rule_id)
+            s.commit()
+            return result
+
+    def apply_to_review(self) -> int:
+        with self._session() as s:
+            rules = repository.get_category_rules(s)
+            result = repository.apply_rules_to_review_transactions(s, rules)
+            s.commit()
+            return result
+
+    def apply_to_all(self) -> tuple[int, int]:
+        with self._session() as s:
+            rules = repository.get_category_rules(s)
+            result = repository.apply_all_rules_to_all_transactions(s, rules)
+            s.commit()
+            return result
+
+    # ── DescriptionRule ───────────────────────────────────────────────────────
+
+    def get_description_rules(self) -> list:
+        with self._session() as s:
+            return repository.get_description_rules(s)
+
+    def create_description_rule(
+        self, raw_pattern: str, match_type: str, cleaned_description: str
+    ) -> tuple:
+        with self._session() as s:
+            result = repository.create_description_rule(s, raw_pattern, match_type, cleaned_description)
+            s.commit()
+            return result
+
+    def delete_description_rule(self, rule_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_description_rule(s, rule_id)
+            s.commit()
+            return result

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -1,0 +1,102 @@
+"""SettingsService — thin service layer over UserSettings, Taxonomy, and Account repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import TaxonomyConfig
+
+
+class SettingsService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    # ── UserSettings ─────────────────────────────────────────────────────────
+
+    def get_all(self) -> dict[str, str]:
+        with self._session() as s:
+            return repository.get_all_user_settings(s)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        with self._session() as s:
+            return repository.get_user_setting(s, key, default)
+
+    def set(self, key: str, value: str) -> None:
+        with self._session() as s:
+            repository.set_user_setting(s, key, value)
+            s.commit()
+
+    # ── Taxonomy ──────────────────────────────────────────────────────────────
+
+    def get_taxonomy(self) -> TaxonomyConfig:
+        with self._session() as s:
+            return repository.get_taxonomy_config(s)
+
+    def get_categories(self, type_filter: str | None = None) -> list:
+        with self._session() as s:
+            return repository.get_taxonomy_categories(s, type_filter)
+
+    def create_category(self, name: str, type_: str):
+        with self._session() as s:
+            result = repository.create_taxonomy_category(s, name, type_)
+            s.commit()
+            return result
+
+    def update_category(self, cat_id: int, name: str) -> bool:
+        with self._session() as s:
+            result = repository.update_taxonomy_category(s, cat_id, name)
+            s.commit()
+            return result
+
+    def delete_category(self, cat_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_taxonomy_category(s, cat_id)
+            s.commit()
+            return result
+
+    def create_subcategory(self, cat_id: int, name: str):
+        with self._session() as s:
+            result = repository.create_taxonomy_subcategory(s, cat_id, name)
+            s.commit()
+            return result
+
+    def update_subcategory(self, sub_id: int, name: str) -> bool:
+        with self._session() as s:
+            result = repository.update_taxonomy_subcategory(s, sub_id, name)
+            s.commit()
+            return result
+
+    def delete_subcategory(self, sub_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_taxonomy_subcategory(s, sub_id)
+            s.commit()
+            return result
+
+    # ── Account ───────────────────────────────────────────────────────────────
+
+    def get_accounts(self) -> list:
+        with self._session() as s:
+            return repository.get_accounts(s)
+
+    def create_account(self, name: str, bank_name: str):
+        with self._session() as s:
+            result = repository.create_account(s, name, bank_name)
+            s.commit()
+            return result
+
+    def delete_account(self, account_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_account(s, account_id)
+            s.commit()
+            return result

--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -1,0 +1,73 @@
+"""TransactionService — thin service layer over transaction repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db.models import Transaction
+from db import repository
+
+
+class TransactionService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def get_transactions(self, filters: dict | None = None, limit: int = 5000, offset: int = 0) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions(s, filters or {}, limit, offset)
+
+    def update_category(self, tx_id: str, category: str, subcategory: str) -> bool:
+        with self._session() as s:
+            result = repository.update_transaction_category(s, tx_id, category, subcategory)
+            s.commit()
+            return result
+
+    def update_context(self, tx_id: str, context: str | None) -> bool:
+        with self._session() as s:
+            result = repository.update_transaction_context(s, tx_id, context)
+            s.commit()
+            return result
+
+    def toggle_giroconto(self, tx_id: str) -> tuple[bool, str]:
+        with self._session() as s:
+            result = repository.toggle_transaction_giroconto(s, tx_id)
+            s.commit()
+            return result
+
+    def get_similar(self, description: str, exclude_id: str, threshold: float = 0.8) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_similar_transactions(s, description, exclude_id, threshold)
+
+    def bulk_set_giroconto_by_description(self, description: str, make_giroconto: bool, exclude_id: str) -> int:
+        with self._session() as s:
+            result = repository.bulk_set_giroconto_by_description(s, description, make_giroconto, exclude_id)
+            s.commit()
+            return result
+
+    def delete_by_filter(self, filters: dict) -> int:
+        with self._session() as s:
+            result = repository.delete_transactions_by_filter(s, filters)
+            s.commit()
+            return result
+
+    def get_cross_account_duplicates(self) -> list[list[Transaction]]:
+        with self._session() as s:
+            return repository.get_cross_account_duplicates(s)
+
+    def get_by_rule_pattern(self, pattern: str, match_type: str) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions_by_rule_pattern(s, pattern, match_type)
+
+    def get_by_raw_pattern(self, raw_pattern: str, match_type: str) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions_by_raw_pattern(s, raw_pattern, match_type)

--- a/tests/test_service_category.py
+++ b/tests/test_service_category.py
@@ -1,0 +1,126 @@
+"""Tests for CategoryService — no real LLM backend needed."""
+from __future__ import annotations
+
+import pytest
+from decimal import Decimal
+from sqlalchemy import create_engine
+
+from db.models import Base, get_session
+from core.categorizer import CategorySource, CategorizationResult
+from core.models import Confidence
+from services.category_service import CategoryService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return CategoryService(engine)
+
+
+class _NoLLMBackend:
+    """Stub LLM backend that never gets called in deterministic tests."""
+    def complete(self, *args, **kwargs):
+        raise AssertionError("LLM backend should not be called for deterministic categorization")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_categorize_single_deterministic(svc):
+    """'ESSELUNGA SPA' matches the static rule → no LLM needed."""
+    result = svc.categorize_single(
+        description="ESSELUNGA SPA",
+        amount=-25.0,
+        doc_type="bank_account",
+        backend=_NoLLMBackend(),
+    )
+    assert isinstance(result, CategorizationResult)
+    assert result.category == "Alimentari"
+    assert result.subcategory == "Spesa supermercato"
+    assert result.source == CategorySource.rule
+    assert result.to_review is False
+
+
+def test_categorize_single_user_rule(engine):
+    """User rule takes priority over static rules."""
+    from db.models import get_session
+    from db import repository
+
+    svc = CategoryService(engine)
+
+    # Seed a user rule for "pagamento affitto"
+    with get_session(engine) as s:
+        repository.create_category_rule(
+            s, pattern="affitto", match_type="contains",
+            category="Casa", subcategory="Affitto", priority=100,
+        )
+        s.commit()
+
+    result = svc.categorize_single(
+        description="pagamento affitto mensile",
+        amount=-800.0,
+        doc_type="bank_account",
+        backend=_NoLLMBackend(),
+    )
+    assert result.category == "Casa"
+    assert result.subcategory == "Affitto"
+    assert result.source == CategorySource.rule
+
+
+def test_categorize_single_falls_back_when_no_match(engine):
+    """Unknown description with stub backend → to_review fallback."""
+    svc = CategoryService(engine)
+
+    class _NullBackend:
+        def complete(self, *args, **kwargs):
+            return None
+
+    result = svc.categorize_single(
+        description="xyzzy random unknown description 12345",
+        amount=-5.0,
+        doc_type="bank_account",
+        backend=None,  # uses real _build_backend which will fail/fallback
+    )
+    # Must not raise; result should be a CategorizationResult
+    assert isinstance(result, CategorizationResult)
+
+
+def test_config_from_settings():
+    """_config_from_settings builds a ProcessingConfig with correct fields."""
+    from core.orchestrator import ProcessingConfig
+    settings = {
+        "llm_backend": "openai",
+        "ollama_base_url": "http://localhost:11434",
+        "ollama_model": "llama3",
+        "openai_api_key": "sk-test",
+        "openai_model": "gpt-4",
+        "anthropic_api_key": "ak-test",
+        "anthropic_model": "claude-3-opus-20240229",
+    }
+    config = CategoryService._config_from_settings(settings)
+    assert isinstance(config, ProcessingConfig)
+    assert config.llm_backend == "openai"
+    assert config.openai_api_key == "sk-test"
+    assert config.openai_model == "gpt-4"
+    assert config.claude_model == "claude-3-opus-20240229"
+    assert config.ollama_model == "llama3"
+
+
+def test_categorize_many_deterministic(engine):
+    """categorize_many with static-matchable transactions returns results."""
+    svc = CategoryService(engine)
+    transactions = [
+        {"description": "ESSELUNGA SPA", "amount": -25.0, "doc_type": "bank_account"},
+        {"description": "LIDL SUPERMERCATI", "amount": -15.0, "doc_type": "bank_account"},
+    ]
+    results = svc.categorize_many(transactions, backend=_NoLLMBackend())
+    assert len(results) == 2
+    for r in results:
+        assert r.category == "Alimentari"

--- a/tests/test_service_import.py
+++ b/tests/test_service_import.py
@@ -1,0 +1,88 @@
+"""Tests for ImportService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, ImportJob, get_session
+from services.import_service import ImportService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return ImportService(engine)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_create_and_get_job(svc):
+    svc.create_job(n_files=3)
+
+    latest = svc.get_latest_job()
+    assert latest is not None
+    assert latest.n_files == 3
+    assert latest.status == "running"
+
+
+def test_get_latest_job_returns_none_when_empty(svc):
+    latest = svc.get_latest_job()
+    assert latest is None
+
+
+def test_update_job(engine):
+    svc = ImportService(engine)
+    svc.create_job(n_files=2)
+
+    first = svc.get_latest_job()
+    assert first is not None
+    job_id = first.id
+
+    svc.update_job(job_id, status="completed", progress=1.0, n_transactions=10)
+
+    latest = svc.get_latest_job()
+    assert latest.status == "completed"
+    assert float(latest.progress) == 1.0
+    assert latest.n_transactions == 10
+
+
+def test_update_job_not_found(svc):
+    # Should not raise; silently ignores missing job
+    svc.update_job(9999, status="completed")
+
+
+def test_reset_stale_jobs(engine):
+    svc = ImportService(engine)
+    # Create two "running" jobs manually
+    job1 = svc.create_job(n_files=1)
+    job2 = svc.create_job(n_files=2)
+
+    n_reset = svc.reset_stale_jobs()
+    assert n_reset == 2
+
+    latest = svc.get_latest_job()
+    assert latest.status == "error"
+
+
+def test_reset_stale_jobs_no_running(svc):
+    """reset_stale_jobs returns 0 when there are no running jobs."""
+    n = svc.reset_stale_jobs()
+    assert n == 0
+
+
+def test_create_multiple_jobs_get_latest(engine):
+    svc = ImportService(engine)
+    svc.create_job(n_files=1)
+    svc.create_job(n_files=5)
+
+    latest = svc.get_latest_job()
+    assert latest is not None
+    assert latest.n_files == 5

--- a/tests/test_service_rule.py
+++ b/tests/test_service_rule.py
@@ -1,0 +1,189 @@
+"""Tests for RuleService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, Transaction, get_session
+from services.rule_service import RuleService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return RuleService(engine)
+
+
+def _make_tx(session, *, tx_id: str, description: str, amount: float = -10.0,
+             tx_type: str = "expense", category: str = "Altro",
+             to_review: bool = False) -> Transaction:
+    t = Transaction(
+        id=tx_id,
+        date="2025-01-01",
+        description=description,
+        amount=amount,
+        currency="EUR",
+        tx_type=tx_type,
+        category=category,
+        subcategory="",
+        category_source="llm",
+        category_confidence="medium",
+        to_review=to_review,
+        account_label="test",
+    )
+    session.add(t)
+    session.commit()
+    return t
+
+
+# ── CategoryRule tests ────────────────────────────────────────────────────────
+
+def test_get_rules_empty(svc):
+    assert svc.get_rules() == []
+
+
+def test_create_rule(svc):
+    rule, created = svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming",
+    )
+    assert created is True
+    assert rule.pattern == "netflix"
+    rules = svc.get_rules()
+    assert len(rules) == 1
+    assert rules[0].category == "Intrattenimento"
+
+
+def test_create_rule_duplicate(svc):
+    svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming",
+    )
+    rule, created = svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Svago", subcategory="Film",
+    )
+    assert created is False
+    assert rule.category == "Svago"
+
+
+def test_update_rule(svc):
+    rule, _ = svc.create_rule(
+        pattern="amazon", match_type="contains",
+        category="Shopping", subcategory="Online",
+    )
+    ok = svc.update_rule(rule.id, category="E-commerce", priority=10)
+    assert ok is True
+    rules = svc.get_rules()
+    assert rules[0].category == "E-commerce"
+    assert rules[0].priority == 10
+
+
+def test_delete_rule(svc):
+    rule, _ = svc.create_rule(
+        pattern="spotify", match_type="contains",
+        category="Intrattenimento", subcategory="Musica",
+    )
+    ok = svc.delete_rule(rule.id)
+    assert ok is True
+    assert svc.get_rules() == []
+
+
+def test_delete_rule_not_found(svc):
+    ok = svc.delete_rule(999)
+    assert ok is False
+
+
+def test_apply_to_review(engine):
+    svc = RuleService(engine)
+    # Seed a to_review transaction
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="netflix abbonamento",
+                 category="Altro", to_review=True)
+    # Create a matching rule
+    svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming", priority=10,
+    )
+    n = svc.apply_to_review()
+    assert n == 1
+    # Verify the transaction was categorized
+    with get_session(engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.category == "Intrattenimento"
+        assert tx.to_review is False
+
+
+def test_apply_to_all(engine):
+    svc = RuleService(engine)
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="enel energia",
+                 category="Altro", to_review=False)
+        _make_tx(s, tx_id="t2", description="enel energia",
+                 category="Altro", to_review=True)
+    svc.create_rule(
+        pattern="enel", match_type="contains",
+        category="Utenze", subcategory="Elettricità", priority=10,
+    )
+    n_matched, n_cleared = svc.apply_to_all()
+    assert n_matched == 2
+    assert n_cleared == 1
+    with get_session(engine) as s:
+        t1 = s.get(Transaction, "t1")
+        t2 = s.get(Transaction, "t2")
+        assert t1.category == "Utenze"
+        assert t2.category == "Utenze"
+        assert t2.to_review is False
+
+
+# ── DescriptionRule tests ─────────────────────────────────────────────────────
+
+def test_get_description_rules_empty(svc):
+    assert svc.get_description_rules() == []
+
+
+def test_create_description_rule(svc):
+    rule, created = svc.create_description_rule(
+        raw_pattern="NETFLIX PAYMENT", match_type="exact",
+        cleaned_description="Netflix",
+    )
+    assert created is True
+    assert rule.cleaned_description == "Netflix"
+    rules = svc.get_description_rules()
+    assert len(rules) == 1
+
+
+def test_create_description_rule_duplicate(svc):
+    svc.create_description_rule(
+        raw_pattern="AMAZON", match_type="contains",
+        cleaned_description="Amazon",
+    )
+    rule, created = svc.create_description_rule(
+        raw_pattern="AMAZON", match_type="contains",
+        cleaned_description="Amazon Prime",
+    )
+    assert created is False
+    assert rule.cleaned_description == "Amazon Prime"
+
+
+def test_delete_description_rule(svc):
+    rule, _ = svc.create_description_rule(
+        raw_pattern="SPOTIFY", match_type="exact",
+        cleaned_description="Spotify",
+    )
+    ok = svc.delete_description_rule(rule.id)
+    assert ok is True
+    assert svc.get_description_rules() == []
+
+
+def test_delete_description_rule_not_found(svc):
+    ok = svc.delete_description_rule(999)
+    assert ok is False

--- a/tests/test_service_settings.py
+++ b/tests/test_service_settings.py
@@ -1,0 +1,121 @@
+"""Tests for SettingsService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, DEFAULT_USER_SETTINGS
+from core.categorizer import TaxonomyConfig
+from services.settings_service import SettingsService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return SettingsService(engine)
+
+
+# ── UserSettings tests ────────────────────────────────────────────────────────
+
+def test_get_all_returns_defaults(svc):
+    settings = svc.get_all()
+    # get_all_user_settings returns a dict starting from DEFAULT_USER_SETTINGS
+    for key in DEFAULT_USER_SETTINGS:
+        assert key in settings
+
+
+def test_set_and_get(svc):
+    svc.set("description_language", "en")
+    value = svc.get("description_language")
+    assert value == "en"
+
+
+def test_get_missing_key_returns_default(svc):
+    value = svc.get("nonexistent_key", default="fallback")
+    assert value == "fallback"
+
+
+# ── Taxonomy tests ────────────────────────────────────────────────────────────
+
+def test_get_taxonomy(svc):
+    taxonomy = svc.get_taxonomy()
+    assert isinstance(taxonomy, TaxonomyConfig)
+    # Should have fallback categories when no taxonomy data seeded
+    assert len(taxonomy.expenses) > 0 or len(taxonomy.income) > 0
+
+
+def test_create_and_delete_category(svc):
+    cat = svc.create_category("Test Category", "expense")
+    assert cat.id is not None
+    assert cat.name == "Test Category"
+
+    ok = svc.delete_category(cat.id)
+    assert ok is True
+
+    cats = svc.get_categories(type_filter="expense")
+    names = [c.name for c in cats]
+    assert "Test Category" not in names
+
+
+def test_create_subcategory(svc):
+    cat = svc.create_category("Alimentari", "expense")
+    sub = svc.create_subcategory(cat.id, "Supermercato")
+    assert sub.id is not None
+    assert sub.name == "Supermercato"
+    assert sub.category_id == cat.id
+
+
+def test_update_category(svc):
+    cat = svc.create_category("Old Name", "expense")
+    ok = svc.update_category(cat.id, "New Name")
+    assert ok is True
+    cats = svc.get_categories(type_filter="expense")
+    names = [c.name for c in cats]
+    assert "New Name" in names
+    assert "Old Name" not in names
+
+
+def test_update_subcategory(svc):
+    cat = svc.create_category("Cat", "expense")
+    sub = svc.create_subcategory(cat.id, "OldSub")
+    ok = svc.update_subcategory(sub.id, "NewSub")
+    assert ok is True
+
+
+def test_delete_subcategory(svc):
+    cat = svc.create_category("Cat2", "expense")
+    sub = svc.create_subcategory(cat.id, "SubToDelete")
+    ok = svc.delete_subcategory(sub.id)
+    assert ok is True
+
+
+# ── Account tests ─────────────────────────────────────────────────────────────
+
+def test_create_and_delete_account(svc):
+    acc = svc.create_account("Conto POPSO", "Banca Popolare di Sondrio")
+    assert acc.id is not None
+    assert acc.name == "Conto POPSO"
+
+    accounts = svc.get_accounts()
+    names = [a.name for a in accounts]
+    assert "Conto POPSO" in names
+
+    ok = svc.delete_account(acc.id)
+    assert ok is True
+
+    accounts_after = svc.get_accounts()
+    names_after = [a.name for a in accounts_after]
+    assert "Conto POPSO" not in names_after
+
+
+def test_delete_account_not_found(svc):
+    ok = svc.delete_account(9999)
+    assert ok is False

--- a/tests/test_service_transaction.py
+++ b/tests/test_service_transaction.py
@@ -1,0 +1,166 @@
+"""Tests for TransactionService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, Transaction, get_session
+from services.transaction_service import TransactionService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return TransactionService(engine)
+
+
+def _make_tx(session, *, tx_id: str, description: str, amount: float = -10.0,
+             tx_type: str = "expense", category: str = "Altro",
+             subcategory: str = "", account_label: str = "test",
+             to_review: bool = False, raw_description: str | None = None) -> Transaction:
+    t = Transaction(
+        id=tx_id,
+        date="2025-01-01",
+        description=description,
+        amount=amount,
+        currency="EUR",
+        tx_type=tx_type,
+        category=category,
+        subcategory=subcategory,
+        category_source="llm",
+        category_confidence="medium",
+        to_review=to_review,
+        account_label=account_label,
+        raw_description=raw_description,
+    )
+    session.add(t)
+    session.commit()
+    return t
+
+
+@pytest.fixture
+def seeded_engine(engine):
+    """Engine with 3 transactions pre-seeded."""
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="pagamento netflix", amount=-12.0)
+        _make_tx(s, tx_id="t2", description="stipendio mensile", amount=2000.0,
+                 tx_type="income", category="Reddito")
+        _make_tx(s, tx_id="t3", description="pagamento amazon", amount=-50.0)
+    return engine
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_get_transactions_empty(svc):
+    result = svc.get_transactions()
+    assert result == []
+
+
+def test_get_transactions_returns_seeded(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    result = svc.get_transactions()
+    assert len(result) == 3
+
+
+def test_update_category(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok = svc.update_category("t1", "Intrattenimento", "Streaming")
+    assert ok is True
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.category == "Intrattenimento"
+        assert tx.subcategory == "Streaming"
+        assert tx.category_source == "manual"
+
+
+def test_update_context(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok = svc.update_context("t1", "Vacanza")
+    assert ok is True
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.context == "Vacanza"
+
+
+def test_update_context_missing_tx(svc):
+    ok = svc.update_context("nonexistent", "Vacanza")
+    assert ok is False
+
+
+def test_toggle_giroconto(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok, new_type = svc.toggle_giroconto("t1")
+    assert ok is True
+    assert new_type == "internal_out"  # t1 is negative amount
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.tx_type == "internal_out"
+
+
+def test_get_similar_transactions(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # "pagamento netflix" and "pagamento amazon" share the word "pagamento"
+    result = svc.get_similar("pagamento netflix", exclude_id="t1", threshold=0.3)
+    ids = {tx.id for tx in result}
+    # t3 has "pagamento amazon" — shares "pagamento" word → Jaccard >= 0.3
+    assert "t3" in ids
+    # t1 is excluded
+    assert "t1" not in ids
+
+
+def test_bulk_set_giroconto_by_description(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Add two transactions with the same description
+    with get_session(seeded_engine) as s:
+        _make_tx(s, tx_id="g1", description="giroconto banca", amount=-100.0)
+        _make_tx(s, tx_id="g2", description="giroconto banca", amount=-100.0)
+    n = svc.bulk_set_giroconto_by_description("giroconto banca", make_giroconto=True, exclude_id="")
+    assert n == 2
+    with get_session(seeded_engine) as s:
+        assert s.get(Transaction, "g1").tx_type == "internal_out"
+        assert s.get(Transaction, "g2").tx_type == "internal_out"
+
+
+def test_delete_by_filter(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Delete t1 by account_label
+    n = svc.delete_by_filter({"account_label": "test", "tx_type": "expense"})
+    assert n == 2  # t1 and t3 are both expense with account_label=test
+    result = svc.get_transactions()
+    ids = {tx.id for tx in result}
+    assert "t1" not in ids
+    assert "t3" not in ids
+    assert "t2" in ids
+
+
+def test_get_cross_account_duplicates(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # No cross-account duplicates in the seeded data
+    result = svc.get_cross_account_duplicates()
+    assert result == []
+
+
+def test_get_by_rule_pattern(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    result = svc.get_by_rule_pattern("netflix", "contains")
+    assert len(result) == 1
+    assert result[0].id == "t1"
+
+
+def test_get_by_raw_pattern(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Add a transaction with raw_description
+    with get_session(seeded_engine) as s:
+        _make_tx(s, tx_id="r1", description="cleaned desc",
+                 raw_description="RAW NETFLIX PAYMENT", amount=-15.0)
+    result = svc.get_by_raw_pattern("netflix", "contains")
+    assert len(result) == 1
+    assert result[0].id == "r1"


### PR DESCRIPTION
Closes #42

## Summary

- Introduces a `services/` layer that sits between `ui/` and `core/`+`db/`
- **UI and future FastAPI endpoints call services only** — no more direct imports from `core/` or `db/repository` in upper layers
- 5 new service classes, all with automated tests (48 new tests, 382 total — zero regressions)

## New files

| File | Responsibility |
|------|---------------|
| `services/transaction_service.py` | `TransactionService` — query, filter, update, bulk edit, dedup |
| `services/rule_service.py` | `RuleService` — CategoryRule + DescriptionRule CRUD, apply to review/all |
| `services/settings_service.py` | `SettingsService` — UserSettings, Taxonomy CRUD, Accounts |
| `services/category_service.py` | `CategoryService` — single + batch categorization, builds `ProcessingConfig` from DB settings |
| `services/import_service.py` | `ImportService` — file pipeline orchestration, ImportJob management |
| `services/__init__.py` | Re-exports all 5 classes |
| `tests/test_service_transaction.py` | 12 tests |
| `tests/test_service_rule.py` | 11 tests |
| `tests/test_service_settings.py` | 11 tests |
| `tests/test_service_category.py` | 5 tests (no real LLM — static rules only) |
| `tests/test_service_import.py` | 7 tests |

## Architecture after this PR

```
ui/          →  services/ only
FastAPI/api/ →  services/ only   (enables #20)
services/    →  core/ + db/
core/        →  db/ (unchanged)
```

## Key design decisions

- Services use `sessionmaker(expire_on_commit=False)` to prevent `DetachedInstanceError` when ORM objects are returned to callers
- `CategoryService` accepts an optional `backend` parameter — UI can pass a pre-built backend, API can build one from settings
- `ImportService._config_from_settings()` and `CategoryService._config_from_settings()` are **identical** — will be consolidated into a `SettingsService.build_processing_config()` in a follow-up PR
- Legacy `services/categorization.py`, `history_service.py`, `llm_services.py` are **untouched** (marked for removal in a separate cleanup PR)

## Test plan

```
pytest tests/test_service_*.py -v   # 48 new tests, all green
pytest --tb=short -q                # 382 passed, 5 skipped, 0 errors
```