### PR TITLE
fix(gh-pages): untrack rsvd_docs symlink

### DIFF
--- a/rsvd_docs
+++ b/rsvd_docs
@@ -1,1 +1,0 @@
-../documents


### PR DESCRIPTION
Pages build fails because rsvd_docs symlink points outside the repo. Removing from git tracking (already in .gitignore, symlink stays local).