### PR TITLE
docs: move engineering docs to documents/, add developer_guide

### DIFF
--- a/docs/developer_guide.en.md
+++ b/docs/developer_guide.en.md
@@ -1,0 +1,253 @@
+# Spendify — Developer Guide
+
+> Version: 3.0 — updated 2026-03-21
+>
+> For user features and quick reference see **[reference_guide.en.md](reference_guide.en.md)**.
+> For detailed technical documentation (DB, pipeline, deployment, etc.) see the `documents/` folder.
+
+---
+
+## Table of Contents
+
+1. [Layered architecture](#1-layered-architecture)
+2. [Development environment setup](#2-development-environment-setup)
+3. [Project structure](#3-project-structure)
+4. [Service layer](#4-service-layer)
+5. [Coupling gate (CI)](#5-coupling-gate-ci)
+6. [REST API](#6-rest-api)
+7. [Tests](#7-tests)
+8. [Key design decisions](#8-key-design-decisions)
+9. [Technical reference documentation](#9-technical-reference-documentation)
+
+---
+
+## 1. Layered architecture
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   app.py  (Streamlit)                │
+│  ui/upload  ui/ledger  ui/analytics  ui/settings … │
+└──────────────────────┬───────────────────────────────┘
+                       │  imports only from services.*
+┌──────────────────────▼───────────────────────────────┐
+│                  services/                           │
+│  ImportService · TransactionService · RuleService    │
+│  SettingsService · CategoryService · ReviewService  │
+└──────┬────────────────────────────────────┬──────────┘
+       │                                    │
+┌──────▼──────┐                    ┌────────▼────────┐
+│   core/     │                    │    db/          │
+│ orchestrator│                    │ models.py       │
+│ normalizer  │                    │ repository.py   │
+│ classifier  │                    └─────────────────┘
+│ categorizer │
+│ sanitizer   │
+└─────────────┘
+```
+
+**Fundamental rule:** `ui/` modules import **only** from `services.*`.
+They must never import directly from `core.*`, `db.*`, or `support.*`.
+This rule is enforced automatically in CI (see §5).
+
+---
+
+## 2. Development environment setup
+
+### Prerequisites
+
+| Tool | Minimum version |
+|------|----------------|
+| Python | 3.13 |
+| uv | any |
+| Docker Desktop | optional (local smoke test) |
+
+### Installation
+
+```bash
+git clone https://github.com/drake69/spendify.git
+cd spendify
+uv sync
+cp .env.example .env
+uv run streamlit run app.py
+```
+
+App available at `http://localhost:8501`.
+
+### Environment variables
+
+`.env` contains only:
+
+```
+DATABASE_URL=sqlite:///ledger.db   # SQLite DB path
+```
+
+LLM configuration (backend, model, API key) lives in the database and is managed from the UI → Settings page.
+
+---
+
+## 3. Project structure
+
+```
+spendify/
+├── app.py                  # Streamlit entry point
+├── ui/                     # Streamlit pages (imports only from services.*)
+├── services/               # service layer — facade between UI and core/db
+│   ├── import_service.py
+│   ├── transaction_service.py
+│   ├── rule_service.py
+│   ├── settings_service.py
+│   ├── category_service.py
+│   └── review_service.py
+├── core/                   # pure domain logic (no UI, no DB)
+│   ├── orchestrator.py     # pipeline entry point
+│   ├── normalizer.py
+│   ├── classifier.py
+│   ├── categorizer.py
+│   ├── description_cleaner.py
+│   └── sanitizer.py
+├── db/                     # ORM, migrations, repository
+│   ├── models.py           # SQLAlchemy tables + idempotent migrations
+│   ├── repository.py       # CRUD queries for services
+│   └── taxonomy_defaults.py # taxonomy templates for 5 languages
+├── api/                    # FastAPI REST API (optional)
+│   ├── main.py
+│   └── routers/
+├── tests/                  # pytest — 453+ tests, no DB mocks
+├── tools/                  # development tools
+│   ├── coupling_check.py   # static analysis of UI → service imports
+│   └── coupling_baseline.json
+└── docs/                   # public documentation in the repo
+    ├── reference_guide.en.md
+    └── developer_guide.en.md  # ← this file
+```
+
+---
+
+## 4. Service layer
+
+Each service is a class that takes `engine: Engine` in its constructor and encapsulates all operations for a domain. The UI never sees SQLAlchemy or `core` models directly.
+
+### ImportService — complete facade
+
+`ImportService` is the access point for the entire import pipeline. It re-exports domain types (`DocumentType`, `SignConvention`, `DocumentSchema`, etc.) via `__all__` so the UI never needs to import from `core.*`.
+
+```python
+from services.import_service import ImportService, DocumentType, SignConvention
+
+svc = ImportService(engine)
+analysis = svc.analyze_file(raw_bytes, filename)
+config   = svc.build_config(giroconto_mode="neutral")
+result   = svc.process_file_single(raw_bytes, filename, config)
+svc.persist_result(result)
+```
+
+### SettingsService — user configuration
+
+Reads and writes `user_settings` (key-value). Exposes:
+
+```python
+svc.get(key, default)
+svc.set(key, value)
+svc.set_bulk(dict)
+svc.is_onboarding_done()
+svc.set_onboarding_done()
+svc.apply_default_taxonomy(language)   # 'it' | 'en' | 'fr' | 'de' | 'es'
+```
+
+### Onboarding
+
+On the first run with an empty DB, `app.py` shows the onboarding wizard (4 steps: language, owner names, accounts, confirmation). After completing the wizard, `set_onboarding_done()` is called and the app reloads normally.
+
+For existing installations (DB with data) onboarding is skipped automatically: `_migrate_set_onboarding_done_for_existing_users()` in `db/models.py` sets the flag if `taxonomy_category` already has rows.
+
+---
+
+## 5. Coupling gate (CI)
+
+`tools/coupling_check.py` statically analyzes all `ui/` files and verifies they do not import from `core.*`, `db.*`, or `support.*`.
+
+```bash
+# Local run
+uv run python tools/coupling_check.py --strict
+
+# Expected output
+✅ Coupling check passed — 0 violations across 12 UI files
+```
+
+The `coupling-check` job in `.github/workflows/ci.yml` runs `--strict --json` and posts a Markdown comment on the PR with per-file detail. A file with new violations fails the CI.
+
+**Baseline:** `tools/coupling_baseline.json` — currently empty `{}` (all files must have 0 violations). Adding a file to the baseline is possible but requires an explicit justification in the JSON.
+
+---
+
+## 6. REST API
+
+An optional FastAPI server exposes core operations as REST endpoints.
+
+```bash
+uv run uvicorn api.main:app --reload --port 8000
+# Interactive docs: http://localhost:8000/docs
+```
+
+The server uses the same `services.*` as the Streamlit UI — no duplicated logic.
+
+---
+
+## 7. Tests
+
+```bash
+# All tests
+uv run pytest tests/ -v
+
+# With coverage
+uv run pytest tests/ -v --cov=. --cov-report=term-missing
+
+# Single module
+uv run pytest tests/test_normalizer.py -v
+```
+
+**Coverage thresholds:**
+
+| Module | Minimum |
+|--------|---------|
+| `core/normalizer.py` | 100% |
+| `core/description_cleaner.py` | 100% |
+| `core/classifier.py` | ≥ 99% |
+| All others | ≥ 80% |
+
+Tests use SQLite in-memory (`create_engine("sqlite://")`) — no DB mocks.
+
+---
+
+## 8. Key design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `Decimal` for amounts, never `float` | Avoids rounding errors in financial calculations |
+| SHA-256 as `tx_id` | Idempotent import: re-importing the same file never creates duplicates |
+| Idempotent migrations (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`) | Safe updates on existing DBs without separate migration scripts |
+| Offline-first LLM (Ollama default) | Privacy: no financial data leaves the machine by default |
+| PII sanitization before any remote call | IBANs, cards, tax codes, and names replaced in memory before sending |
+| Service layer as sole access point for UI | Decoupling that allows testing logic independently of Streamlit |
+| Default taxonomy in DB (not YAML) | Multi-language support (it/en/fr/de/es) without additional config files |
+
+---
+
+## 9. Technical reference documentation
+
+Detailed engineering documentation is in `documents/` (outside the repo):
+
+| File | Content |
+|------|---------|
+| `documents/progetto.en.md` | Project document: goals, stack, architecture |
+| `documents/pipeline.en.md` | Step-by-step import pipeline |
+| `documents/database.en.md` | Full DB schema, migrations, backup/restore |
+| `documents/deployment.en.md` | Docker deployment, environment variables, updates |
+| `documents/configurazione.en.md` | All configurable parameters, LLM providers, API keys |
+| `documents/deterministic_rules.en.md` | Rule engine: syntax, priority, retroactive application |
+| `documents/deterministic_tools.en.md` | Debug and pipeline analysis tools |
+| `documents/installazione.en.md` | Native installation (Mac/Linux/Windows), Docker |
+| `documents/guida_utente.en.md` | End-user operational guide |
+| `documents/landing_page.en.md` | Landing page copy |
+
+For contributing code see also **[CONTRIBUTING.md](../CONTRIBUTING.md)**.

--- a/docs/developer_guide.md
+++ b/docs/developer_guide.md
@@ -1,0 +1,253 @@
+# Spendify — Developer Guide
+
+> Versione: 3.0 — aggiornato 2026-03-21
+>
+> Per le funzionalità utente e il reference rapido vedi **[reference_guide.md](reference_guide.md)**.
+> Per la documentazione tecnica dettagliata (DB, pipeline, deployment, ecc.) vedi la cartella `documents/`.
+
+---
+
+## Indice
+
+1. [Architettura a layer](#1-architettura-a-layer)
+2. [Setup ambiente di sviluppo](#2-setup-ambiente-di-sviluppo)
+3. [Struttura del progetto](#3-struttura-del-progetto)
+4. [Service layer](#4-service-layer)
+5. [Coupling gate (CI)](#5-coupling-gate-ci)
+6. [REST API](#6-rest-api)
+7. [Test](#7-test)
+8. [Decisioni di design chiave](#8-decisioni-di-design-chiave)
+9. [Documentazione tecnica di riferimento](#9-documentazione-tecnica-di-riferimento)
+
+---
+
+## 1. Architettura a layer
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   app.py  (Streamlit)                │
+│  ui/upload  ui/ledger  ui/analytics  ui/settings … │
+└──────────────────────┬───────────────────────────────┘
+                       │  importa solo da services.*
+┌──────────────────────▼───────────────────────────────┐
+│                  services/                           │
+│  ImportService · TransactionService · RuleService    │
+│  SettingsService · CategoryService · ReviewService  │
+└──────┬────────────────────────────────────┬──────────┘
+       │                                    │
+┌──────▼──────┐                    ┌────────▼────────┐
+│   core/     │                    │    db/          │
+│ orchestrator│                    │ models.py       │
+│ normalizer  │                    │ repository.py   │
+│ classifier  │                    └─────────────────┘
+│ categorizer │
+│ sanitizer   │
+└─────────────┘
+```
+
+**Regola fondamentale:** i moduli `ui/` importano **solo** da `services.*`.
+Non devono mai importare direttamente da `core.*`, `db.*`, `support.*`.
+Questa regola è verificata automaticamente in CI (vedi §5).
+
+---
+
+## 2. Setup ambiente di sviluppo
+
+### Prerequisiti
+
+| Strumento | Versione minima |
+|-----------|----------------|
+| Python | 3.13 |
+| uv | qualsiasi |
+| Docker Desktop | opzionale (smoke test locale) |
+
+### Installazione
+
+```bash
+git clone https://github.com/drake69/spendify.git
+cd spendify
+uv sync
+cp .env.example .env
+uv run streamlit run app.py
+```
+
+App disponibile su `http://localhost:8501`.
+
+### Variabili d'ambiente
+
+`.env` contiene solo:
+
+```
+DATABASE_URL=sqlite:///ledger.db   # percorso DB SQLite
+```
+
+La configurazione LLM (backend, modello, API key) vive nel database e si gestisce dall'UI → Impostazioni.
+
+---
+
+## 3. Struttura del progetto
+
+```
+spendify/
+├── app.py                  # entry point Streamlit
+├── ui/                     # pagine Streamlit (solo import da services.*)
+├── services/               # service layer — facade tra UI e core/db
+│   ├── import_service.py
+│   ├── transaction_service.py
+│   ├── rule_service.py
+│   ├── settings_service.py
+│   ├── category_service.py
+│   └── review_service.py
+├── core/                   # logica di dominio pura (no UI, no DB)
+│   ├── orchestrator.py     # entry point pipeline
+│   ├── normalizer.py
+│   ├── classifier.py
+│   ├── categorizer.py
+│   ├── description_cleaner.py
+│   └── sanitizer.py
+├── db/                     # ORM, migrazioni, repository
+│   ├── models.py           # tabelle SQLAlchemy + migrazioni idempotenti
+│   ├── repository.py       # query CRUD per servizi
+│   └── taxonomy_defaults.py # template tassonomia per 5 lingue
+├── api/                    # REST API FastAPI (opzionale)
+│   ├── main.py
+│   └── routers/
+├── tests/                  # pytest — 453+ test, 0 mock su DB
+├── tools/                  # strumenti di sviluppo
+│   ├── coupling_check.py   # analisi statica import UI → service
+│   └── coupling_baseline.json
+└── docs/                   # documentazione pubblica nel repo
+    ├── reference_guide.md
+    └── developer_guide.md  # ← questo file
+```
+
+---
+
+## 4. Service layer
+
+Ogni servizio è una classe che riceve `engine: Engine` nel costruttore e incapsula tutte le operazioni di un dominio. La UI non vede mai SQLAlchemy o i modelli `core`.
+
+### ImportService — facade completa
+
+`ImportService` è il punto di accesso a tutta la pipeline di importazione. Re-esporta i tipi di dominio (`DocumentType`, `SignConvention`, `DocumentSchema`, ecc.) via `__all__` in modo che la UI non debba mai importare da `core.*`.
+
+```python
+from services.import_service import ImportService, DocumentType, SignConvention
+
+svc = ImportService(engine)
+analysis = svc.analyze_file(raw_bytes, filename)
+config   = svc.build_config(giroconto_mode="neutral")
+result   = svc.process_file_single(raw_bytes, filename, config)
+svc.persist_result(result)
+```
+
+### SettingsService — configurazione utente
+
+Legge e scrive `user_settings` (chiave-valore). Espone:
+
+```python
+svc.get(key, default)
+svc.set(key, value)
+svc.set_bulk(dict)
+svc.is_onboarding_done()
+svc.set_onboarding_done()
+svc.apply_default_taxonomy(language)   # 'it' | 'en' | 'fr' | 'de' | 'es'
+```
+
+### Onboarding
+
+Alla prima esecuzione su un DB vuoto, `app.py` mostra il wizard di onboarding (4 step: lingua, nomi titolari, conti, conferma). Dopo aver completato il wizard, `set_onboarding_done()` è chiamato e l'app ricarica normalmente.
+
+Per installazioni esistenti (DB con dati) l'onboarding è saltato automaticamente: `_migrate_set_onboarding_done_for_existing_users()` in `db/models.py` imposta il flag se `taxonomy_category` ha già righe.
+
+---
+
+## 5. Coupling gate (CI)
+
+`tools/coupling_check.py` analizza staticamente tutti i file `ui/` e verifica che non importino da `core.*`, `db.*`, `support.*`.
+
+```bash
+# Run locale
+uv run python tools/coupling_check.py --strict
+
+# Output atteso
+✅ Coupling check passed — 0 violations across 12 UI files
+```
+
+Il job `coupling-check` in `.github/workflows/ci.yml` esegue `--strict --json` e posta un commento Markdown sulla PR con il dettaglio per file. Un file con nuove violazioni fa fallire la CI.
+
+**Baseline:** `tools/coupling_baseline.json` — attualmente vuoto `{}` (tutti i file devono avere 0 violazioni). Aggiungere un file alla baseline è possibile ma richiede una motivazione esplicita nel JSON.
+
+---
+
+## 6. REST API
+
+Un server FastAPI opzionale espone le operazioni core come endpoint REST.
+
+```bash
+uv run uvicorn api.main:app --reload --port 8000
+# Documentazione interattiva: http://localhost:8000/docs
+```
+
+Il server usa gli stessi `services.*` dell'UI Streamlit — nessuna logica duplicata.
+
+---
+
+## 7. Test
+
+```bash
+# Tutti i test
+uv run pytest tests/ -v
+
+# Con coverage
+uv run pytest tests/ -v --cov=. --cov-report=term-missing
+
+# Un singolo modulo
+uv run pytest tests/test_normalizer.py -v
+```
+
+**Soglie di coverage:**
+
+| Modulo | Minima |
+|--------|--------|
+| `core/normalizer.py` | 100% |
+| `core/description_cleaner.py` | 100% |
+| `core/classifier.py` | ≥ 99% |
+| Tutti gli altri | ≥ 80% |
+
+I test usano SQLite in-memory (`create_engine("sqlite://")`) — nessun mock sul DB.
+
+---
+
+## 8. Decisioni di design chiave
+
+| Decisione | Motivazione |
+|-----------|-------------|
+| `Decimal` per gli importi, mai `float` | Evita errori di arrotondamento nei calcoli finanziari |
+| SHA-256 come `tx_id` | Importazione idempotente: re-import dello stesso file non crea duplicati |
+| Migrazioni idempotenti (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`) | Aggiornamenti sicuri su DB esistenti senza script di migrazione separati |
+| LLM offline-first (Ollama default) | Privacy: nessun dato finanziario lascia la macchina per default |
+| PII sanitization prima di ogni chiamata remota | IBAN, carte, codici fiscali e nomi sostituiti in memoria prima dell'invio |
+| Service layer come unica porta d'accesso per la UI | Disaccoppiamento che permette di testare la logica indipendentemente da Streamlit |
+| Tassonomia default nel DB (non in YAML) | Supporto multi-lingua (it/en/fr/de/es) senza file di configurazione aggiuntivi |
+
+---
+
+## 9. Documentazione tecnica di riferimento
+
+La documentazione di ingegneria dettagliata è in `documents/` (fuori dal repo):
+
+| File | Contenuto |
+|------|-----------|
+| `documents/progetto.md` | Documento di progetto: obiettivi, stack, architettura |
+| `documents/pipeline.md` | Pipeline di importazione passo-passo |
+| `documents/database.md` | Schema DB completo, migrazioni, backup/restore |
+| `documents/deployment.md` | Deployment Docker, variabili d'ambiente, aggiornamenti |
+| `documents/configurazione.md` | Tutti i parametri configurabili, provider LLM, API key |
+| `documents/deterministic_rules.md` | Motore regole: sintassi, priorità, applicazione retroattiva |
+| `documents/deterministic_tools.md` | Tools di debug e analisi pipeline |
+| `documents/installazione.md` | Installazione nativa (Mac/Linux/Windows), Docker |
+| `documents/guida_utente.md` | Guida operativa per l'utente finale |
+| `documents/landing_page.md` | Copy landing page |
+
+Per contribuire al codice vedi anche **[CONTRIBUTING.md](../CONTRIBUTING.md)**.

--- a/docs/reference_guide.en.md
+++ b/docs/reference_guide.en.md
@@ -1,6 +1,6 @@
 # Spendify — Reference Guide
 
-> For detailed configuration of all parameters and LLM providers see **[configurazione.md](configurazione.md)**.
+> For detailed configuration of all parameters and LLM providers see **[developer_guide.en.md](developer_guide.en.md)** and the technical documentation in `documents/configurazione.en.md`.
 
 ---
 
@@ -216,7 +216,7 @@ Allows bulk deletion of transactions selected via combinable filters:
 - The counter shows in real time the number of transactions that will be deleted
 - An expandable preview shows the first 10 matching rows
 - Confirmation requires typing exactly `ELIMINA` in the text field before enabling the button
-- Deletion is **irreversible** — make sure you have a backup before proceeding (see `deployment.md`)
+- Deletion is **irreversible** — make sure you have a backup before proceeding (see `documents/deployment.md`)
 - Reconciliation and internal transfer links associated with deleted transactions are removed in cascade
 
 ---

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1,6 +1,6 @@
 # Spendify — Reference Guide
 
-> Per la configurazione dettagliata di tutti i parametri e dei provider LLM vedi **[configurazione.md](configurazione.md)**.
+> Per la configurazione dettagliata di tutti i parametri e dei provider LLM vedi **[developer_guide.md](developer_guide.md)** e la documentazione tecnica in `documents/configurazione.md`.
 
 ---
 
@@ -216,7 +216,7 @@ Permette di eliminare in blocco transazioni selezionate tramite filtri combinabi
 - Il contatore mostra in tempo reale il numero di transazioni che verranno cancellate
 - Un'anteprima espandibile mostra le prime 10 righe corrispondenti
 - La conferma richiede di digitare esattamente `ELIMINA` nel campo testo prima di abilitare il pulsante
-- L'eliminazione è **irreversibile** — assicurarsi di avere un backup prima di procedere (vedi `deployment.md`)
+- L'eliminazione è **irreversibile** — assicurarsi di avere un backup prima di procedere (vedi `documents/deployment.md`)
 - I link di riconciliazione e giroconti associati alle transazioni eliminate vengono rimossi in cascade
 
 ---


### PR DESCRIPTION
## Summary

- Move 20 files (10 IT+EN pairs) from `docs/` to `documents/` (outside the repo, same level as `src/`): configurazione, database, deployment, deterministic_rules, deterministic_tools, guida_utente, installazione, landing_page, pipeline, progetto
- Create `docs/developer_guide.md` + `docs/developer_guide.en.md`: architecture layers diagram, service layer pattern, coupling gate, setup/test commands, design decisions table, index to `documents/`
- Update `docs/reference_guide.{md,en.md}`: fix links to `configurazione.md` and `deployment.md` → now reference `documents/` path

## Result

`docs/` now contains only:
- `reference_guide.md` / `reference_guide.en.md`
- `developer_guide.md` / `developer_guide.en.md`
- `spendify_v3.0.tex`

## Test plan

- [ ] Verify `docs/` contains only reference_guide + developer_guide
- [ ] Verify all files present in `documents/` (20 markdown files)
- [ ] Check no broken internal links in reference_guide or developer_guide