### PR TITLE
docs(gh-pages): rebrand Spendif.ai + desktop install section

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — I tuoi movimenti unificati, sul tuo computer</title>
-  <meta name="description" content="Spendify aggrega automaticamente i movimenti di banche diverse in un unico ledger, senza duplicati, senza abbonamenti, senza inviare i tuoi dati a nessuno." />
-  <meta property="og:title" content="Spendify — I tuoi movimenti unificati" />
+  <title>Spendif.ai — I tuoi movimenti unificati, sul tuo computer</title>
+  <meta name="description" content="Spendif.ai aggrega automaticamente i movimenti di banche diverse in un unico ledger, senza duplicati, senza abbonamenti, senza inviare i tuoi dati a nessuno." />
+  <meta property="og:title" content="Spendif.ai — I tuoi movimenti unificati" />
   <meta property="og:description" content="Un registro finanziario personale open source che gira sul tuo computer. I tuoi dati restano tuoi." />
   <meta property="og:type" content="website" />
   <style>
@@ -683,7 +683,7 @@
   <div class="hero-badge">Open source · <strong>Offline-first</strong> · Nessun abbonamento</div>
   <h1>I tuoi movimenti <span class="accent">unificati</span>,<br>sul tuo computer</h1>
   <p class="hero-sub">
-    Importa i file di tutte le tue banche. Spendify li unifica, elimina i doppi conteggi,
+    Importa i file di tutte le tue banche. Spendif.ai li unifica, elimina i doppi conteggi,
     classifica ogni transazione — e i tuoi dati non lasciano mai il tuo disco.
   </p>
   <div class="hero-actions">
@@ -755,13 +755,13 @@
       <div class="step">
         <h3>Scarica i file dalla tua banca</h3>
         <p>Esporta i movimenti in CSV o XLSX dal portale della tua banca.
-        Funziona con qualsiasi banca italiana (e non solo) — Spendify riconosce
+        Funziona con qualsiasi banca italiana (e non solo) — Spendif.ai riconosce
         automaticamente il formato senza configurazione manuale.</p>
       </div>
       <div class="step">
-        <h3>Trascinali in Spendify e clicca Elabora</h3>
+        <h3>Trascinali in Spendif.ai e clicca Elabora</h3>
         <p>Seleziona tutti i file insieme, anche da banche diverse, anche di anni diversi.
-        Spendify rileva il tipo di documento, corregge i segni, elimina i doppi conteggi
+        Spendif.ai rileva il tipo di documento, corregge i segni, elimina i doppi conteggi
         tra carta e conto, classifica ogni transazione.</p>
       </div>
       <div class="step">
@@ -787,7 +787,7 @@
         <div class="tag">RF-03</div>
         <h3>Riconciliazione carta–conto corrente</h3>
         <p>Quando la carta di credito addebita l'importo mensile sul conto corrente,
-        Spendify riconosce la relazione e rimuove il doppio conteggio automaticamente.</p>
+        Spendif.ai riconosce la relazione e rimuove il doppio conteggio automaticamente.</p>
         <p style="margin-top:.75rem; color: var(--muted); font-size:.88rem;">
           Finestra temporale ±45 giorni · 3 fasi di matching:
           finestra scorrevole → subset sum per importi frazionati → riconciliazione parziale
@@ -797,7 +797,7 @@
         <div class="tag">RF-04</div>
         <h3>Rilevamento giroconti interni</h3>
         <p>Un bonifico dal conto corrente al conto deposito non è né una spesa né
-        un'entrata: è un trasferimento interno. Spendify lo riconosce confrontando
+        un'entrata: è un trasferimento interno. Spendif.ai lo riconosce confrontando
         importi, date e nomi dei titolari nelle descrizioni — anche se i due file
         sono stati importati in momenti diversi.</p>
       </div>
@@ -836,14 +836,14 @@
       <div class="privacy-card">
         <div class="ico-big">🏠</div>
         <h3>Offline-first per default</h3>
-        <p>Spendify usa <strong>Ollama in locale</strong> di default: un motore AI che gira
+        <p>Spendif.ai usa <strong>Ollama in locale</strong> di default: un motore AI che gira
         sul tuo computer, senza connessione internet. I tuoi movimenti non
         lasciano mai il tuo disco.</p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">🛡️</div>
         <h3>PII redaction automatica</h3>
-        <p>Se usi OpenAI o Claude, Spendify rimuove automaticamente tutti i dati
+        <p>Se usi OpenAI o Claude, Spendif.ai rimuove automaticamente tutti i dati
         identificativi prima di qualsiasi chiamata remota:</p>
         <div class="pii-chips">
           <span class="pii-chip">IBAN → &lt;ACCOUNT_ID&gt;</span>
@@ -871,9 +871,9 @@
 <!-- ── PER CHI ───────────────────────────────────────────────────────────── -->
 <section id="per-chi">
   <div class="container">
-    <div class="section-label">Per chi è Spendify</div>
+    <div class="section-label">Per chi è Spendif.ai</div>
     <h2>Non per tutti. Per chi vuole il controllo vero.</h2>
-    <p class="section-sub">Quattro profili che trovano in Spendify qualcosa che le alternative non danno.</p>
+    <p class="section-sub">Quattro profili che trovano in Spendif.ai qualcosa che le alternative non danno.</p>
 
     <div class="audience-grid fade-in">
       <div class="audience-card">
@@ -881,15 +881,15 @@
         <div>
           <h3>Chi ha più conti in banche diverse</h3>
           <p>Conto corrente + carta di credito + conto deposito + conto trading?
-          Spendify li unifica tutti in un unico ledger senza dover fare nulla a mano.</p>
+          Spendif.ai li unifica tutti in un unico ledger senza dover fare nulla a mano.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">📊</div>
         <div>
           <h3>Chi tiene i conti seriamente</h3>
-          <p>Se usi Excel per le spese, Spendify può sostituire quella routine:
-          importi i file una volta, Spendify unifica e classifica, tu controlli
+          <p>Se usi Excel per le spese, Spendif.ai può sostituire quella routine:
+          importi i file una volta, Spendif.ai unifica e classifica, tu controlli
           solo le eccezioni.</p>
         </div>
       </div>
@@ -1033,6 +1033,52 @@
       Sviluppatore o installazione nativa? →
       <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.md" target="_blank">Guida completa (Mac nativo · Linux Docker · Windows llama.cpp)</a>
     </p>
+
+    <!-- ── Desktop native install ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--green); margin-bottom: 0.5rem;">🖥️ App desktop nativa (senza Docker)</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Installer one-click che scaricano il modello AI automaticamente.<br>
+        Nessun Docker, nessun Terminal — una finestra nativa con tutto incluso.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">bash</span> packaging/macos/install.sh</div>
+            </div>
+          </div>
+          <small style="color: var(--muted);">Oppure: <code>brew install --cask spendifai</code></small>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">winget</span> install SpendifAi.SpendifAi</div>
+            </div>
+          </div>
+          <small style="color: var(--muted);">Oppure: esegui <code>install.ps1</code></small>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">sudo apt install</span> ./spendifai_*.deb</div>
+            </div>
+          </div>
+          <small style="color: var(--muted);">Anche .rpm per Fedora/RHEL</small>
+        </div>
+      </div>
+
+      <p style="color: var(--muted); margin-top: 1rem; font-size: 0.9rem;">
+        L'installer rileva il tuo hardware, scarica il modello AI migliore per la tua RAM (1–7 GB) e configura tutto automaticamente — <strong style="color: var(--text);">zero intervento</strong>.
+      </p>
+    </div>
+
   </div>
 </section>
 
@@ -1176,11 +1222,11 @@
 <!-- ── FOOTER ─────────────────────────────────────────────────────────────── -->
 <footer>
   <p>
-    <strong>Spendify</strong> è open source —
+    <strong>Spendif.ai</strong> è open source —
     <a href="https://github.com/drake69/spendify" target="_blank">github.com/drake69/spendify</a>
   </p>
   <p class="disclaimer">
-    Spendify non è un servizio cloud. È un programma che gira sul tuo computer.
+    Spendif.ai non è un servizio cloud. È un programma che gira sul tuo computer.
     I tuoi dati bancari non vengono mai inviati a server di terzi, a meno che tu non scelga
     esplicitamente un backend LLM remoto — in quel caso, tutti i dati identificativi vengono
     rimossi prima dell'invio.


### PR DESCRIPTION
## Summary
- Replace all "Spendify" branding with "Spendif.ai" in the landing page (28 occurrences)
- Add native desktop app install section (macOS/Windows/Linux) below Docker install
- Repo URLs unchanged (will be updated in AI-5 repo rename)

## Test plan
- [ ] Verify landing page renders at https://drake69.github.io/spendify/
- [ ] Verify branding shows "Spendif.ai" everywhere
- [ ] Verify desktop install section shows macOS, Windows, Linux cards