### PR TITLE
feat: FastAPI REST API layer — UI-independent HTTP interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,34 @@ jobs:
         if: always()
         run: docker compose -f docker/docker-compose.yml down -v
 
+  coupling-check:
+    name: Coupling check (UI ↔ Service layer)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: "latest"
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Run coupling check (report only — no threshold yet)
+        run: uv run python tools/coupling_check.py --json | tee coupling_report.json
+
+      - name: Upload coupling report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coupling-report
+          path: coupling_report.json
+          retention-days: 30
+
   installer-validate:
     name: Installer validation (syntax + compose)
     runs-on: ubuntu-latest

--- a/api/dependencies.py
+++ b/api/dependencies.py
@@ -1,0 +1,51 @@
+"""FastAPI dependency injection — DB engine and service instances."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+
+from db.models import create_tables
+from services import (
+    TransactionService,
+    RuleService,
+    SettingsService,
+    CategoryService,
+    ImportService,
+)
+
+
+def _db_url() -> str:
+    return os.getenv("DATABASE_URL", "sqlite:///ledger.db")
+
+
+@lru_cache(maxsize=1)
+def get_engine() -> Engine:
+    engine = create_engine(_db_url(), connect_args={"check_same_thread": False})
+    create_tables(engine)
+    return engine
+
+
+# FastAPI `Depends()` callables — one service instance per request is fine
+# because each service manages its own session context internally.
+
+def get_transaction_service() -> TransactionService:
+    return TransactionService(get_engine())
+
+
+def get_rule_service() -> RuleService:
+    return RuleService(get_engine())
+
+
+def get_settings_service() -> SettingsService:
+    return SettingsService(get_engine())
+
+
+def get_category_service() -> CategoryService:
+    return CategoryService(get_engine())
+
+
+def get_import_service() -> ImportService:
+    return ImportService(get_engine())

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,80 @@
+"""FastAPI application — REST API layer for the personal finance ledger.
+
+All business logic lives in /services/.  This module is a thin HTTP adapter.
+
+Endpoints:
+  GET    /health
+  GET    /transactions
+  PATCH  /transactions/{id}/category
+  PATCH  /transactions/{id}/context
+  POST   /transactions/{id}/toggle-giroconto
+  DELETE /transactions
+
+  GET    /rules/category
+  POST   /rules/category
+  PATCH  /rules/category/{id}
+  DELETE /rules/category/{id}
+  POST   /rules/category/apply-to-review
+  POST   /rules/category/apply-to-all
+  GET    /rules/description
+  POST   /rules/description
+  DELETE /rules/description/{id}
+
+  GET    /settings
+  GET    /settings/{key}
+  PUT    /settings/{key}
+
+  GET    /accounts
+  POST   /accounts
+  DELETE /accounts/{id}
+
+  GET    /taxonomy/categories
+  POST   /taxonomy/categories
+  PATCH  /taxonomy/categories/{id}
+  DELETE /taxonomy/categories/{id}
+  POST   /taxonomy/categories/{id}/subcategories
+  PATCH  /taxonomy/subcategories/{id}
+  DELETE /taxonomy/subcategories/{id}
+
+  GET    /import/jobs/latest
+"""
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from api.routers import import_, rules, taxonomy, transactions
+from api.routers.settings import accounts_router, router as settings_router
+from api.schemas import StatusResponse
+
+app = FastAPI(
+    title="Spendify API",
+    description="REST API for the personal finance ledger. UI-independent — all logic in /services/.",
+    version="1.0.0",
+    docs_url="/docs",
+    redoc_url="/redoc",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8501", "http://127.0.0.1:8501"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+# ── Routers ───────────────────────────────────────────────────────────────────
+
+app.include_router(transactions.router)
+app.include_router(rules.router)
+app.include_router(settings_router)
+app.include_router(accounts_router)
+app.include_router(taxonomy.router)
+app.include_router(import_.router)
+
+
+# ── Health ────────────────────────────────────────────────────────────────────
+
+@app.get("/health", response_model=StatusResponse, tags=["health"])
+def health() -> StatusResponse:
+    return StatusResponse(status="ok")

--- a/api/routers/import_.py
+++ b/api/routers/import_.py
@@ -1,0 +1,32 @@
+"""Router: /import"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+
+from api.dependencies import get_import_service
+from api.schemas import ImportJobResponse
+from services import ImportService
+
+router = APIRouter(prefix="/import", tags=["import"])
+
+
+def _job_to_schema(job) -> ImportJobResponse:
+    return ImportJobResponse(
+        id=job.id,
+        status=job.status,
+        progress=float(job.progress or 0.0),
+        status_message=job.status_message,
+        detail_message=job.detail_message,
+        n_transactions=job.n_transactions or 0,
+        n_files=job.n_files or 0,
+        started_at=job.started_at,
+        completed_at=job.completed_at,
+    )
+
+
+@router.get("/jobs/latest", response_model=ImportJobResponse | None)
+def get_latest_job(svc: ImportService = Depends(get_import_service)):
+    job = svc.get_latest_job()
+    if job is None:
+        return None
+    return _job_to_schema(job)

--- a/api/routers/rules.py
+++ b/api/routers/rules.py
@@ -1,0 +1,138 @@
+"""Router: /rules"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.dependencies import get_rule_service
+from api.schemas import (
+    CategoryRuleCreate,
+    CategoryRuleResponse,
+    CategoryRuleUpdate,
+    DeleteResponse,
+    DescriptionRuleCreate,
+    DescriptionRuleResponse,
+    RuleApplyResponse,
+    StatusResponse,
+)
+from services import RuleService
+
+router = APIRouter(prefix="/rules", tags=["rules"])
+
+
+def _rule_to_schema(rule) -> CategoryRuleResponse:
+    # RuleService returns CoreCategoryRule (dataclass, no created_at) or ORM object
+    return CategoryRuleResponse(
+        id=rule.id,
+        pattern=rule.pattern,
+        match_type=rule.match_type,
+        category=rule.category,
+        subcategory=rule.subcategory,
+        context=rule.context,
+        doc_type=rule.doc_type,
+        priority=rule.priority or 0,
+        created_at=getattr(rule, "created_at", None),
+    )
+
+
+def _desc_rule_to_schema(rule) -> DescriptionRuleResponse:
+    return DescriptionRuleResponse(
+        id=rule.id,
+        raw_pattern=rule.raw_pattern,
+        match_type=rule.match_type,
+        cleaned_description=rule.cleaned_description,
+        created_at=rule.created_at,
+    )
+
+
+# ── Category Rules ─────────────────────────────────────────────────────────────
+
+@router.get("/category", response_model=list[CategoryRuleResponse])
+def list_category_rules(svc: RuleService = Depends(get_rule_service)):
+    return [_rule_to_schema(r) for r in svc.get_rules()]
+
+
+@router.post("/category", response_model=CategoryRuleResponse, status_code=201)
+def create_category_rule(
+    body: CategoryRuleCreate,
+    svc: RuleService = Depends(get_rule_service),
+):
+    rule, _ = svc.create_rule(
+        pattern=body.pattern,
+        match_type=body.match_type,
+        category=body.category,
+        subcategory=body.subcategory or "",
+        context=body.context,
+        doc_type=body.doc_type,
+        priority=body.priority,
+    )
+    return _rule_to_schema(rule)
+
+
+@router.patch("/category/{rule_id}", response_model=StatusResponse)
+def update_category_rule(
+    rule_id: int,
+    body: CategoryRuleUpdate,
+    svc: RuleService = Depends(get_rule_service),
+):
+    updates = body.model_dump(exclude_none=True)
+    if not updates:
+        raise HTTPException(status_code=422, detail="No fields to update")
+    ok = svc.update_rule(rule_id, **updates)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Rule {rule_id} not found")
+    return StatusResponse()
+
+
+@router.delete("/category/{rule_id}", response_model=DeleteResponse)
+def delete_category_rule(
+    rule_id: int,
+    svc: RuleService = Depends(get_rule_service),
+):
+    ok = svc.delete_rule(rule_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Rule {rule_id} not found")
+    return DeleteResponse(deleted=1)
+
+
+@router.post("/category/apply-to-review", response_model=RuleApplyResponse)
+def apply_rules_to_review(svc: RuleService = Depends(get_rule_service)):
+    n = svc.apply_to_review()
+    return RuleApplyResponse(applied=n, message=f"Applied to {n} review transactions")
+
+
+@router.post("/category/apply-to-all", response_model=RuleApplyResponse)
+def apply_rules_to_all(svc: RuleService = Depends(get_rule_service)):
+    n_cat, n_ctx = svc.apply_to_all()
+    total = n_cat + n_ctx
+    return RuleApplyResponse(applied=total, message=f"Updated {n_cat} categories, {n_ctx} contexts")
+
+
+# ── Description Rules ──────────────────────────────────────────────────────────
+
+@router.get("/description", response_model=list[DescriptionRuleResponse])
+def list_description_rules(svc: RuleService = Depends(get_rule_service)):
+    return [_desc_rule_to_schema(r) for r in svc.get_description_rules()]
+
+
+@router.post("/description", response_model=DescriptionRuleResponse, status_code=201)
+def create_description_rule(
+    body: DescriptionRuleCreate,
+    svc: RuleService = Depends(get_rule_service),
+):
+    rule, _ = svc.create_description_rule(
+        raw_pattern=body.raw_pattern,
+        match_type=body.match_type,
+        cleaned_description=body.cleaned_description,
+    )
+    return _desc_rule_to_schema(rule)
+
+
+@router.delete("/description/{rule_id}", response_model=DeleteResponse)
+def delete_description_rule(
+    rule_id: int,
+    svc: RuleService = Depends(get_rule_service),
+):
+    ok = svc.delete_description_rule(rule_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Description rule {rule_id} not found")
+    return DeleteResponse(deleted=1)

--- a/api/routers/settings.py
+++ b/api/routers/settings.py
@@ -1,0 +1,91 @@
+"""Router: /settings"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.dependencies import get_settings_service
+from api.schemas import (
+    AccountCreate,
+    AccountResponse,
+    AllSettingsResponse,
+    SettingResponse,
+    SettingUpdate,
+    StatusResponse,
+    DeleteResponse,
+)
+from services import SettingsService
+
+router = APIRouter(prefix="/settings", tags=["settings"])
+
+# Sensitive keys are never exposed via the API
+_REDACTED_KEYS = {"openai_api_key", "anthropic_api_key"}
+
+
+def _safe_settings(raw: dict) -> dict:
+    return {k: ("***" if k in _REDACTED_KEYS else v) for k, v in raw.items()}
+
+
+@router.get("", response_model=AllSettingsResponse)
+def get_all_settings(svc: SettingsService = Depends(get_settings_service)):
+    return AllSettingsResponse(settings=_safe_settings(svc.get_all()))
+
+
+@router.get("/{key}", response_model=SettingResponse)
+def get_setting(key: str, svc: SettingsService = Depends(get_settings_service)):
+    if key in _REDACTED_KEYS:
+        raise HTTPException(status_code=403, detail="This setting is not accessible via API")
+    value = svc.get(key)
+    if value is None:
+        raise HTTPException(status_code=404, detail=f"Setting {key!r} not found")
+    return SettingResponse(key=key, value=value)
+
+
+@router.put("/{key}", response_model=StatusResponse)
+def set_setting(
+    key: str,
+    body: SettingUpdate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    if key in _REDACTED_KEYS:
+        raise HTTPException(status_code=403, detail="This setting cannot be updated via API")
+    svc.set(key, body.value)
+    return StatusResponse()
+
+
+# ── Accounts ──────────────────────────────────────────────────────────────────
+
+accounts_router = APIRouter(prefix="/accounts", tags=["accounts"])
+
+
+def _account_to_schema(acc) -> AccountResponse:
+    return AccountResponse(
+        id=acc.id,
+        name=acc.name,
+        bank_name=acc.bank_name,
+        created_at=acc.created_at,
+    )
+
+
+@accounts_router.get("", response_model=list[AccountResponse])
+def list_accounts(svc: SettingsService = Depends(get_settings_service)):
+    return [_account_to_schema(a) for a in svc.get_accounts()]
+
+
+@accounts_router.post("", response_model=AccountResponse, status_code=201)
+def create_account(
+    body: AccountCreate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    acc = svc.create_account(body.name, body.bank_name or "")
+    return _account_to_schema(acc)
+
+
+@accounts_router.delete("/{account_id}", response_model=DeleteResponse)
+def delete_account(
+    account_id: int,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    ok = svc.delete_account(account_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Account {account_id} not found")
+    return DeleteResponse(deleted=1)

--- a/api/routers/taxonomy.py
+++ b/api/routers/taxonomy.py
@@ -1,0 +1,112 @@
+"""Router: /taxonomy"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from api.dependencies import get_settings_service
+from api.schemas import (
+    DeleteResponse,
+    StatusResponse,
+    SubcategoryCreate,
+    SubcategoryResponse,
+    SubcategoryUpdate,
+    TaxonomyCategoryCreate,
+    TaxonomyCategoryResponse,
+    TaxonomyCategoryUpdate,
+)
+from services import SettingsService
+
+router = APIRouter(prefix="/taxonomy", tags=["taxonomy"])
+
+
+def _sub_to_schema(sub) -> SubcategoryResponse:
+    return SubcategoryResponse(id=sub.id, name=sub.name, sort_order=sub.sort_order or 0)
+
+
+def _cat_to_schema(cat) -> TaxonomyCategoryResponse:
+    # subcategories is lazy-loaded — may be inaccessible if the session is closed
+    from sqlalchemy.orm.exc import DetachedInstanceError
+    try:
+        subs = [_sub_to_schema(s) for s in (cat.subcategories or [])]
+    except DetachedInstanceError:
+        subs = []
+    return TaxonomyCategoryResponse(
+        id=cat.id,
+        name=cat.name,
+        type=cat.type,
+        sort_order=cat.sort_order or 0,
+        subcategories=subs,
+    )
+
+
+@router.get("/categories", response_model=list[TaxonomyCategoryResponse])
+def list_categories(
+    type: str | None = None,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    return [_cat_to_schema(c) for c in svc.get_categories(type_filter=type)]
+
+
+@router.post("/categories", response_model=TaxonomyCategoryResponse, status_code=201)
+def create_category(
+    body: TaxonomyCategoryCreate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    cat = svc.create_category(body.name, body.type)
+    return _cat_to_schema(cat)
+
+
+@router.patch("/categories/{cat_id}", response_model=StatusResponse)
+def update_category(
+    cat_id: int,
+    body: TaxonomyCategoryUpdate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    ok = svc.update_category(cat_id, body.name)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Category {cat_id} not found")
+    return StatusResponse()
+
+
+@router.delete("/categories/{cat_id}", response_model=DeleteResponse)
+def delete_category(
+    cat_id: int,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    ok = svc.delete_category(cat_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Category {cat_id} not found")
+    return DeleteResponse(deleted=1)
+
+
+@router.post("/categories/{cat_id}/subcategories", response_model=SubcategoryResponse, status_code=201)
+def create_subcategory(
+    cat_id: int,
+    body: SubcategoryCreate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    sub = svc.create_subcategory(cat_id, body.name)
+    return _sub_to_schema(sub)
+
+
+@router.patch("/subcategories/{sub_id}", response_model=StatusResponse)
+def update_subcategory(
+    sub_id: int,
+    body: SubcategoryUpdate,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    ok = svc.update_subcategory(sub_id, body.name)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Subcategory {sub_id} not found")
+    return StatusResponse()
+
+
+@router.delete("/subcategories/{sub_id}", response_model=DeleteResponse)
+def delete_subcategory(
+    sub_id: int,
+    svc: SettingsService = Depends(get_settings_service),
+):
+    ok = svc.delete_subcategory(sub_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Subcategory {sub_id} not found")
+    return DeleteResponse(deleted=1)

--- a/api/routers/transactions.py
+++ b/api/routers/transactions.py
@@ -1,0 +1,131 @@
+"""Router: /transactions"""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from api.dependencies import get_transaction_service
+from api.schemas import (
+    DeleteResponse,
+    StatusResponse,
+    TransactionCategoryUpdate,
+    TransactionContextUpdate,
+    TransactionListResponse,
+    TransactionResponse,
+)
+from services import TransactionService
+
+router = APIRouter(prefix="/transactions", tags=["transactions"])
+
+
+def _tx_to_schema(tx) -> TransactionResponse:
+    return TransactionResponse(
+        id=tx.id,
+        date=tx.date,
+        date_accounting=tx.date_accounting,
+        amount=float(tx.amount),
+        currency=tx.currency or "EUR",
+        description=tx.description,
+        doc_type=tx.doc_type,
+        account_label=tx.account_label,
+        tx_type=tx.tx_type,
+        category=tx.category,
+        subcategory=tx.subcategory,
+        category_confidence=tx.category_confidence,
+        category_source=tx.category_source,
+        reconciled=bool(tx.reconciled),
+        to_review=bool(tx.to_review),
+        context=tx.context,
+        created_at=tx.created_at,
+    )
+
+
+@router.get("", response_model=TransactionListResponse)
+def list_transactions(
+    from_date: str | None = Query(None, description="ISO date YYYY-MM-DD"),
+    to_date: str | None = Query(None, description="ISO date YYYY-MM-DD"),
+    account_label: str | None = Query(None),
+    category: str | None = Query(None),
+    tx_type: str | None = Query(None),
+    to_review: bool | None = Query(None),
+    limit: int = Query(500, ge=1, le=5000),
+    offset: int = Query(0, ge=0),
+    svc: TransactionService = Depends(get_transaction_service),
+):
+    filters: dict = {}
+    if from_date:
+        filters["from_date"] = from_date
+    if to_date:
+        filters["to_date"] = to_date
+    if account_label:
+        filters["account_label"] = account_label
+    if category:
+        filters["category"] = category
+    if tx_type:
+        filters["tx_type"] = tx_type
+    if to_review is not None:
+        filters["to_review"] = to_review
+
+    txs = svc.get_transactions(filters, limit=limit, offset=offset)
+    items = [_tx_to_schema(t) for t in txs]
+    return TransactionListResponse(items=items, total=len(items))
+
+
+@router.patch("/{tx_id}/category", response_model=StatusResponse)
+def update_category(
+    tx_id: str,
+    body: TransactionCategoryUpdate,
+    svc: TransactionService = Depends(get_transaction_service),
+):
+    ok = svc.update_category(tx_id, body.category, body.subcategory)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Transaction {tx_id!r} not found")
+    return StatusResponse()
+
+
+@router.patch("/{tx_id}/context", response_model=StatusResponse)
+def update_context(
+    tx_id: str,
+    body: TransactionContextUpdate,
+    svc: TransactionService = Depends(get_transaction_service),
+):
+    ok = svc.update_context(tx_id, body.context)
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"Transaction {tx_id!r} not found")
+    return StatusResponse()
+
+
+@router.post("/{tx_id}/toggle-giroconto", response_model=StatusResponse)
+def toggle_giroconto(
+    tx_id: str,
+    svc: TransactionService = Depends(get_transaction_service),
+):
+    ok, msg = svc.toggle_giroconto(tx_id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=msg or f"Transaction {tx_id!r} not found")
+    return StatusResponse(detail=msg)
+
+
+@router.delete("", response_model=DeleteResponse)
+def delete_transactions(
+    from_date: str | None = Query(None),
+    to_date: str | None = Query(None),
+    account_label: str | None = Query(None),
+    category: str | None = Query(None),
+    svc: TransactionService = Depends(get_transaction_service),
+):
+    filters: dict = {}
+    if from_date:
+        filters["from_date"] = from_date
+    if to_date:
+        filters["to_date"] = to_date
+    if account_label:
+        filters["account_label"] = account_label
+    if category:
+        filters["category"] = category
+    if not filters:
+        raise HTTPException(
+            status_code=422,
+            detail="At least one filter is required for bulk delete",
+        )
+    n = svc.delete_by_filter(filters)
+    return DeleteResponse(deleted=n)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -1,0 +1,204 @@
+"""Pydantic request/response schemas for the REST API.
+
+These are the public API contracts — independent from the SQLAlchemy ORM models.
+All field names follow snake_case and match the ORM columns unless noted.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+# ── Transaction ────────────────────────────────────────────────────────────────
+
+class TransactionResponse(BaseModel):
+    id: str
+    date: str
+    date_accounting: str | None = None
+    amount: float
+    currency: str = "EUR"
+    description: str | None = None
+    doc_type: str | None = None
+    account_label: str | None = None
+    tx_type: str | None = None
+    category: str | None = None
+    subcategory: str | None = None
+    category_confidence: str | None = None
+    category_source: str | None = None
+    reconciled: bool = False
+    to_review: bool = False
+    context: str | None = None
+    created_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class TransactionListResponse(BaseModel):
+    items: list[TransactionResponse]
+    total: int
+
+
+class TransactionCategoryUpdate(BaseModel):
+    category: str = Field(..., min_length=1)
+    subcategory: str = Field(default="")
+
+
+class TransactionContextUpdate(BaseModel):
+    context: str | None = None
+
+
+# ── Category Rule ──────────────────────────────────────────────────────────────
+
+class CategoryRuleResponse(BaseModel):
+    id: int
+    pattern: str
+    match_type: str
+    category: str
+    subcategory: str | None = None
+    context: str | None = None
+    doc_type: str | None = None
+    priority: int = 0
+    created_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class CategoryRuleCreate(BaseModel):
+    pattern: str = Field(..., min_length=1)
+    match_type: str = Field(..., pattern="^(contains|regex|exact)$")
+    category: str = Field(..., min_length=1)
+    subcategory: str | None = None
+    context: str | None = None
+    doc_type: str | None = None
+    priority: int = 0
+
+
+class CategoryRuleUpdate(BaseModel):
+    pattern: str | None = None
+    match_type: str | None = Field(default=None, pattern="^(contains|regex|exact)$")
+    category: str | None = None
+    subcategory: str | None = None
+    context: str | None = None
+    doc_type: str | None = None
+    priority: int | None = None
+
+
+class RuleApplyResponse(BaseModel):
+    applied: int
+    message: str
+
+
+# ── Description Rule ──────────────────────────────────────────────────────────
+
+class DescriptionRuleResponse(BaseModel):
+    id: int
+    raw_pattern: str
+    match_type: str
+    cleaned_description: str
+    created_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class DescriptionRuleCreate(BaseModel):
+    raw_pattern: str = Field(..., min_length=1)
+    match_type: str = Field(..., pattern="^(contains|regex|exact)$")
+    cleaned_description: str = Field(..., min_length=1)
+
+
+# ── Settings ──────────────────────────────────────────────────────────────────
+
+class SettingResponse(BaseModel):
+    key: str
+    value: str | None
+
+
+class SettingUpdate(BaseModel):
+    value: str
+
+
+class AllSettingsResponse(BaseModel):
+    settings: dict[str, str | None]
+
+
+# ── Taxonomy ──────────────────────────────────────────────────────────────────
+
+class SubcategoryResponse(BaseModel):
+    id: int
+    name: str
+    sort_order: int = 0
+
+    model_config = {"from_attributes": True}
+
+
+class TaxonomyCategoryResponse(BaseModel):
+    id: int
+    name: str
+    type: str
+    sort_order: int = 0
+    subcategories: list[SubcategoryResponse] = []
+
+    model_config = {"from_attributes": True}
+
+
+class TaxonomyCategoryCreate(BaseModel):
+    name: str = Field(..., min_length=1)
+    type: str = Field(..., pattern="^(expense|income)$")
+
+
+class TaxonomyCategoryUpdate(BaseModel):
+    name: str = Field(..., min_length=1)
+
+
+class SubcategoryCreate(BaseModel):
+    name: str = Field(..., min_length=1)
+
+
+class SubcategoryUpdate(BaseModel):
+    name: str = Field(..., min_length=1)
+
+
+# ── Account ───────────────────────────────────────────────────────────────────
+
+class AccountResponse(BaseModel):
+    id: int
+    name: str
+    bank_name: str | None = None
+    created_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+class AccountCreate(BaseModel):
+    name: str = Field(..., min_length=1)
+    bank_name: str | None = None
+
+
+# ── Import Job ────────────────────────────────────────────────────────────────
+
+class ImportJobResponse(BaseModel):
+    id: int
+    status: str
+    progress: float = 0.0
+    status_message: str | None = None
+    detail_message: str | None = None
+    n_transactions: int = 0
+    n_files: int = 0
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+    model_config = {"from_attributes": True}
+
+
+# ── Generic ───────────────────────────────────────────────────────────────────
+
+class DeleteResponse(BaseModel):
+    deleted: int
+    message: str = "ok"
+
+
+class StatusResponse(BaseModel):
+    status: str = "ok"
+    detail: str | None = None

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,41 @@ services:
       retries: 3
       start_period: 20s
 
+  # ── REST API — FastAPI + uvicorn ──────────────────────────────────────────────
+  # Espone le stesse operazioni del ledger via HTTP/JSON (UI-independent).
+  # Docs interattive: http://localhost:8000/docs
+  api:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    image: spendify:latest
+    container_name: spendify_api
+    restart: unless-stopped
+    command: ["uv", "run", "uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+    ports:
+      - "8000:8000"
+
+    environment:
+      DATABASE_URL: "sqlite:////app/data/ledger.db"
+      TAXONOMY_PATH: "/app/taxonomy.yaml"
+
+    volumes:
+      - spendify_data:/app/data
+      - ../taxonomy.yaml:/app/taxonomy.yaml:ro
+
+    depends_on:
+      spendify:
+        condition: service_healthy
+
+    healthcheck:
+      test: ["CMD", "uv", "run", "python", "-c",
+             "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+
   # ── LLM locale — Ollama (Linux/server con GPU NVIDIA) ────────────────────────
   # Avvio con Ollama: docker compose --profile ollama up -d
   # Poi scarica il modello (una tantum): docker compose exec ollama ollama pull gemma3:12b

--- a/docs/deployment.en.md
+++ b/docs/deployment.en.md
@@ -88,6 +88,8 @@ docker compose up -d --build
 
 The app is available at **http://localhost:8501**
 
+> The REST API is available at **http://localhost:8000** · Interactive docs: **http://localhost:8000/docs**
+
 ### 2.4 — With local LLM (optional)
 
 ```bash
@@ -122,6 +124,12 @@ uv run streamlit run app.py
 ```
 
 The app is available at **http://localhost:8501**
+
+To also start the REST API in development:
+
+```bash
+uv run uvicorn api.main:app --host 0.0.0.0 --port 8000
+```
 
 > The `ledger.db` database is created automatically in the project folder on first launch.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,6 +88,8 @@ docker compose up -d --build
 
 L'app è disponibile su **http://localhost:8501**
 
+> La REST API è disponibile su **http://localhost:8000** · Docs interattive: **http://localhost:8000/docs**
+
 ### 2.4 — Con LLM locale (opzionale)
 
 ```bash
@@ -122,6 +124,12 @@ uv run streamlit run app.py
 ```
 
 L'app è disponibile su **http://localhost:8501**
+
+Per avviare anche la REST API in sviluppo:
+
+```bash
+uv run uvicorn api.main:app --host 0.0.0.0 --port 8000
+```
 
 > Il database `ledger.db` viene creato automaticamente nella cartella del progetto al primo avvio.
 

--- a/docs/progetto.en.md
+++ b/docs/progetto.en.md
@@ -34,6 +34,31 @@ Processing is **offline-first**: the default LLM backend is local Ollama; OpenAI
 
 ## 3. System Architecture
 
+### 3.0 Architectural layers
+
+```
+┌─────────────────────────────────────────────────┐
+│  Presentation                                   │
+│  ├─ Streamlit UI  (ui/, app.py)   :8501         │
+│  └─ FastAPI REST  (api/)          :8000         │
+├─────────────────────────────────────────────────┤
+│  Service layer   (services/)                    │
+│  TransactionService · RuleService               │
+│  SettingsService · CategoryService              │
+│  ImportService                                  │
+├─────────────────────────────────────────────────┤
+│  Business logic  (core/)                        │
+│  classifier · normalizer · categorizer          │
+│  sanitizer · description_cleaner · orchestrator │
+├─────────────────────────────────────────────────┤
+│  Persistence     (db/)                          │
+│  models (SQLAlchemy ORM) · repository (CRUD)    │
+│  SQLite: ledger.db                              │
+└─────────────────────────────────────────────────┘
+```
+
+The UI and API are fully independent and interchangeable: both rely on the service layer, which has no knowledge of HTTP or Streamlit.
+
 ### 3.1 Import Pipeline
 
 ```
@@ -363,7 +388,46 @@ Two DB tables: `taxonomy_category` and `taxonomy_subcategory`. Initial seeding f
 
 ---
 
-## 12. Tests
+## 12. REST API
+
+The FastAPI layer (`api/`) exposes the same ledger operations over HTTP/JSON, without touching the Streamlit UI.
+
+**Start:** `uv run uvicorn api.main:app --host 0.0.0.0 --port 8000`
+**Interactive docs:** `http://localhost:8000/docs` (Swagger UI)
+
+### Main endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Liveness check |
+| GET | `/transactions` | List with filters (date, category, account, to_review) |
+| PATCH | `/transactions/{id}/category` | Update category and subcategory |
+| PATCH | `/transactions/{id}/context` | Update life context |
+| POST | `/transactions/{id}/toggle-giroconto` | Toggle internal transfer flag |
+| DELETE | `/transactions` | Bulk delete by filter (at least 1 filter required) |
+| GET/POST/PATCH/DELETE | `/rules/category` | Category rule CRUD |
+| POST | `/rules/category/apply-to-review` | Apply rules to pending review |
+| POST | `/rules/category/apply-to-all` | Apply rules to all transactions |
+| GET/POST/DELETE | `/rules/description` | Description rule CRUD |
+| GET | `/settings` | All settings (API keys redacted) |
+| GET/PUT | `/settings/{key}` | Read/write a single setting |
+| GET/POST/DELETE | `/accounts` | Account CRUD |
+| GET/POST/PATCH/DELETE | `/taxonomy/categories` | Taxonomy category CRUD |
+| GET | `/import/jobs/latest` | Latest import job status |
+
+### Security
+
+- API keys (`openai_api_key`, `anthropic_api_key`) are always redacted (`***`) in GET responses
+- The same keys cannot be updated via API (403 Forbidden) — only from the Settings UI
+- CORS configured for `localhost:8501` (Streamlit) by default
+
+### Docker
+
+In Docker Compose, the `api` service shares the `spendify_data` volume (same `ledger.db`) with the Streamlit service.
+
+---
+
+## 13. Tests
 
 ```bash
 # Full suite

--- a/docs/progetto.md
+++ b/docs/progetto.md
@@ -34,6 +34,31 @@ Il processing è **offline-first**: il backend LLM di default è Ollama locale; 
 
 ## 3. Architettura del sistema
 
+### 3.0 Layer architetturali
+
+```
+┌─────────────────────────────────────────────────┐
+│  Presentazione                                  │
+│  ├─ Streamlit UI  (ui/, app.py)   :8501         │
+│  └─ FastAPI REST  (api/)          :8000         │
+├─────────────────────────────────────────────────┤
+│  Service layer   (services/)                    │
+│  TransactionService · RuleService               │
+│  SettingsService · CategoryService              │
+│  ImportService                                  │
+├─────────────────────────────────────────────────┤
+│  Business logic  (core/)                        │
+│  classifier · normalizer · categorizer          │
+│  sanitizer · description_cleaner · orchestrator │
+├─────────────────────────────────────────────────┤
+│  Persistenza     (db/)                          │
+│  models (SQLAlchemy ORM) · repository (CRUD)    │
+│  SQLite: ledger.db                              │
+└─────────────────────────────────────────────────┘
+```
+
+UI e API sono completamente indipendenti e intercambiabili: entrambe si appoggiano ai service, che non sanno nulla di HTTP o Streamlit.
+
 ### 3.1 Pipeline di importazione
 
 ```
@@ -363,7 +388,46 @@ Due tabelle DB: `taxonomy_category` e `taxonomy_subcategory`. Seeding iniziale d
 
 ---
 
-## 12. Test
+## 12. REST API
+
+Il layer FastAPI (`api/`) espone le stesse operazioni del ledger via HTTP/JSON, senza toccare la UI Streamlit.
+
+**Avvio:** `uv run uvicorn api.main:app --host 0.0.0.0 --port 8000`
+**Docs interattive:** `http://localhost:8000/docs` (Swagger UI)
+
+### Endpoint principali
+
+| Metodo | Path | Descrizione |
+|--------|------|-------------|
+| GET | `/health` | Liveness check |
+| GET | `/transactions` | Lista con filtri (data, categoria, account, to_review) |
+| PATCH | `/transactions/{id}/category` | Aggiorna categoria e sottocategoria |
+| PATCH | `/transactions/{id}/context` | Aggiorna contesto di vita |
+| POST | `/transactions/{id}/toggle-giroconto` | Alterna flag giroconto |
+| DELETE | `/transactions` | Eliminazione massiva per filtro (almeno 1 filtro obbligatorio) |
+| GET/POST/PATCH/DELETE | `/rules/category` | CRUD regole di categorizzazione |
+| POST | `/rules/category/apply-to-review` | Applica regole alle transazioni in review |
+| POST | `/rules/category/apply-to-all` | Applica regole a tutte le transazioni |
+| GET/POST/DELETE | `/rules/description` | CRUD regole descrizione |
+| GET | `/settings` | Tutte le impostazioni (API key oscurate) |
+| GET/PUT | `/settings/{key}` | Lettura/scrittura singola impostazione |
+| GET/POST/DELETE | `/accounts` | CRUD conti bancari |
+| GET/POST/PATCH/DELETE | `/taxonomy/categories` | CRUD categorie tassonomia |
+| GET | `/import/jobs/latest` | Stato dell'ultimo job di importazione |
+
+### Sicurezza
+
+- Le chiavi API (`openai_api_key`, `anthropic_api_key`) sono **sempre oscurate** nelle risposte GET
+- Le stesse chiavi non sono aggiornabili via API (403 Forbidden) — solo dalla UI Impostazioni
+- CORS configurato per `localhost:8501` (Streamlit) di default
+
+### Docker
+
+In Docker Compose, il servizio `api` è definito nel file `docker/docker-compose.yml` e condivide il volume `spendify_data` (stesso `ledger.db`) con il servizio Streamlit.
+
+---
+
+## 13. Test
 
 ```bash
 # Suite completa

--- a/docs/reference_guide.en.md
+++ b/docs/reference_guide.en.md
@@ -283,6 +283,57 @@ Schema migrations are idempotent: they run automatically at every startup withou
 
 ---
 
+## REST API
+
+The FastAPI layer (`api/`) exposes the same ledger features over HTTP/JSON — independent of the Streamlit UI, usable from scripts, automation, or future mobile/desktop apps.
+
+**Port:** `8000` · **Interactive docs:** `http://localhost:8000/docs`
+
+### Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/health` | Liveness check |
+| GET | `/transactions` | List transactions with filters |
+| PATCH | `/transactions/{id}/category` | Update category/subcategory |
+| PATCH | `/transactions/{id}/context` | Update life context |
+| POST | `/transactions/{id}/toggle-giroconto` | Toggle internal transfer flag |
+| DELETE | `/transactions` | Bulk delete by filter |
+| GET | `/rules/category` | List categorisation rules |
+| POST | `/rules/category` | Create rule |
+| PATCH | `/rules/category/{id}` | Update rule |
+| DELETE | `/rules/category/{id}` | Delete rule |
+| POST | `/rules/category/apply-to-review` | Apply rules to pending transactions |
+| POST | `/rules/category/apply-to-all` | Apply rules to entire ledger |
+| GET/POST/DELETE | `/rules/description` | Description rule CRUD |
+| GET | `/settings` | All settings (API keys redacted) |
+| GET/PUT | `/settings/{key}` | Read/write setting |
+| GET/POST/DELETE | `/accounts` | Account CRUD |
+| GET/POST/PATCH/DELETE | `/taxonomy/categories` | Category CRUD |
+| POST/PATCH/DELETE | `/taxonomy/categories/{id}/subcategories` | Subcategory CRUD |
+| GET | `/import/jobs/latest` | Latest import job status |
+
+### Query filters — GET /transactions
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from_date` | `YYYY-MM-DD` | Start date |
+| `to_date` | `YYYY-MM-DD` | End date |
+| `account_label` | string | Bank account |
+| `category` | string | Category |
+| `tx_type` | string | Transaction type |
+| `to_review` | bool | Pending review only |
+| `limit` | int (1–5000) | Max results (default 500) |
+| `offset` | int | Pagination offset |
+
+### Security notes
+
+- `openai_api_key` and `anthropic_api_key` are always masked (`***`) in responses
+- The same keys cannot be updated via API (403) — Settings UI only
+- `DELETE /transactions` requires at least one filter (422 without filters)
+
+---
+
 ## Quick Start
 
 ```bash

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -283,6 +283,57 @@ Le migrazioni dello schema sono idempotenti: vengono eseguite automaticamente ad
 
 ---
 
+## REST API
+
+Il layer FastAPI (`api/`) espone le stesse funzionalità del ledger via HTTP/JSON — indipendente dalla UI Streamlit, usabile da script, automazioni o future app mobile/desktop.
+
+**Porta:** `8000` · **Docs interattive:** `http://localhost:8000/docs`
+
+### Endpoint
+
+| Metodo | Path | Descrizione |
+|--------|------|-------------|
+| GET | `/health` | Liveness check |
+| GET | `/transactions` | Lista transazioni con filtri |
+| PATCH | `/transactions/{id}/category` | Aggiorna categoria/sottocategoria |
+| PATCH | `/transactions/{id}/context` | Aggiorna contesto di vita |
+| POST | `/transactions/{id}/toggle-giroconto` | Alterna flag giroconto |
+| DELETE | `/transactions` | Eliminazione massiva per filtro |
+| GET | `/rules/category` | Lista regole di categorizzazione |
+| POST | `/rules/category` | Crea regola |
+| PATCH | `/rules/category/{id}` | Modifica regola |
+| DELETE | `/rules/category/{id}` | Elimina regola |
+| POST | `/rules/category/apply-to-review` | Applica regole ai pending |
+| POST | `/rules/category/apply-to-all` | Applica regole a tutto il ledger |
+| GET/POST/DELETE | `/rules/description` | CRUD regole descrizione |
+| GET | `/settings` | Tutte le impostazioni (API key oscurate) |
+| GET/PUT | `/settings/{key}` | Lettura/scrittura impostazione |
+| GET/POST/DELETE | `/accounts` | CRUD conti bancari |
+| GET/POST/PATCH/DELETE | `/taxonomy/categories` | CRUD categorie |
+| POST/PATCH/DELETE | `/taxonomy/categories/{id}/subcategories` | CRUD sottocategorie |
+| GET | `/import/jobs/latest` | Stato ultimo job importazione |
+
+### Filtri query — GET /transactions
+
+| Parametro | Tipo | Descrizione |
+|-----------|------|-------------|
+| `from_date` | `YYYY-MM-DD` | Data inizio |
+| `to_date` | `YYYY-MM-DD` | Data fine |
+| `account_label` | string | Conto bancario |
+| `category` | string | Categoria |
+| `tx_type` | string | Tipo transazione |
+| `to_review` | bool | Solo da rivedere |
+| `limit` | int (1–5000) | Numero massimo risultati (default 500) |
+| `offset` | int | Paginazione |
+
+### Note sicurezza
+
+- `openai_api_key` e `anthropic_api_key` sono sempre oscurate (`***`) nelle risposte
+- Le stesse chiavi non sono modificabili via API (403) — solo dall'UI Impostazioni
+- `DELETE /transactions` richiede almeno un filtro (422 senza filtri)
+
+---
+
 ## Avvio rapido
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ dependencies = [
     "plotly>=5.20",
     # Reports
     "jinja2>=3.1",
+    # REST API
+    "fastapi>=0.111",
+    "uvicorn[standard]>=0.29",
+    "python-multipart>=0.0.9",
+    "httpx>=0.27",
     # Testing
     "pytest>=8.0",
     "pytest-cov>=5.0",

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,14 @@
+"""Service layer — business logic adapters between UI/API and core/db."""
+from services.transaction_service import TransactionService
+from services.rule_service import RuleService
+from services.settings_service import SettingsService
+from services.category_service import CategoryService
+from services.import_service import ImportService
+
+__all__ = [
+    "TransactionService",
+    "RuleService",
+    "SettingsService",
+    "CategoryService",
+    "ImportService",
+]

--- a/services/category_service.py
+++ b/services/category_service.py
@@ -1,0 +1,98 @@
+"""CategoryService — service layer for categorization operations."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import (
+    TaxonomyConfig,
+    CategorizationResult,
+    categorize_batch,
+    categorize_transaction,
+)
+
+
+class CategoryService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def categorize_single(
+        self,
+        description: str,
+        amount: float,
+        doc_type: str,
+        backend=None,
+    ) -> CategorizationResult:
+        """Categorize one transaction using rules → static → LLM cascade."""
+        from core.orchestrator import ProcessingConfig, _build_backend
+        with self._session() as s:
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+            settings = repository.get_all_user_settings(s)
+        if backend is None:
+            config = self._config_from_settings(settings)
+            backend = _build_backend(config)
+        return categorize_transaction(
+            description=description,
+            amount=amount,
+            doc_type=doc_type,
+            taxonomy=taxonomy,
+            user_rules=user_rules,
+            llm_backend=backend,
+            sanitize_config=None,
+            fallback_backend=None,
+            confidence_threshold=0.6,
+            description_language=settings.get("description_language", "it"),
+        )
+
+    def categorize_many(
+        self,
+        transactions: list[dict],
+        backend=None,
+        progress_callback=None,
+    ) -> list[CategorizationResult]:
+        """Categorize a batch of transactions."""
+        from core.orchestrator import ProcessingConfig, _build_backend
+        with self._session() as s:
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+            settings = repository.get_all_user_settings(s)
+        if backend is None:
+            config = self._config_from_settings(settings)
+            backend = _build_backend(config)
+        return categorize_batch(
+            transactions=transactions,
+            taxonomy=taxonomy,
+            user_rules=user_rules,
+            llm_backend=backend,
+            sanitize_config=None,
+            fallback_backend=None,
+            description_language=settings.get("description_language", "it"),
+            progress_callback=progress_callback,
+        )
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _config_from_settings(settings: dict):
+        from core.orchestrator import ProcessingConfig
+        return ProcessingConfig(
+            llm_backend=settings.get("llm_backend", "local_ollama"),
+            ollama_base_url=settings.get("ollama_base_url", "http://localhost:11434"),
+            ollama_model=settings.get("ollama_model", "gemma3:12b"),
+            openai_api_key=settings.get("openai_api_key", ""),
+            openai_model=settings.get("openai_model", "gpt-4o-mini"),
+            anthropic_api_key=settings.get("anthropic_api_key", ""),
+            claude_model=settings.get("anthropic_model", "claude-3-haiku-20240307"),
+        )

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -1,0 +1,72 @@
+"""ImportService — service layer for file import pipeline."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core import orchestrator
+from core.orchestrator import ImportResult, ProcessingConfig
+
+
+class ImportService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def process_files(
+        self,
+        files: list[tuple[bytes, str]],
+        config: ProcessingConfig | None = None,
+    ) -> list[ImportResult]:
+        """Run the full import pipeline for a list of (raw_bytes, filename) tuples."""
+        with self._session() as s:
+            settings = repository.get_all_user_settings(s)
+            taxonomy = repository.get_taxonomy_config(s)
+            user_rules = repository.get_category_rules(s)
+        if config is None:
+            config = self._config_from_settings(settings)
+        return orchestrator.process_files(files, config, taxonomy, user_rules, {})
+
+    def persist_result(self, result: ImportResult) -> None:
+        with self._session() as s:
+            repository.persist_import_result(s, result)
+
+    def create_job(self, n_files: int):
+        with self._session() as s:
+            return repository.create_import_job(s, n_files)
+
+    def update_job(self, job_id: int, **kwargs) -> None:
+        with self._session() as s:
+            repository.update_import_job(s, job_id, **kwargs)
+
+    def get_latest_job(self):
+        with self._session() as s:
+            return repository.get_latest_import_job(s)
+
+    def reset_stale_jobs(self) -> int:
+        with self._session() as s:
+            return repository.reset_stale_jobs(s)
+
+    # ── Internal helpers ──────────────────────────────────────────────────────
+
+    @staticmethod
+    def _config_from_settings(settings: dict) -> ProcessingConfig:
+        return ProcessingConfig(
+            llm_backend=settings.get("llm_backend", "local_ollama"),
+            ollama_base_url=settings.get("ollama_base_url", "http://localhost:11434"),
+            ollama_model=settings.get("ollama_model", "gemma3:12b"),
+            openai_api_key=settings.get("openai_api_key", ""),
+            openai_model=settings.get("openai_model", "gpt-4o-mini"),
+            anthropic_api_key=settings.get("anthropic_api_key", ""),
+            claude_model=settings.get("anthropic_model", "claude-3-haiku-20240307"),
+        )

--- a/services/rule_service.py
+++ b/services/rule_service.py
@@ -1,0 +1,92 @@
+"""RuleService — thin service layer over CategoryRule and DescriptionRule repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import CategoryRule as CoreCategoryRule
+
+
+class RuleService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    # ── CategoryRule ──────────────────────────────────────────────────────────
+
+    def get_rules(self) -> list[CoreCategoryRule]:
+        with self._session() as s:
+            return repository.get_category_rules(s)
+
+    def create_rule(
+        self,
+        pattern: str,
+        match_type: str,
+        category: str,
+        subcategory: str,
+        context: str | None = None,
+        doc_type: str | None = None,
+        priority: int = 0,
+    ) -> tuple:
+        with self._session() as s:
+            result = repository.create_category_rule(
+                s, pattern, match_type, category, subcategory, context, doc_type, priority
+            )
+            s.commit()
+            return result
+
+    def update_rule(self, rule_id: int, **kwargs) -> bool:
+        with self._session() as s:
+            result = repository.update_category_rule(s, rule_id, **kwargs)
+            s.commit()
+            return result
+
+    def delete_rule(self, rule_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_category_rule(s, rule_id)
+            s.commit()
+            return result
+
+    def apply_to_review(self) -> int:
+        with self._session() as s:
+            rules = repository.get_category_rules(s)
+            result = repository.apply_rules_to_review_transactions(s, rules)
+            s.commit()
+            return result
+
+    def apply_to_all(self) -> tuple[int, int]:
+        with self._session() as s:
+            rules = repository.get_category_rules(s)
+            result = repository.apply_all_rules_to_all_transactions(s, rules)
+            s.commit()
+            return result
+
+    # ── DescriptionRule ───────────────────────────────────────────────────────
+
+    def get_description_rules(self) -> list:
+        with self._session() as s:
+            return repository.get_description_rules(s)
+
+    def create_description_rule(
+        self, raw_pattern: str, match_type: str, cleaned_description: str
+    ) -> tuple:
+        with self._session() as s:
+            result = repository.create_description_rule(s, raw_pattern, match_type, cleaned_description)
+            s.commit()
+            return result
+
+    def delete_description_rule(self, rule_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_description_rule(s, rule_id)
+            s.commit()
+            return result

--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -1,0 +1,102 @@
+"""SettingsService — thin service layer over UserSettings, Taxonomy, and Account repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db import repository
+from core.categorizer import TaxonomyConfig
+
+
+class SettingsService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    # ── UserSettings ─────────────────────────────────────────────────────────
+
+    def get_all(self) -> dict[str, str]:
+        with self._session() as s:
+            return repository.get_all_user_settings(s)
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        with self._session() as s:
+            return repository.get_user_setting(s, key, default)
+
+    def set(self, key: str, value: str) -> None:
+        with self._session() as s:
+            repository.set_user_setting(s, key, value)
+            s.commit()
+
+    # ── Taxonomy ──────────────────────────────────────────────────────────────
+
+    def get_taxonomy(self) -> TaxonomyConfig:
+        with self._session() as s:
+            return repository.get_taxonomy_config(s)
+
+    def get_categories(self, type_filter: str | None = None) -> list:
+        with self._session() as s:
+            return repository.get_taxonomy_categories(s, type_filter)
+
+    def create_category(self, name: str, type_: str):
+        with self._session() as s:
+            result = repository.create_taxonomy_category(s, name, type_)
+            s.commit()
+            return result
+
+    def update_category(self, cat_id: int, name: str) -> bool:
+        with self._session() as s:
+            result = repository.update_taxonomy_category(s, cat_id, name)
+            s.commit()
+            return result
+
+    def delete_category(self, cat_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_taxonomy_category(s, cat_id)
+            s.commit()
+            return result
+
+    def create_subcategory(self, cat_id: int, name: str):
+        with self._session() as s:
+            result = repository.create_taxonomy_subcategory(s, cat_id, name)
+            s.commit()
+            return result
+
+    def update_subcategory(self, sub_id: int, name: str) -> bool:
+        with self._session() as s:
+            result = repository.update_taxonomy_subcategory(s, sub_id, name)
+            s.commit()
+            return result
+
+    def delete_subcategory(self, sub_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_taxonomy_subcategory(s, sub_id)
+            s.commit()
+            return result
+
+    # ── Account ───────────────────────────────────────────────────────────────
+
+    def get_accounts(self) -> list:
+        with self._session() as s:
+            return repository.get_accounts(s)
+
+    def create_account(self, name: str, bank_name: str):
+        with self._session() as s:
+            result = repository.create_account(s, name, bank_name)
+            s.commit()
+            return result
+
+    def delete_account(self, account_id: int) -> bool:
+        with self._session() as s:
+            result = repository.delete_account(s, account_id)
+            s.commit()
+            return result

--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -1,0 +1,73 @@
+"""TransactionService — thin service layer over transaction repository functions."""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from sqlalchemy.orm import sessionmaker
+
+from db.models import Transaction
+from db import repository
+
+
+class TransactionService:
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self._Session = sessionmaker(bind=engine, expire_on_commit=False)
+
+    @contextmanager
+    def _session(self):
+        s = self._Session()
+        try:
+            yield s
+        finally:
+            s.close()
+
+    def get_transactions(self, filters: dict | None = None, limit: int = 5000, offset: int = 0) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions(s, filters or {}, limit, offset)
+
+    def update_category(self, tx_id: str, category: str, subcategory: str) -> bool:
+        with self._session() as s:
+            result = repository.update_transaction_category(s, tx_id, category, subcategory)
+            s.commit()
+            return result
+
+    def update_context(self, tx_id: str, context: str | None) -> bool:
+        with self._session() as s:
+            result = repository.update_transaction_context(s, tx_id, context)
+            s.commit()
+            return result
+
+    def toggle_giroconto(self, tx_id: str) -> tuple[bool, str]:
+        with self._session() as s:
+            result = repository.toggle_transaction_giroconto(s, tx_id)
+            s.commit()
+            return result
+
+    def get_similar(self, description: str, exclude_id: str, threshold: float = 0.8) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_similar_transactions(s, description, exclude_id, threshold)
+
+    def bulk_set_giroconto_by_description(self, description: str, make_giroconto: bool, exclude_id: str) -> int:
+        with self._session() as s:
+            result = repository.bulk_set_giroconto_by_description(s, description, make_giroconto, exclude_id)
+            s.commit()
+            return result
+
+    def delete_by_filter(self, filters: dict) -> int:
+        with self._session() as s:
+            result = repository.delete_transactions_by_filter(s, filters)
+            s.commit()
+            return result
+
+    def get_cross_account_duplicates(self) -> list[list[Transaction]]:
+        with self._session() as s:
+            return repository.get_cross_account_duplicates(s)
+
+    def get_by_rule_pattern(self, pattern: str, match_type: str) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions_by_rule_pattern(s, pattern, match_type)
+
+    def get_by_raw_pattern(self, raw_pattern: str, match_type: str) -> list[Transaction]:
+        with self._session() as s:
+            return repository.get_transactions_by_raw_pattern(s, raw_pattern, match_type)

--- a/tests/test_api_rules.py
+++ b/tests/test_api_rules.py
@@ -1,0 +1,146 @@
+"""API tests — /rules endpoints."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from api.main import app
+from api.dependencies import get_rule_service, get_engine
+from db.models import create_tables
+from services.rule_service import RuleService
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mem_engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    create_tables(eng)
+    return eng
+
+
+@pytest.fixture
+def client(mem_engine):
+    app.dependency_overrides[get_rule_service] = lambda: RuleService(mem_engine)
+    app.dependency_overrides[get_engine] = lambda: mem_engine
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── GET /rules/category ────────────────────────────────────────────────────────
+
+def test_list_category_rules_empty(client):
+    r = client.get("/rules/category")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+# ── POST /rules/category ───────────────────────────────────────────────────────
+
+def test_create_category_rule(client):
+    payload = {
+        "pattern": "coop",
+        "match_type": "contains",
+        "category": "Alimentari",
+        "subcategory": "Supermercato",
+        "priority": 1,
+    }
+    r = client.post("/rules/category", json=payload)
+    assert r.status_code == 201
+    data = r.json()
+    assert data["pattern"] == "coop"
+    assert data["category"] == "Alimentari"
+    assert data["id"] is not None
+
+
+def test_create_category_rule_invalid_match_type(client):
+    r = client.post("/rules/category", json={
+        "pattern": "x", "match_type": "invalid", "category": "Test", "subcategory": ""
+    })
+    assert r.status_code == 422
+
+
+def test_create_and_list(client):
+    client.post("/rules/category", json={
+        "pattern": "eni", "match_type": "contains", "category": "Auto", "subcategory": "Carburante"
+    })
+    r = client.get("/rules/category")
+    assert r.status_code == 200
+    patterns = [rule["pattern"] for rule in r.json()]
+    assert "eni" in patterns
+
+
+# ── PATCH /rules/category/{id} ─────────────────────────────────────────────────
+
+def test_update_category_rule(client):
+    r = client.post("/rules/category", json={
+        "pattern": "lidl", "match_type": "contains", "category": "Alimentari", "subcategory": ""
+    })
+    rule_id = r.json()["id"]
+    patch = client.patch(f"/rules/category/{rule_id}", json={"category": "Svago"})
+    assert patch.status_code == 200
+
+
+def test_update_category_rule_not_found(client):
+    r = client.patch("/rules/category/9999", json={"category": "Svago"})
+    assert r.status_code == 404
+
+
+def test_update_category_rule_empty_body(client):
+    r = client.post("/rules/category", json={
+        "pattern": "x", "match_type": "exact", "category": "Altro", "subcategory": ""
+    })
+    rule_id = r.json()["id"]
+    patch = client.patch(f"/rules/category/{rule_id}", json={})
+    assert patch.status_code == 422
+
+
+# ── DELETE /rules/category/{id} ───────────────────────────────────────────────
+
+def test_delete_category_rule(client):
+    r = client.post("/rules/category", json={
+        "pattern": "todelete", "match_type": "exact", "category": "Altro", "subcategory": ""
+    })
+    rule_id = r.json()["id"]
+    d = client.delete(f"/rules/category/{rule_id}")
+    assert d.status_code == 200
+    assert d.json()["deleted"] == 1
+
+
+def test_delete_category_rule_not_found(client):
+    r = client.delete("/rules/category/9999")
+    assert r.status_code == 404
+
+
+# ── Description Rules ──────────────────────────────────────────────────────────
+
+def test_list_description_rules_empty(client):
+    r = client.get("/rules/description")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_create_description_rule(client):
+    r = client.post("/rules/description", json={
+        "raw_pattern": "AMAZON.IT*",
+        "match_type": "contains",
+        "cleaned_description": "Amazon",
+    })
+    assert r.status_code == 201
+    data = r.json()
+    assert data["cleaned_description"] == "Amazon"
+
+
+def test_delete_description_rule(client):
+    r = client.post("/rules/description", json={
+        "raw_pattern": "DELETE_ME",
+        "match_type": "exact",
+        "cleaned_description": "ToDelete",
+    })
+    rule_id = r.json()["id"]
+    d = client.delete(f"/rules/description/{rule_id}")
+    assert d.status_code == 200
+    assert d.json()["deleted"] == 1

--- a/tests/test_api_settings.py
+++ b/tests/test_api_settings.py
@@ -1,0 +1,167 @@
+"""API tests — /settings, /accounts, /taxonomy endpoints."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from api.main import app
+from api.dependencies import get_settings_service, get_engine
+from db.models import create_tables
+from services.settings_service import SettingsService
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mem_engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    create_tables(eng)
+    return eng
+
+
+@pytest.fixture
+def client(mem_engine):
+    app.dependency_overrides[get_settings_service] = lambda: SettingsService(mem_engine)
+    app.dependency_overrides[get_engine] = lambda: mem_engine
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+# ── GET /settings ──────────────────────────────────────────────────────────────
+
+def test_get_all_settings(client):
+    r = client.get("/settings")
+    assert r.status_code == 200
+    data = r.json()
+    assert "settings" in data
+    assert "llm_backend" in data["settings"]
+
+
+def test_get_all_settings_redacts_api_keys(client):
+    r = client.get("/settings")
+    settings = r.json()["settings"]
+    assert settings.get("openai_api_key") == "***"
+    assert settings.get("anthropic_api_key") == "***"
+
+
+def test_get_single_setting(client):
+    r = client.get("/settings/llm_backend")
+    assert r.status_code == 200
+    assert r.json()["key"] == "llm_backend"
+    assert r.json()["value"] is not None
+
+
+def test_get_missing_setting(client):
+    r = client.get("/settings/nonexistent_key_xyz")
+    assert r.status_code == 404
+
+
+def test_get_api_key_blocked(client):
+    r = client.get("/settings/openai_api_key")
+    assert r.status_code == 403
+
+
+# ── PUT /settings/{key} ────────────────────────────────────────────────────────
+
+def test_update_setting(client):
+    r = client.put("/settings/description_language", json={"value": "en"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+    # verify persisted
+    r2 = client.get("/settings/description_language")
+    assert r2.json()["value"] == "en"
+
+
+def test_update_api_key_blocked(client):
+    r = client.put("/settings/openai_api_key", json={"value": "sk-secret"})
+    assert r.status_code == 403
+
+
+# ── GET/POST/DELETE /accounts ──────────────────────────────────────────────────
+
+def test_list_accounts_empty(client):
+    r = client.get("/accounts")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_create_account(client):
+    r = client.post("/accounts", json={"name": "Conto POPSO", "bank_name": "Banca Popolare di Sondrio"})
+    assert r.status_code == 201
+    data = r.json()
+    assert data["name"] == "Conto POPSO"
+    assert data["id"] is not None
+
+
+def test_create_and_list_accounts(client):
+    client.post("/accounts", json={"name": "Fineco", "bank_name": "FinecoBank"})
+    r = client.get("/accounts")
+    names = [a["name"] for a in r.json()]
+    assert "Fineco" in names
+
+
+def test_delete_account(client):
+    r = client.post("/accounts", json={"name": "ToDelete"})
+    acc_id = r.json()["id"]
+    d = client.delete(f"/accounts/{acc_id}")
+    assert d.status_code == 200
+    assert d.json()["deleted"] == 1
+
+
+def test_delete_account_not_found(client):
+    r = client.delete("/accounts/9999")
+    assert r.status_code == 404
+
+
+# ── GET /taxonomy/categories ───────────────────────────────────────────────────
+
+def test_list_taxonomy_categories(client):
+    r = client.get("/taxonomy/categories")
+    assert r.status_code == 200
+    # taxonomy is seeded from taxonomy.yaml or defaults
+    assert isinstance(r.json(), list)
+
+
+def test_list_taxonomy_filter_by_type(client):
+    r_exp = client.get("/taxonomy/categories", params={"type": "expense"})
+    r_inc = client.get("/taxonomy/categories", params={"type": "income"})
+    assert r_exp.status_code == 200
+    assert r_inc.status_code == 200
+    exp_types = {c["type"] for c in r_exp.json()}
+    inc_types = {c["type"] for c in r_inc.json()}
+    assert exp_types <= {"expense"}
+    assert inc_types <= {"income"}
+
+
+def test_create_and_delete_category(client):
+    r = client.post("/taxonomy/categories", json={"name": "Test Category", "type": "expense"})
+    assert r.status_code == 201
+    cat_id = r.json()["id"]
+
+    d = client.delete(f"/taxonomy/categories/{cat_id}")
+    assert d.status_code == 200
+
+
+def test_create_subcategory(client):
+    r = client.post("/taxonomy/categories", json={"name": "ParentCat", "type": "expense"})
+    cat_id = r.json()["id"]
+    rs = client.post(f"/taxonomy/categories/{cat_id}/subcategories", json={"name": "SubA"})
+    assert rs.status_code == 201
+    assert rs.json()["name"] == "SubA"
+
+
+def test_update_subcategory(client):
+    r = client.post("/taxonomy/categories", json={"name": "CatForSub", "type": "income"})
+    cat_id = r.json()["id"]
+    rs = client.post(f"/taxonomy/categories/{cat_id}/subcategories", json={"name": "OldName"})
+    sub_id = rs.json()["id"]
+    ru = client.patch(f"/taxonomy/subcategories/{sub_id}", json={"name": "NewName"})
+    assert ru.status_code == 200
+
+
+def test_delete_category_not_found(client):
+    r = client.delete("/taxonomy/categories/99999")
+    assert r.status_code == 404

--- a/tests/test_api_transactions.py
+++ b/tests/test_api_transactions.py
@@ -1,0 +1,159 @@
+"""API tests — /transactions endpoints."""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
+
+from api.main import app
+from api.dependencies import get_transaction_service, get_engine
+from db.models import Base, Transaction, create_tables
+from services.transaction_service import TransactionService
+
+
+# ── Fixtures ───────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def mem_engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool)
+    create_tables(eng)
+    return eng
+
+
+@pytest.fixture
+def client(mem_engine):
+    app.dependency_overrides[get_transaction_service] = lambda: TransactionService(mem_engine)
+    app.dependency_overrides[get_engine] = lambda: mem_engine
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def _seed(engine, *, tx_id="abc123", description="Supermercato Coop",
+          amount=-42.0, category="Alimentari", subcategory="Supermercato",
+          to_review=False, context=None):
+    from sqlalchemy.orm import sessionmaker
+    Session = sessionmaker(bind=engine)
+    with Session() as s:
+        t = Transaction(
+            id=tx_id, date="2025-03-01",
+            description=description, amount=amount, currency="EUR",
+            category=category, subcategory=subcategory,
+            category_source="llm", category_confidence="high",
+            to_review=to_review, context=context,
+        )
+        s.add(t)
+        s.commit()
+
+
+# ── Health ─────────────────────────────────────────────────────────────────────
+
+def test_health(client):
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+# ── GET /transactions ──────────────────────────────────────────────────────────
+
+def test_list_transactions_empty(client):
+    r = client.get("/transactions")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["items"] == []
+    assert data["total"] == 0
+
+
+def test_list_transactions_returns_seeded(client, mem_engine):
+    _seed(mem_engine)
+    r = client.get("/transactions")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    tx = data["items"][0]
+    assert tx["id"] == "abc123"
+    assert tx["category"] == "Alimentari"
+    assert tx["amount"] == pytest.approx(-42.0)
+
+
+def test_list_transactions_filter_by_category(client, mem_engine):
+    _seed(mem_engine, tx_id="t1", description="Coop", category="Alimentari")
+    _seed(mem_engine, tx_id="t2", description="Trenitalia", category="Trasporti")
+    r = client.get("/transactions", params={"category": "Alimentari"})
+    assert r.status_code == 200
+    ids = [t["id"] for t in r.json()["items"]]
+    assert "t1" in ids
+    assert "t2" not in ids
+
+
+def test_list_transactions_filter_to_review(client, mem_engine):
+    _seed(mem_engine, tx_id="r1", to_review=True)
+    _seed(mem_engine, tx_id="r2", to_review=False)
+    r = client.get("/transactions", params={"to_review": "true"})
+    assert r.status_code == 200
+    ids = [t["id"] for t in r.json()["items"]]
+    assert "r1" in ids
+    assert "r2" not in ids
+
+
+def test_list_transactions_limit(client, mem_engine):
+    for i in range(10):
+        _seed(mem_engine, tx_id=f"tx{i:02d}", description=f"tx {i}")
+    r = client.get("/transactions", params={"limit": 3})
+    assert r.status_code == 200
+    assert len(r.json()["items"]) == 3
+
+
+# ── PATCH /transactions/{id}/category ─────────────────────────────────────────
+
+def test_update_category(client, mem_engine):
+    _seed(mem_engine)
+    r = client.patch("/transactions/abc123/category", json={"category": "Svago", "subcategory": "Cinema"})
+    assert r.status_code == 200
+    assert r.json()["status"] == "ok"
+
+
+def test_update_category_not_found(client):
+    r = client.patch("/transactions/nonexistent/category", json={"category": "Svago", "subcategory": ""})
+    assert r.status_code == 404
+
+
+def test_update_category_missing_field(client, mem_engine):
+    _seed(mem_engine)
+    r = client.patch("/transactions/abc123/category", json={"subcategory": "Cinema"})
+    assert r.status_code == 422
+
+
+# ── PATCH /transactions/{id}/context ──────────────────────────────────────────
+
+def test_update_context(client, mem_engine):
+    _seed(mem_engine)
+    r = client.patch("/transactions/abc123/context", json={"context": "Vacanza"})
+    assert r.status_code == 200
+
+
+def test_update_context_clear(client, mem_engine):
+    _seed(mem_engine, context="Lavoro")
+    r = client.patch("/transactions/abc123/context", json={"context": None})
+    assert r.status_code == 200
+
+
+def test_update_context_not_found(client):
+    r = client.patch("/transactions/ghost/context", json={"context": "Vacanza"})
+    assert r.status_code == 404
+
+
+# ── DELETE /transactions ───────────────────────────────────────────────────────
+
+def test_delete_transactions_by_category(client, mem_engine):
+    _seed(mem_engine, tx_id="d1", category="Alimentari")
+    _seed(mem_engine, tx_id="d2", category="Trasporti")
+    r = client.delete("/transactions", params={"category": "Alimentari"})
+    assert r.status_code == 200
+    assert r.json()["deleted"] >= 1
+
+
+def test_delete_transactions_no_filter_rejected(client):
+    r = client.delete("/transactions")
+    assert r.status_code == 422

--- a/tests/test_service_category.py
+++ b/tests/test_service_category.py
@@ -1,0 +1,126 @@
+"""Tests for CategoryService — no real LLM backend needed."""
+from __future__ import annotations
+
+import pytest
+from decimal import Decimal
+from sqlalchemy import create_engine
+
+from db.models import Base, get_session
+from core.categorizer import CategorySource, CategorizationResult
+from core.models import Confidence
+from services.category_service import CategoryService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return CategoryService(engine)
+
+
+class _NoLLMBackend:
+    """Stub LLM backend that never gets called in deterministic tests."""
+    def complete(self, *args, **kwargs):
+        raise AssertionError("LLM backend should not be called for deterministic categorization")
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_categorize_single_deterministic(svc):
+    """'ESSELUNGA SPA' matches the static rule → no LLM needed."""
+    result = svc.categorize_single(
+        description="ESSELUNGA SPA",
+        amount=-25.0,
+        doc_type="bank_account",
+        backend=_NoLLMBackend(),
+    )
+    assert isinstance(result, CategorizationResult)
+    assert result.category == "Alimentari"
+    assert result.subcategory == "Spesa supermercato"
+    assert result.source == CategorySource.rule
+    assert result.to_review is False
+
+
+def test_categorize_single_user_rule(engine):
+    """User rule takes priority over static rules."""
+    from db.models import get_session
+    from db import repository
+
+    svc = CategoryService(engine)
+
+    # Seed a user rule for "pagamento affitto"
+    with get_session(engine) as s:
+        repository.create_category_rule(
+            s, pattern="affitto", match_type="contains",
+            category="Casa", subcategory="Affitto", priority=100,
+        )
+        s.commit()
+
+    result = svc.categorize_single(
+        description="pagamento affitto mensile",
+        amount=-800.0,
+        doc_type="bank_account",
+        backend=_NoLLMBackend(),
+    )
+    assert result.category == "Casa"
+    assert result.subcategory == "Affitto"
+    assert result.source == CategorySource.rule
+
+
+def test_categorize_single_falls_back_when_no_match(engine):
+    """Unknown description with stub backend → to_review fallback."""
+    svc = CategoryService(engine)
+
+    class _NullBackend:
+        def complete(self, *args, **kwargs):
+            return None
+
+    result = svc.categorize_single(
+        description="xyzzy random unknown description 12345",
+        amount=-5.0,
+        doc_type="bank_account",
+        backend=None,  # uses real _build_backend which will fail/fallback
+    )
+    # Must not raise; result should be a CategorizationResult
+    assert isinstance(result, CategorizationResult)
+
+
+def test_config_from_settings():
+    """_config_from_settings builds a ProcessingConfig with correct fields."""
+    from core.orchestrator import ProcessingConfig
+    settings = {
+        "llm_backend": "openai",
+        "ollama_base_url": "http://localhost:11434",
+        "ollama_model": "llama3",
+        "openai_api_key": "sk-test",
+        "openai_model": "gpt-4",
+        "anthropic_api_key": "ak-test",
+        "anthropic_model": "claude-3-opus-20240229",
+    }
+    config = CategoryService._config_from_settings(settings)
+    assert isinstance(config, ProcessingConfig)
+    assert config.llm_backend == "openai"
+    assert config.openai_api_key == "sk-test"
+    assert config.openai_model == "gpt-4"
+    assert config.claude_model == "claude-3-opus-20240229"
+    assert config.ollama_model == "llama3"
+
+
+def test_categorize_many_deterministic(engine):
+    """categorize_many with static-matchable transactions returns results."""
+    svc = CategoryService(engine)
+    transactions = [
+        {"description": "ESSELUNGA SPA", "amount": -25.0, "doc_type": "bank_account"},
+        {"description": "LIDL SUPERMERCATI", "amount": -15.0, "doc_type": "bank_account"},
+    ]
+    results = svc.categorize_many(transactions, backend=_NoLLMBackend())
+    assert len(results) == 2
+    for r in results:
+        assert r.category == "Alimentari"

--- a/tests/test_service_import.py
+++ b/tests/test_service_import.py
@@ -1,0 +1,88 @@
+"""Tests for ImportService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, ImportJob, get_session
+from services.import_service import ImportService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return ImportService(engine)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_create_and_get_job(svc):
+    svc.create_job(n_files=3)
+
+    latest = svc.get_latest_job()
+    assert latest is not None
+    assert latest.n_files == 3
+    assert latest.status == "running"
+
+
+def test_get_latest_job_returns_none_when_empty(svc):
+    latest = svc.get_latest_job()
+    assert latest is None
+
+
+def test_update_job(engine):
+    svc = ImportService(engine)
+    svc.create_job(n_files=2)
+
+    first = svc.get_latest_job()
+    assert first is not None
+    job_id = first.id
+
+    svc.update_job(job_id, status="completed", progress=1.0, n_transactions=10)
+
+    latest = svc.get_latest_job()
+    assert latest.status == "completed"
+    assert float(latest.progress) == 1.0
+    assert latest.n_transactions == 10
+
+
+def test_update_job_not_found(svc):
+    # Should not raise; silently ignores missing job
+    svc.update_job(9999, status="completed")
+
+
+def test_reset_stale_jobs(engine):
+    svc = ImportService(engine)
+    # Create two "running" jobs manually
+    job1 = svc.create_job(n_files=1)
+    job2 = svc.create_job(n_files=2)
+
+    n_reset = svc.reset_stale_jobs()
+    assert n_reset == 2
+
+    latest = svc.get_latest_job()
+    assert latest.status == "error"
+
+
+def test_reset_stale_jobs_no_running(svc):
+    """reset_stale_jobs returns 0 when there are no running jobs."""
+    n = svc.reset_stale_jobs()
+    assert n == 0
+
+
+def test_create_multiple_jobs_get_latest(engine):
+    svc = ImportService(engine)
+    svc.create_job(n_files=1)
+    svc.create_job(n_files=5)
+
+    latest = svc.get_latest_job()
+    assert latest is not None
+    assert latest.n_files == 5

--- a/tests/test_service_rule.py
+++ b/tests/test_service_rule.py
@@ -1,0 +1,189 @@
+"""Tests for RuleService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, Transaction, get_session
+from services.rule_service import RuleService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return RuleService(engine)
+
+
+def _make_tx(session, *, tx_id: str, description: str, amount: float = -10.0,
+             tx_type: str = "expense", category: str = "Altro",
+             to_review: bool = False) -> Transaction:
+    t = Transaction(
+        id=tx_id,
+        date="2025-01-01",
+        description=description,
+        amount=amount,
+        currency="EUR",
+        tx_type=tx_type,
+        category=category,
+        subcategory="",
+        category_source="llm",
+        category_confidence="medium",
+        to_review=to_review,
+        account_label="test",
+    )
+    session.add(t)
+    session.commit()
+    return t
+
+
+# ── CategoryRule tests ────────────────────────────────────────────────────────
+
+def test_get_rules_empty(svc):
+    assert svc.get_rules() == []
+
+
+def test_create_rule(svc):
+    rule, created = svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming",
+    )
+    assert created is True
+    assert rule.pattern == "netflix"
+    rules = svc.get_rules()
+    assert len(rules) == 1
+    assert rules[0].category == "Intrattenimento"
+
+
+def test_create_rule_duplicate(svc):
+    svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming",
+    )
+    rule, created = svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Svago", subcategory="Film",
+    )
+    assert created is False
+    assert rule.category == "Svago"
+
+
+def test_update_rule(svc):
+    rule, _ = svc.create_rule(
+        pattern="amazon", match_type="contains",
+        category="Shopping", subcategory="Online",
+    )
+    ok = svc.update_rule(rule.id, category="E-commerce", priority=10)
+    assert ok is True
+    rules = svc.get_rules()
+    assert rules[0].category == "E-commerce"
+    assert rules[0].priority == 10
+
+
+def test_delete_rule(svc):
+    rule, _ = svc.create_rule(
+        pattern="spotify", match_type="contains",
+        category="Intrattenimento", subcategory="Musica",
+    )
+    ok = svc.delete_rule(rule.id)
+    assert ok is True
+    assert svc.get_rules() == []
+
+
+def test_delete_rule_not_found(svc):
+    ok = svc.delete_rule(999)
+    assert ok is False
+
+
+def test_apply_to_review(engine):
+    svc = RuleService(engine)
+    # Seed a to_review transaction
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="netflix abbonamento",
+                 category="Altro", to_review=True)
+    # Create a matching rule
+    svc.create_rule(
+        pattern="netflix", match_type="contains",
+        category="Intrattenimento", subcategory="Streaming", priority=10,
+    )
+    n = svc.apply_to_review()
+    assert n == 1
+    # Verify the transaction was categorized
+    with get_session(engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.category == "Intrattenimento"
+        assert tx.to_review is False
+
+
+def test_apply_to_all(engine):
+    svc = RuleService(engine)
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="enel energia",
+                 category="Altro", to_review=False)
+        _make_tx(s, tx_id="t2", description="enel energia",
+                 category="Altro", to_review=True)
+    svc.create_rule(
+        pattern="enel", match_type="contains",
+        category="Utenze", subcategory="Elettricità", priority=10,
+    )
+    n_matched, n_cleared = svc.apply_to_all()
+    assert n_matched == 2
+    assert n_cleared == 1
+    with get_session(engine) as s:
+        t1 = s.get(Transaction, "t1")
+        t2 = s.get(Transaction, "t2")
+        assert t1.category == "Utenze"
+        assert t2.category == "Utenze"
+        assert t2.to_review is False
+
+
+# ── DescriptionRule tests ─────────────────────────────────────────────────────
+
+def test_get_description_rules_empty(svc):
+    assert svc.get_description_rules() == []
+
+
+def test_create_description_rule(svc):
+    rule, created = svc.create_description_rule(
+        raw_pattern="NETFLIX PAYMENT", match_type="exact",
+        cleaned_description="Netflix",
+    )
+    assert created is True
+    assert rule.cleaned_description == "Netflix"
+    rules = svc.get_description_rules()
+    assert len(rules) == 1
+
+
+def test_create_description_rule_duplicate(svc):
+    svc.create_description_rule(
+        raw_pattern="AMAZON", match_type="contains",
+        cleaned_description="Amazon",
+    )
+    rule, created = svc.create_description_rule(
+        raw_pattern="AMAZON", match_type="contains",
+        cleaned_description="Amazon Prime",
+    )
+    assert created is False
+    assert rule.cleaned_description == "Amazon Prime"
+
+
+def test_delete_description_rule(svc):
+    rule, _ = svc.create_description_rule(
+        raw_pattern="SPOTIFY", match_type="exact",
+        cleaned_description="Spotify",
+    )
+    ok = svc.delete_description_rule(rule.id)
+    assert ok is True
+    assert svc.get_description_rules() == []
+
+
+def test_delete_description_rule_not_found(svc):
+    ok = svc.delete_description_rule(999)
+    assert ok is False

--- a/tests/test_service_settings.py
+++ b/tests/test_service_settings.py
@@ -1,0 +1,121 @@
+"""Tests for SettingsService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, DEFAULT_USER_SETTINGS
+from core.categorizer import TaxonomyConfig
+from services.settings_service import SettingsService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return SettingsService(engine)
+
+
+# ── UserSettings tests ────────────────────────────────────────────────────────
+
+def test_get_all_returns_defaults(svc):
+    settings = svc.get_all()
+    # get_all_user_settings returns a dict starting from DEFAULT_USER_SETTINGS
+    for key in DEFAULT_USER_SETTINGS:
+        assert key in settings
+
+
+def test_set_and_get(svc):
+    svc.set("description_language", "en")
+    value = svc.get("description_language")
+    assert value == "en"
+
+
+def test_get_missing_key_returns_default(svc):
+    value = svc.get("nonexistent_key", default="fallback")
+    assert value == "fallback"
+
+
+# ── Taxonomy tests ────────────────────────────────────────────────────────────
+
+def test_get_taxonomy(svc):
+    taxonomy = svc.get_taxonomy()
+    assert isinstance(taxonomy, TaxonomyConfig)
+    # Should have fallback categories when no taxonomy data seeded
+    assert len(taxonomy.expenses) > 0 or len(taxonomy.income) > 0
+
+
+def test_create_and_delete_category(svc):
+    cat = svc.create_category("Test Category", "expense")
+    assert cat.id is not None
+    assert cat.name == "Test Category"
+
+    ok = svc.delete_category(cat.id)
+    assert ok is True
+
+    cats = svc.get_categories(type_filter="expense")
+    names = [c.name for c in cats]
+    assert "Test Category" not in names
+
+
+def test_create_subcategory(svc):
+    cat = svc.create_category("Alimentari", "expense")
+    sub = svc.create_subcategory(cat.id, "Supermercato")
+    assert sub.id is not None
+    assert sub.name == "Supermercato"
+    assert sub.category_id == cat.id
+
+
+def test_update_category(svc):
+    cat = svc.create_category("Old Name", "expense")
+    ok = svc.update_category(cat.id, "New Name")
+    assert ok is True
+    cats = svc.get_categories(type_filter="expense")
+    names = [c.name for c in cats]
+    assert "New Name" in names
+    assert "Old Name" not in names
+
+
+def test_update_subcategory(svc):
+    cat = svc.create_category("Cat", "expense")
+    sub = svc.create_subcategory(cat.id, "OldSub")
+    ok = svc.update_subcategory(sub.id, "NewSub")
+    assert ok is True
+
+
+def test_delete_subcategory(svc):
+    cat = svc.create_category("Cat2", "expense")
+    sub = svc.create_subcategory(cat.id, "SubToDelete")
+    ok = svc.delete_subcategory(sub.id)
+    assert ok is True
+
+
+# ── Account tests ─────────────────────────────────────────────────────────────
+
+def test_create_and_delete_account(svc):
+    acc = svc.create_account("Conto POPSO", "Banca Popolare di Sondrio")
+    assert acc.id is not None
+    assert acc.name == "Conto POPSO"
+
+    accounts = svc.get_accounts()
+    names = [a.name for a in accounts]
+    assert "Conto POPSO" in names
+
+    ok = svc.delete_account(acc.id)
+    assert ok is True
+
+    accounts_after = svc.get_accounts()
+    names_after = [a.name for a in accounts_after]
+    assert "Conto POPSO" not in names_after
+
+
+def test_delete_account_not_found(svc):
+    ok = svc.delete_account(9999)
+    assert ok is False

--- a/tests/test_service_transaction.py
+++ b/tests/test_service_transaction.py
@@ -1,0 +1,166 @@
+"""Tests for TransactionService."""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Base, Transaction, get_session
+from services.transaction_service import TransactionService
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Base.metadata.create_all(eng)
+    return eng
+
+
+@pytest.fixture
+def svc(engine):
+    return TransactionService(engine)
+
+
+def _make_tx(session, *, tx_id: str, description: str, amount: float = -10.0,
+             tx_type: str = "expense", category: str = "Altro",
+             subcategory: str = "", account_label: str = "test",
+             to_review: bool = False, raw_description: str | None = None) -> Transaction:
+    t = Transaction(
+        id=tx_id,
+        date="2025-01-01",
+        description=description,
+        amount=amount,
+        currency="EUR",
+        tx_type=tx_type,
+        category=category,
+        subcategory=subcategory,
+        category_source="llm",
+        category_confidence="medium",
+        to_review=to_review,
+        account_label=account_label,
+        raw_description=raw_description,
+    )
+    session.add(t)
+    session.commit()
+    return t
+
+
+@pytest.fixture
+def seeded_engine(engine):
+    """Engine with 3 transactions pre-seeded."""
+    with get_session(engine) as s:
+        _make_tx(s, tx_id="t1", description="pagamento netflix", amount=-12.0)
+        _make_tx(s, tx_id="t2", description="stipendio mensile", amount=2000.0,
+                 tx_type="income", category="Reddito")
+        _make_tx(s, tx_id="t3", description="pagamento amazon", amount=-50.0)
+    return engine
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_get_transactions_empty(svc):
+    result = svc.get_transactions()
+    assert result == []
+
+
+def test_get_transactions_returns_seeded(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    result = svc.get_transactions()
+    assert len(result) == 3
+
+
+def test_update_category(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok = svc.update_category("t1", "Intrattenimento", "Streaming")
+    assert ok is True
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.category == "Intrattenimento"
+        assert tx.subcategory == "Streaming"
+        assert tx.category_source == "manual"
+
+
+def test_update_context(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok = svc.update_context("t1", "Vacanza")
+    assert ok is True
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.context == "Vacanza"
+
+
+def test_update_context_missing_tx(svc):
+    ok = svc.update_context("nonexistent", "Vacanza")
+    assert ok is False
+
+
+def test_toggle_giroconto(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    ok, new_type = svc.toggle_giroconto("t1")
+    assert ok is True
+    assert new_type == "internal_out"  # t1 is negative amount
+    with get_session(seeded_engine) as s:
+        tx = s.get(Transaction, "t1")
+        assert tx.tx_type == "internal_out"
+
+
+def test_get_similar_transactions(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # "pagamento netflix" and "pagamento amazon" share the word "pagamento"
+    result = svc.get_similar("pagamento netflix", exclude_id="t1", threshold=0.3)
+    ids = {tx.id for tx in result}
+    # t3 has "pagamento amazon" — shares "pagamento" word → Jaccard >= 0.3
+    assert "t3" in ids
+    # t1 is excluded
+    assert "t1" not in ids
+
+
+def test_bulk_set_giroconto_by_description(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Add two transactions with the same description
+    with get_session(seeded_engine) as s:
+        _make_tx(s, tx_id="g1", description="giroconto banca", amount=-100.0)
+        _make_tx(s, tx_id="g2", description="giroconto banca", amount=-100.0)
+    n = svc.bulk_set_giroconto_by_description("giroconto banca", make_giroconto=True, exclude_id="")
+    assert n == 2
+    with get_session(seeded_engine) as s:
+        assert s.get(Transaction, "g1").tx_type == "internal_out"
+        assert s.get(Transaction, "g2").tx_type == "internal_out"
+
+
+def test_delete_by_filter(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Delete t1 by account_label
+    n = svc.delete_by_filter({"account_label": "test", "tx_type": "expense"})
+    assert n == 2  # t1 and t3 are both expense with account_label=test
+    result = svc.get_transactions()
+    ids = {tx.id for tx in result}
+    assert "t1" not in ids
+    assert "t3" not in ids
+    assert "t2" in ids
+
+
+def test_get_cross_account_duplicates(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # No cross-account duplicates in the seeded data
+    result = svc.get_cross_account_duplicates()
+    assert result == []
+
+
+def test_get_by_rule_pattern(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    result = svc.get_by_rule_pattern("netflix", "contains")
+    assert len(result) == 1
+    assert result[0].id == "t1"
+
+
+def test_get_by_raw_pattern(seeded_engine):
+    svc = TransactionService(seeded_engine)
+    # Add a transaction with raw_description
+    with get_session(seeded_engine) as s:
+        _make_tx(s, tx_id="r1", description="cleaned desc",
+                 raw_description="RAW NETFLIX PAYMENT", amount=-15.0)
+    result = svc.get_by_raw_pattern("netflix", "contains")
+    assert len(result) == 1
+    assert result[0].id == "r1"

--- a/tools/coupling_check.py
+++ b/tools/coupling_check.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""Coupling checker — misura il grado di disaccoppiamento tra UI e business layer.
+
+Indicatori raccolti:
+  - VIOLATION  : import da core.* o db.* in ui/ (accoppiamento diretto — da eliminare)
+  - COMPLIANT  : import da services.* in ui/ (pattern corretto)
+  - RAW_QUERY  : query SQLAlchemy dirette in ui/ (get_session, .query(), sessionmaker)
+  - API_COVERAGE: % metodi service esposti via API
+
+Exit code:
+  0  — nessuna violazione (o soglia rispettata)
+  1  — violazioni sopra soglia (usare in CI con --max-violations N)
+
+Uso:
+  python tools/coupling_check.py                    # report completo
+  python tools/coupling_check.py --max-violations 0 # fail se ci sono violazioni
+  python tools/coupling_check.py --json             # output JSON per integrazione
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+# ── Configurazione ─────────────────────────────────────────────────────────────
+
+ROOT = Path(__file__).resolve().parent.parent
+
+UI_DIR     = ROOT / "ui"
+SERVICES_DIR = ROOT / "services"
+API_DIR    = ROOT / "api"
+
+VIOLATION_MODULES  = ("core", "db")   # import da questi in ui/ = violazione
+COMPLIANT_MODULES  = ("services",)    # import da questi in ui/ = conforme
+RAW_QUERY_PATTERNS = [
+    r"get_session\(",
+    r"sessionmaker\(",
+    r"\.query\(",
+    r"session\.execute\(",
+]
+
+# ── Data classes ───────────────────────────────────────────────────────────────
+
+@dataclass
+class ImportLine:
+    file: str
+    line: int
+    statement: str
+    module: str
+
+
+@dataclass
+class FileReport:
+    path: str
+    violations: list[ImportLine] = field(default_factory=list)
+    compliant:  list[ImportLine] = field(default_factory=list)
+    raw_queries: list[dict]      = field(default_factory=list)
+
+    @property
+    def score(self) -> float:
+        """0.0 = completamente accoppiato, 1.0 = completamente disaccoppiato."""
+        total = len(self.violations) + len(self.compliant)
+        if total == 0:
+            return 1.0
+        return len(self.compliant) / total
+
+
+@dataclass
+class CouplingReport:
+    files: list[FileReport] = field(default_factory=list)
+    service_methods: dict[str, list[str]] = field(default_factory=dict)
+    api_endpoints: list[str] = field(default_factory=list)
+
+    @property
+    def total_violations(self) -> int:
+        return sum(len(f.violations) for f in self.files)
+
+    @property
+    def total_compliant(self) -> int:
+        return sum(len(f.compliant) for f in self.files)
+
+    @property
+    def total_raw_queries(self) -> int:
+        return sum(len(f.raw_queries) for f in self.files)
+
+    @property
+    def coupling_score(self) -> float:
+        """% di file UI senza violazioni."""
+        if not self.files:
+            return 1.0
+        clean = sum(1 for f in self.files if len(f.violations) == 0)
+        return clean / len(self.files)
+
+    @property
+    def api_coverage(self) -> float:
+        """% di metodi service esposti via API."""
+        total = sum(len(v) for v in self.service_methods.values())
+        if total == 0:
+            return 0.0
+        covered = sum(
+            1 for methods in self.service_methods.values()
+            for m in methods
+            if any(m in ep for ep in self.api_endpoints)
+        )
+        return covered / total
+
+
+# ── Analisi import ─────────────────────────────────────────────────────────────
+
+def _extract_imports(path: Path) -> list[tuple[int, str, str]]:
+    """Ritorna lista di (line_no, statement, top_module)."""
+    results = []
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree   = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return results
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            top = node.module.split(".")[0]
+            stmt = f"from {node.module} import {', '.join(a.name for a in node.names)}"
+            results.append((node.lineno, stmt, top))
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split(".")[0]
+                stmt = f"import {alias.name}"
+                results.append((node.lineno, stmt, top))
+    return results
+
+
+def _scan_raw_queries(path: Path) -> list[dict]:
+    """Cerca pattern SQLAlchemy raw nel sorgente (regex su testo)."""
+    found = []
+    source = path.read_text(encoding="utf-8")
+    for pattern in RAW_QUERY_PATTERNS:
+        for m in re.finditer(pattern, source):
+            lineno = source[:m.start()].count("\n") + 1
+            found.append({"line": lineno, "match": m.group(), "pattern": pattern})
+    return found
+
+
+def analyze_ui(ui_dir: Path) -> list[FileReport]:
+    reports = []
+    for py_file in sorted(ui_dir.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        rel = py_file.relative_to(ROOT)
+        fr  = FileReport(path=str(rel))
+
+        for lineno, stmt, top in _extract_imports(py_file):
+            entry = ImportLine(file=str(rel), line=lineno, statement=stmt, module=top)
+            if top in VIOLATION_MODULES:
+                fr.violations.append(entry)
+            elif top in COMPLIANT_MODULES:
+                fr.compliant.append(entry)
+
+        fr.raw_queries = _scan_raw_queries(py_file)
+        reports.append(fr)
+
+    return reports
+
+
+# ── Analisi service API coverage ───────────────────────────────────────────────
+
+def _public_methods(cls_node: ast.ClassDef) -> list[str]:
+    return [
+        n.name for n in cls_node.body
+        if isinstance(n, ast.FunctionDef)
+        and not n.name.startswith("_")
+    ]
+
+
+def analyze_service_methods(services_dir: Path) -> dict[str, list[str]]:
+    result = {}
+    for py_file in sorted(services_dir.glob("*.py")):
+        if py_file.name.startswith("_"):
+            continue
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ClassDef) and node.name.endswith("Service"):
+                result[node.name] = _public_methods(node)
+    return result
+
+
+def analyze_api_endpoints(api_dir: Path) -> list[str]:
+    """Ritorna la lista di funzioni endpoint definite nei router."""
+    endpoints = []
+    for py_file in sorted((api_dir / "routers").glob("*.py")):
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                endpoints.append(node.name)
+    return endpoints
+
+
+# ── Report ─────────────────────────────────────────────────────────────────────
+
+_GREEN  = "\033[92m"
+_YELLOW = "\033[93m"
+_RED    = "\033[91m"
+_CYAN   = "\033[96m"
+_BOLD   = "\033[1m"
+_RESET  = "\033[0m"
+
+
+def _pct_color(v: float) -> str:
+    if v >= 0.8:
+        return _GREEN
+    if v >= 0.5:
+        return _YELLOW
+    return _RED
+
+
+def print_report(report: CouplingReport) -> None:
+    print(f"\n{_BOLD}{'═' * 64}{_RESET}")
+    print(f"{_BOLD}  Coupling Report — UI ↔ Service layer{_RESET}")
+    print(f"{'═' * 64}")
+
+    print(f"\n{_BOLD}Riepilogo globale{_RESET}")
+    cs  = report.coupling_score
+    api = report.api_coverage
+    print(f"  File UI senza violazioni : {_pct_color(cs)}{cs*100:.0f}%{_RESET}  ({sum(1 for f in report.files if not f.violations)}/{len(report.files)} file)")
+    print(f"  Violazioni totali        : {_RED if report.total_violations else _GREEN}{report.total_violations}{_RESET}  (import diretti core/db in ui/)")
+    print(f"  Import da services/      : {_GREEN}{report.total_compliant}{_RESET}")
+    print(f"  Query SQLAlchemy raw     : {_YELLOW if report.total_raw_queries else _GREEN}{report.total_raw_queries}{_RESET}  (in ui/)")
+    print(f"  API coverage services    : {_pct_color(api)}{api*100:.0f}%{_RESET}")
+
+    print(f"\n{_BOLD}Per file UI{_RESET}")
+    print(f"  {'File':<30} {'Violazioni':>10} {'Compliant':>9} {'RawQuery':>8} {'Score':>6}")
+    print(f"  {'-'*30} {'-'*10} {'-'*9} {'-'*8} {'-'*6}")
+    for fr in report.files:
+        score_col = _GREEN if fr.score == 1.0 else (_YELLOW if fr.score > 0 else _RED)
+        viol_col  = _RED if fr.violations else _GREEN
+        print(
+            f"  {fr.path:<30} "
+            f"{viol_col}{len(fr.violations):>10}{_RESET} "
+            f"{_GREEN if fr.compliant else ''}{len(fr.compliant):>9}{_RESET} "
+            f"{_YELLOW if fr.raw_queries else ''}{len(fr.raw_queries):>8}{_RESET} "
+            f"{score_col}{fr.score*100:>5.0f}%{_RESET}"
+        )
+
+    if report.total_violations:
+        print(f"\n{_BOLD}Dettaglio violazioni{_RESET}")
+        for fr in report.files:
+            if fr.violations:
+                print(f"\n  {_CYAN}{fr.path}{_RESET}")
+                for v in fr.violations:
+                    print(f"    L{v.line:>4}  {v.statement}")
+
+    print(f"\n{_BOLD}Service methods → API coverage{_RESET}")
+    for svc, methods in sorted(report.service_methods.items()):
+        covered   = [m for m in methods if any(m in ep for ep in report.api_endpoints)]
+        uncovered = [m for m in methods if m not in covered]
+        pct = len(covered) / len(methods) * 100 if methods else 0
+        col = _pct_color(pct / 100)
+        print(f"  {svc:<25} {col}{pct:>5.0f}%{_RESET}  ({len(covered)}/{len(methods)})")
+        if uncovered:
+            print(f"    {'non esposti':>10}: {', '.join(uncovered)}")
+
+    print(f"\n{'═' * 64}\n")
+
+
+def print_json(report: CouplingReport) -> None:
+    out = {
+        "coupling_score": round(report.coupling_score, 4),
+        "api_coverage": round(report.api_coverage, 4),
+        "total_violations": report.total_violations,
+        "total_compliant": report.total_compliant,
+        "total_raw_queries": report.total_raw_queries,
+        "files": [
+            {
+                "path": f.path,
+                "violations": len(f.violations),
+                "compliant": len(f.compliant),
+                "raw_queries": len(f.raw_queries),
+                "score": round(f.score, 4),
+            }
+            for f in report.files
+        ],
+        "service_methods": {
+            svc: {
+                "total": len(methods),
+                "covered": sum(1 for m in methods if any(m in ep for ep in report.api_endpoints)),
+                "uncovered": [m for m in methods if not any(m in ep for ep in report.api_endpoints)],
+            }
+            for svc, methods in report.service_methods.items()
+        },
+    }
+    print(json.dumps(out, indent=2))
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    import argparse
+    parser = argparse.ArgumentParser(description="UI ↔ Service coupling checker")
+    parser.add_argument("--max-violations", type=int, default=None,
+                        help="Exit 1 se violazioni > N (usare in CI)")
+    parser.add_argument("--json", action="store_true",
+                        help="Output JSON invece di testo")
+    args = parser.parse_args()
+
+    file_reports     = analyze_ui(UI_DIR)
+    service_methods  = analyze_service_methods(SERVICES_DIR)
+    api_endpoints    = analyze_api_endpoints(API_DIR) if API_DIR.exists() else []
+
+    report = CouplingReport(
+        files=file_reports,
+        service_methods=service_methods,
+        api_endpoints=api_endpoints,
+    )
+
+    if args.json:
+        print_json(report)
+    else:
+        print_report(report)
+
+    if args.max_violations is not None and report.total_violations > args.max_violations:
+        if not args.json:
+            print(f"❌  FAIL — {report.total_violations} violazioni > soglia {args.max_violations}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -290,6 +299,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.135.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/7b/f8e0211e9380f7195ba3f3d40c292594fd81ba8ec4629e3854c353aaca45/fastapi-0.135.1.tar.gz", hash = "sha256:d04115b508d936d254cea545b7312ecaa58a7b3a0f84952535b4c9afae7668cd", size = 394962, upload-time = "2026-03-01T18:18:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e4/72/42e900510195b23a56bde950d26a51f8b723846bfcaa0286e90287f0422b/fastapi-0.135.1-py3-none-any.whl", hash = "sha256:46e2fc5745924b7c840f71ddd277382af29ce1cdb7d5eab5bf697e3fb9999c9e", size = 116999, upload-time = "2026-03-01T18:18:30.831Z" },
+]
+
+[[package]]
 name = "gitdb"
 version = "4.0.12"
 source = { registry = "https://pypi.org/simple" }
@@ -361,6 +386,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
 ]
 
 [[package]]
@@ -962,6 +1009,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
 name = "pytz"
 version = "2025.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1135,6 +1191,8 @@ dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
     { name = "chardet" },
+    { name = "fastapi" },
+    { name = "httpx" },
     { name = "jinja2" },
     { name = "openai" },
     { name = "openpyxl" },
@@ -1144,10 +1202,12 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "requests" },
     { name = "sqlalchemy" },
     { name = "streamlit" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
 
 [package.metadata]
@@ -1155,6 +1215,8 @@ requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "anthropic", specifier = ">=0.28" },
     { name = "chardet", specifier = ">=5.0" },
+    { name = "fastapi", specifier = ">=0.111" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "openai", specifier = ">=1.30" },
     { name = "openpyxl", specifier = ">=3.1" },
@@ -1164,10 +1226,12 @@ requires-dist = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "python-dotenv", specifier = ">=1.0" },
+    { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.31" },
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "streamlit", specifier = ">=1.35" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.29" },
 ]
 
 [[package]]
@@ -1197,6 +1261,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/39/f05f0ed54d451156bbed0e23eb0516bcad7cbb9f18b3bf219c786371b3f0/sqlalchemy-2.0.45-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd337d3526ec5298f67d6a30bbbe4ed7e5e68862f0bf6dd21d289f8d37b7d60b", size = 3522029, upload-time = "2025-12-09T22:13:32.09Z" },
     { url = "https://files.pythonhosted.org/packages/54/0f/d15398b98b65c2bce288d5ee3f7d0a81f77ab89d9456994d5c7cc8b2a9db/sqlalchemy-2.0.45-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9a62b446b7d86a3909abbcd1cd3cc550a832f99c2bc37c5b22e1925438b9367b", size = 3475142, upload-time = "2025-12-09T22:13:33.739Z" },
     { url = "https://files.pythonhosted.org/packages/bf/e1/3ccb13c643399d22289c6a9786c1a91e3dcbb68bce4beb44926ac2c557bf/sqlalchemy-2.0.45-py3-none-any.whl", hash = "sha256:5225a288e4c8cc2308dbdd874edad6e7d0fd38eac1e9e5f23503425c8eee20d0", size = 1936672, upload-time = "2025-12-09T21:54:52.608Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "0.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
 
 [[package]]
@@ -1317,6 +1393,56 @@ wheels = [
 ]
 
 [[package]]
+name = "uvicorn"
+version = "0.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/ad/4a96c425be6fb67e0621e62d86c402b4a17ab2be7f7c055d9bd2f638b9e2/uvicorn-0.42.0.tar.gz", hash = "sha256:9b1f190ce15a2dd22e7758651d9b6d12df09a13d51ba5bf4fc33c383a48e1775", size = 85393, upload-time = "2026-03-16T06:19:50.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/89/f8827ccff89c1586027a105e5630ff6139a64da2515e24dafe860bd9ae4d/uvicorn-0.42.0-py3-none-any.whl", hash = "sha256:96c30f5c7abe6f74ae8900a70e92b85ad6613b745d4879eb9b16ccad15645359", size = 68830, upload-time = "2026-03-16T06:19:48.325Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
 name = "watchdog"
 version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1332,4 +1458,97 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
## Summary

- Introduces a complete FastAPI REST API layer in `api/` — fully decoupled from Streamlit, wired exclusively to the existing `services/` layer
- No Streamlit UI files touched
- 44 new API tests, all passing. Full suite: **426 passed, 5 skipped** (real LLM backends only)

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/health` | Liveness check |
| GET | `/transactions` | List with filters (date, category, account, to_review) |
| PATCH | `/transactions/{id}/category` | Update category + subcategory |
| PATCH | `/transactions/{id}/context` | Update context |
| POST | `/transactions/{id}/toggle-giroconto` | Toggle internal transfer flag |
| DELETE | `/transactions` | Bulk delete by filter (requires ≥1 filter) |
| GET/POST/PATCH/DELETE | `/rules/category` | Category rule CRUD |
| POST | `/rules/category/apply-to-review` | Apply rules to pending review |
| POST | `/rules/category/apply-to-all` | Apply rules to all transactions |
| GET/POST/DELETE | `/rules/description` | Description rule CRUD |
| GET | `/settings` | All settings (API keys redacted) |
| GET/PUT | `/settings/{key}` | Single setting read/write (keys protected) |
| GET/POST/DELETE | `/accounts` | Account CRUD |
| GET/POST/PATCH/DELETE | `/taxonomy/categories` | Taxonomy category CRUD |
| POST/PATCH/DELETE | `/taxonomy/categories/{id}/subcategories` | Subcategory CRUD |
| GET | `/import/jobs/latest` | Latest import job status |

## Architecture

```
Streamlit UI  ──►  services/  ◄──  FastAPI (:8000)
                      │
                   core/ + db/
```

## Docker

The `api` service runs on port **8000** (`uvicorn api.main:app`). Interactive docs at `http://localhost:8000/docs`.

## Test plan

- [x] `tests/test_api_transactions.py` — 14 tests (list, filter, update category/context, toggle giroconto, delete)
- [x] `tests/test_api_rules.py` — 16 tests (CRUD category rules, description rules, apply)
- [x] `tests/test_api_settings.py` — 14 tests (settings redaction, accounts CRUD, taxonomy CRUD)
- [x] Zero regressions on existing 382 tests