### PR TITLE
Landing: native desktop installers as primary install path

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -984,14 +984,16 @@
   <div class="container">
     <div class="section-label">Installation</div>
     <h2>Ein Befehl, App bereit</h2>
-    <p class="section-sub">Nur <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> erforderlich. Kein git clone, keine Konfiguration.</p>
+    <p class="section-sub">Native Desktop-App mit integrierter lokaler KI. Kein Docker, kein dauerhaft offenes Terminal.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1002,7 +1004,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Kopieren</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Kopieren</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Kopieren</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1018,24 +1052,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Kopieren</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      Das Skript lädt das Image von <strong>GitHub Container Registry</strong>, startet den Container
-      und öffnet den Browser unter <strong>http://localhost:8501</strong> automatisch.<br>
-      <strong>Optionale lokale KI:</strong> Der Installer fragt, ob Ollama mit <code>gemma3:12b</code> hinzugefügt werden soll — wird im Hintergrund heruntergeladen (~8 GB). Funktioniert auf Apple Silicon (arm64) und amd64.<br>
-      <small>Zum Deinstallieren: <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      Das Skript erkennt deine Hardware, lädt das für deinen RAM optimale KI-Modell (1–7 GB) und konfiguriert alles — <strong>kein Aufwand</strong>.<br>
+      Die App erscheint in Launchpad / Startmenü / Dateimanager, einsatzbereit.
     </p>
 
     <p class="install-dev-link">
-      Entwickler- oder native Installation? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Vollständige Anleitung (Mac nativ · Linux Docker · Windows llama.cpp)</a>
+      Entwickler oder manuelle Installation? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Vollständige Anleitung</a>
     </p>
+
+    <!-- ── Docker (Alternative) ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Bevorzugst du Docker?</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Nur <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> erforderlich. Offizieller Container vom GitHub Container Registry, Browser auf <strong>http://localhost:8501</strong>.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>
+
+<!-- ── Community / Support ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">Brauchst du Hilfe?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Öffne ein Issue auf GitHub</a> — Bugs, Fragen, Feature-Wünsche.<br>
+    ⭐ <strong style="color: var(--text);">Gefällt dir Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Gib uns einen Stern</a> — das hilft uns, in die offiziellen Paket-Registries (Homebrew Core, winget) zu kommen.
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1132,6 +1201,9 @@
       <li><span class="dot"></span>REST-API für externe Integrationen</li>
       <li><span class="dot"></span>Mehrbenutzer-Version mit Authentifizierung</li>
       <li><span class="dot"></span>Mobile App — Hauptbuch- und Analyse-Viewer</li>
+      <li><span class="dot"></span>Verteilung über <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span><code>.deb</code>- und <code>.rpm</code>-Pakete als GitHub Release-Assets</li>
+      <li><span class="dot"></span>Verteilung über <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1210,8 +1282,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {

--- a/index.en.html
+++ b/index.en.html
@@ -983,14 +983,16 @@
   <div class="container">
     <div class="section-label">Installation</div>
     <h2>One command, app ready</h2>
-    <p class="section-sub">Only <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> required. No git clone, no configuration.</p>
+    <p class="section-sub">Native desktop app with local AI included. No Docker, no Terminal kept open.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1001,7 +1003,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Copy</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copy</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copy</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1017,24 +1051,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Copy</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      The script pulls the image from <strong>GitHub Container Registry</strong>, starts the container
-      and opens the browser at <strong>http://localhost:8501</strong> automatically.<br>
-      <strong>Optional local AI:</strong> the installer asks whether to add Ollama with <code>gemma3:12b</code> — downloaded in background (~8 GB). Works on Apple Silicon (arm64) and amd64.<br>
-      <small>To uninstall: <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      The script detects your hardware, downloads the optimal AI model for your RAM (1–7 GB) and sets everything up — <strong>zero intervention</strong>.<br>
+      The app appears in Launchpad / Start Menu / file manager, ready to use.
     </p>
 
     <p class="install-dev-link">
-      Developer or native install? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Full guide (Mac native · Linux Docker · Windows llama.cpp)</a>
+      Developer or manual install? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Full guide</a>
     </p>
+
+    <!-- ── Docker (alternative) ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Prefer Docker?</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Only <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> required. Official container from GitHub Container Registry, browser at <strong>http://localhost:8501</strong>.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>
+
+<!-- ── Community / support ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">Need help?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Open an issue on GitHub</a> — bugs, questions, feature requests.<br>
+    ⭐ <strong style="color: var(--text);">Like Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Give us a star</a> — it helps us reach the official package registries (Homebrew Core, winget).
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1131,6 +1200,9 @@
       <li><span class="dot"></span>REST API for external integrations</li>
       <li><span class="dot"></span>Multi-user version with authentication</li>
       <li><span class="dot"></span>Mobile app — ledger and analytics viewer</li>
+      <li><span class="dot"></span>Distribution via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span><code>.deb</code> and <code>.rpm</code> packages as GitHub release assets</li>
+      <li><span class="dot"></span>Distribution via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1209,8 +1281,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {

--- a/index.es.html
+++ b/index.es.html
@@ -983,14 +983,16 @@
   <div class="container">
     <div class="section-label">Installation</div>
     <h2>Un comando, aplicación lista</h2>
-    <p class="section-sub">Solo se requiere <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>. Sin git clone, sin configuración.</p>
+    <p class="section-sub">App de escritorio nativa con IA local incluida. Sin Docker, sin Terminal siempre abierto.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1001,7 +1003,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Copiar</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copiar</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copiar</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1017,24 +1051,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Copiar</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      El script descarga la imagen de <strong>GitHub Container Registry</strong>, inicia el contenedor
-      y abre el navegador en <strong>http://localhost:8501</strong> automáticamente.<br>
-      <strong>IA local opcional:</strong> el instalador pregunta si agregar Ollama con <code>gemma3:12b</code> — se descarga en segundo plano (~8 GB). Funciona en Apple Silicon (arm64) y amd64.<br>
-      <small>Para desinstalar: <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      El script detecta tu hardware, descarga el modelo de IA óptimo para tu RAM (1–7 GB) y configura todo — <strong>cero intervención</strong>.<br>
+      La app aparece en Launchpad / Menú Inicio / explorador de archivos, lista para usar.
     </p>
 
     <p class="install-dev-link">
-      ¿Instalación para desarrolladores o nativa? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guía completa (Mac nativo · Linux Docker · Windows llama.cpp)</a>
+      ¿Instalación para desarrolladores o manual? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guía completa</a>
     </p>
+
+    <!-- ── Docker (alternativa) ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 ¿Prefieres Docker?</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Solo se requiere <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>. Contenedor oficial desde GitHub Container Registry, navegador en <strong>http://localhost:8501</strong>.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>
+
+<!-- ── Community / Soporte ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">¿Necesitas ayuda?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Abre una issue en GitHub</a> — bugs, preguntas, peticiones de funcionalidades.<br>
+    ⭐ <strong style="color: var(--text);">¿Te gusta Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Danos una estrella</a> — nos ayuda a llegar a los registros oficiales (Homebrew Core, winget).
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1131,6 +1200,9 @@
       <li><span class="dot"></span>API REST para integraciones externas</li>
       <li><span class="dot"></span>Versión multiusuario con autenticación</li>
       <li><span class="dot"></span>Aplicación móvil — visor de libro de cuentas y análisis</li>
+      <li><span class="dot"></span>Distribución vía <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>Paquetes <code>.deb</code> y <code>.rpm</code> como assets de release de GitHub</li>
+      <li><span class="dot"></span>Distribución vía <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1209,8 +1281,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {

--- a/index.fr.html
+++ b/index.fr.html
@@ -983,14 +983,16 @@
   <div class="container">
     <div class="section-label">Installation</div>
     <h2>Une commande, application prête</h2>
-    <p class="section-sub">Seul <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> est requis. Pas de git clone, pas de configuration.</p>
+    <p class="section-sub">Application de bureau native avec IA locale incluse. Pas de Docker, pas de Terminal toujours ouvert.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1001,7 +1003,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Copier</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copier</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copier</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1017,24 +1051,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Copier</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      Le script télécharge l'image depuis <strong>GitHub Container Registry</strong>, démarre le conteneur
-      et ouvre le navigateur à <strong>http://localhost:8501</strong> automatiquement.<br>
-      <strong>IA locale optionnelle :</strong> l'installateur demande s'il faut ajouter Ollama avec <code>gemma3:12b</code> — téléchargé en arrière-plan (~8 Go). Fonctionne sur Apple Silicon (arm64) et amd64.<br>
-      <small>Pour désinstaller : <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      Le script détecte votre matériel, télécharge le modèle IA optimal pour votre RAM (1–7 Go) et configure tout — <strong>zéro intervention</strong>.<br>
+      L'application apparaît dans Launchpad / Menu Démarrer / explorateur de fichiers, prête à l'emploi.
     </p>
 
     <p class="install-dev-link">
-      Installation développeur ou native ? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guide complet (Mac natif · Linux Docker · Windows llama.cpp)</a>
+      Installation développeur ou manuelle ? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guide complet</a>
     </p>
+
+    <!-- ── Docker (alternative) ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Vous préférez Docker ?</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Seul <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> est requis. Conteneur officiel depuis GitHub Container Registry, navigateur à <strong>http://localhost:8501</strong>.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>
+
+<!-- ── Communauté / support ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">Besoin d'aide ?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Ouvrez une issue sur GitHub</a> — bugs, questions, demandes de fonctionnalités.<br>
+    ⭐ <strong style="color: var(--text);">Vous aimez Spendif.ai ?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Mettez-nous une étoile</a> — cela nous aide à atteindre les registres officiels (Homebrew Core, winget).
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1131,6 +1200,9 @@
       <li><span class="dot"></span>API REST pour les intégrations externes</li>
       <li><span class="dot"></span>Version multi-utilisateurs avec authentification</li>
       <li><span class="dot"></span>Application mobile — visualiseur de registre et analyses</li>
+      <li><span class="dot"></span>Distribution via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>Paquets <code>.deb</code> et <code>.rpm</code> comme assets de release GitHub</li>
+      <li><span class="dot"></span>Distribution via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1209,8 +1281,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {

--- a/index.html
+++ b/index.html
@@ -983,14 +983,16 @@
   <div class="container">
     <div class="section-label">Installazione</div>
     <h2>Un comando, l'app è pronta</h2>
-    <p class="section-sub">Serve solo <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>. Nessun git clone, nessuna configurazione.</p>
+    <p class="section-sub">App desktop nativa con AI locale inclusa. Niente Docker, niente Terminal sempre aperto.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1001,7 +1003,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Copia</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copia</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copia</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1017,70 +1051,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Copia</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      Lo script scarica l'immagine da <strong>GitHub Container Registry</strong>, avvia il container
-      e apre il browser su <strong>http://localhost:8501</strong> automaticamente.<br>
-      <strong>AI locale opzionale:</strong> lo script chiede se installare Ollama con <code>gemma3:12b</code> — scaricato in background (~8 GB). Funziona su Apple Silicon (arm64) e amd64.<br>
-      <small>Per disinstallare: <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      Lo script rileva l'hardware, scarica il modello AI ottimale per la tua RAM (1–7 GB) e configura tutto — <strong>zero intervento</strong>.<br>
+      L'app appare in Launchpad / Start Menu / file manager, pronta all'uso.
     </p>
 
     <p class="install-dev-link">
-      Sviluppatore o installazione nativa? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.md" target="_blank">Guida completa (Mac nativo · Linux Docker · Windows llama.cpp)</a>
+      Sviluppatore o installazione manuale? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.md" target="_blank">Guida completa</a>
     </p>
 
-    <!-- ── Desktop native install ──────────────────────────────────────── -->
+    <!-- ── Docker (alternativa) ──────────────────────────────────────── -->
     <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
-      <h3 style="color: var(--green); margin-bottom: 0.5rem;">🖥️ App desktop nativa (senza Docker)</h3>
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Preferisci Docker?</h3>
       <p style="color: var(--muted); margin-bottom: 1.2rem;">
-        Installer one-click che scaricano il modello AI automaticamente.<br>
-        Nessun Docker, nessun Terminal — una finestra nativa con tutto incluso.
+        Serve solo <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>. Container ufficiale da GitHub Container Registry, browser su <strong>http://localhost:8501</strong>.
       </p>
 
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
         <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
-          <strong style="color: var(--text);">🍎 macOS</strong>
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
           <div class="code-block" style="margin-top: 0.5rem;">
             <div class="code-body" style="font-size: 0.85rem;">
-              <div><span class="c">bash</span> packaging/macos/install.sh</div>
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
             </div>
           </div>
-          <small style="color: var(--muted);">Oppure: <code>brew install --cask spendifai</code></small>
         </div>
 
         <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
           <strong style="color: var(--text);">🪟 Windows</strong>
           <div class="code-block" style="margin-top: 0.5rem;">
             <div class="code-body" style="font-size: 0.85rem;">
-              <div><span class="c">winget</span> install SpendifAi.SpendifAi</div>
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
             </div>
           </div>
-          <small style="color: var(--muted);">Oppure: esegui <code>install.ps1</code></small>
-        </div>
-
-        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
-          <strong style="color: var(--text);">🐧 Linux</strong>
-          <div class="code-block" style="margin-top: 0.5rem;">
-            <div class="code-body" style="font-size: 0.85rem;">
-              <div><span class="c">sudo apt install</span> ./spendifai_*.deb</div>
-            </div>
-          </div>
-          <small style="color: var(--muted);">Anche .rpm per Fedora/RHEL</small>
         </div>
       </div>
-
-      <p style="color: var(--muted); margin-top: 1rem; font-size: 0.9rem;">
-        L'installer rileva il tuo hardware, scarica il modello AI migliore per la tua RAM (1–7 GB) e configura tutto automaticamente — <strong style="color: var(--text);">zero intervento</strong>.
-      </p>
     </div>
 
   </div>
 </section>
+
+<!-- ── Community / support ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">Serve aiuto?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Apri una issue su GitHub</a> — bug, domande, richieste di funzionalità.<br>
+    ⭐ <strong style="color: var(--text);">Ti piace Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Lascia una stella</a> — ci aiuta ad arrivare nei repository ufficiali (Homebrew Core, winget).
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1177,6 +1200,9 @@
       <li><span class="dot"></span>API REST per integrazioni esterne</li>
       <li><span class="dot"></span>Versione multi-utente con autenticazione</li>
       <li><span class="dot"></span>App mobile — visualizzazione ledger e analytics</li>
+      <li><span class="dot"></span>Distribuzione via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>Pacchetti <code>.deb</code> e <code>.rpm</code> come release asset GitHub</li>
+      <li><span class="dot"></span>Distribuzione via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1255,8 +1281,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {

--- a/index.pt.html
+++ b/index.pt.html
@@ -983,14 +983,16 @@
   <div class="container">
     <div class="section-label">Instalação</div>
     <h2>Um comando, app pronto</h2>
-    <p class="section-sub">Apenas o <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> é necessário. Sem git clone, sem configuração.</p>
+    <p class="section-sub">App desktop nativa com IA local incluída. Sem Docker, sem Terminal sempre aberto.</p>
 
     <div class="os-tabs">
-      <button class="os-tab active" onclick="switchOS('mac')">🍎 Mac / Linux</button>
+      <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
+      <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>
+      <button class="os-tab" onclick="switchOS('rhel')">🎩 Fedora / RHEL</button>
       <button class="os-tab" onclick="switchOS('win')">🪟 Windows</button>
     </div>
 
-    <!-- Mac / Linux -->
+    <!-- macOS -->
     <div class="os-panel active" id="panel-mac">
       <div class="code-block fade-in">
         <div class="code-header">
@@ -1001,7 +1003,39 @@
           <button class="copy-btn" onclick="copyCode(this, 'mac')">Copiar</button>
         </div>
         <div class="code-body">
-          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</span></div>
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Debian / Ubuntu -->
+    <div class="os-panel" id="panel-deb">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copiar</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Fedora / RHEL -->
+    <div class="os-panel" id="panel-rhel">
+      <div class="code-block fade-in">
+        <div class="code-header">
+          <div class="code-dots">
+            <span class="d1"></span><span class="d2"></span><span class="d3"></span>
+          </div>
+          <span class="code-label">bash</span>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copiar</button>
+        </div>
+        <div class="code-body">
+          <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
         </div>
       </div>
     </div>
@@ -1017,24 +1051,59 @@
           <button class="copy-btn" onclick="copyCode(this, 'win')">Copiar</button>
         </div>
         <div class="code-body">
-          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</span></div>
+          <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
         </div>
       </div>
     </div>
 
     <p class="install-post">
-      O script baixa a imagem do <strong>GitHub Container Registry</strong>, inicia o container
-      e abre o navegador em <strong>http://localhost:8501</strong> automaticamente.<br>
-      <strong>IA local opcional:</strong> o instalador pergunta se deseja adicionar Ollama com <code>gemma3:12b</code> — baixado em segundo plano (~8 GB). Funciona em Apple Silicon (arm64) e amd64.<br>
-      <small>Para desinstalar: <code>curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash</code></small>
+      O script detecta seu hardware, baixa o modelo de IA ideal para sua RAM (1–7 GB) e configura tudo — <strong>zero intervenção</strong>.<br>
+      O app aparece em Launchpad / Menu Iniciar / gerenciador de arquivos, pronto para usar.
     </p>
 
     <p class="install-dev-link">
-      Desenvolvedor ou instalação nativa? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guia completo (Mac nativo · Linux Docker · Windows llama.cpp)</a>
+      Desenvolvedor ou instalação manual? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Guia completo</a>
     </p>
+
+    <!-- ── Docker (alternativa) ──────────────────────────────────────── -->
+    <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Prefere Docker?</h3>
+      <p style="color: var(--muted); margin-bottom: 1.2rem;">
+        Apenas o <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> é necessário. Container oficial do GitHub Container Registry, navegador em <strong>http://localhost:8501</strong>.
+      </p>
+
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🍎 macOS / 🐧 Linux</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">curl</span> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash</div>
+            </div>
+          </div>
+        </div>
+
+        <div style="background: var(--surface2); border-radius: 8px; padding: 1rem;">
+          <strong style="color: var(--text);">🪟 Windows</strong>
+          <div class="code-block" style="margin-top: 0.5rem;">
+            <div class="code-body" style="font-size: 0.85rem;">
+              <div><span class="c">irm</span> https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
   </div>
 </section>
+
+<!-- ── Comunidade / suporte ─────────────────────────────────────────────── -->
+<div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
+  <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
+    🆘 <strong style="color: var(--text);">Precisa de ajuda?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Abra uma issue no GitHub</a> — bugs, perguntas, pedidos de funcionalidades.<br>
+    ⭐ <strong style="color: var(--text);">Gosta do Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Dê-nos uma estrela</a> — ajuda a chegar aos registros oficiais (Homebrew Core, winget).
+  </p>
+</div>
 
 <hr class="divider">
 
@@ -1131,6 +1200,9 @@
       <li><span class="dot"></span>REST API para integrações externas</li>
       <li><span class="dot"></span>Versão multi-usuário com autenticação</li>
       <li><span class="dot"></span>App mobile — visualizador de extrato e análises</li>
+      <li><span class="dot"></span>Distribuição via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>Pacotes <code>.deb</code> e <code>.rpm</code> como release assets do GitHub</li>
+      <li><span class="dot"></span>Distribuição via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1209,8 +1281,10 @@
 
   /* Copy install command */
   const installCmds = {
-    mac: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/install.sh | bash',
-    win: 'irm https://raw.githubusercontent.com/drake69/spendify/main/installer/install.ps1 | iex'
+    mac:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash',
+    deb:  'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash',
+    rhel: 'curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash',
+    win:  'irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex'
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {


### PR DESCRIPTION
## Summary
- Promote native installers (`curl|bash` / `irm|iex` against `packaging/{macos,linux,windows}/install.*`) to the primary install section, with four OS tabs: macOS / Debian-Ubuntu / Fedora-RHEL / Windows.
- Demote Docker to a secondary "Prefer Docker?" block.
- Replace the broken `bash packaging/macos/install.sh` snippet (which assumed a prior `git clone`) with a self-contained one-liner that pulls the installer directly from the repo.
- Roadmap: announce upcoming Homebrew cask, `.deb`/`.rpm` release assets and winget submission as 'in arrivo'.
- Add a Community / support block under install with GitHub Issues link and a star teaser (motivated by Homebrew Core's ≥75 stars threshold).
- Replicated across all six locales: it / en / de / es / fr / pt.

## Test plan
- [ ] Visit https://drake69.github.io/spendify/ once Pages rebuilds — verify the four OS tabs switch correctly and the Copy buttons copy the right one-liner per tab.
- [ ] Spot-check each language version (`/index.en.html`, `.de.html`, `.es.html`, `.fr.html`, `.pt.html`) for the same primary/secondary split.
- [ ] Confirm the Docker section still works as a fallback.
- [ ] Open the GitHub link and the issues link from the support block to verify they target `drake69/spendify`.