### PR TITLE
Landing: add Dutch / Japanese / Polish locales

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -676,6 +676,9 @@
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
+    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 

--- a/index.es.html
+++ b/index.es.html
@@ -670,11 +670,14 @@
   </ul>
   <div class="lang-switcher">
     <a href="index.html" title="Italiano">🇮🇹</a>
-    <a href="index.en.html" title="English" class="active">🇬🇧</a>
+    <a href="index.en.html" title="English">🇬🇧</a>
     <a href="index.de.html" title="Deutsch">🇩🇪</a>
     <a href="index.fr.html" title="Français">🇫🇷</a>
-    <a href="index.es.html" title="Español">🇪🇸</a>
+    <a href="index.es.html" title="Español" class="active">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
+    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 

--- a/index.fr.html
+++ b/index.fr.html
@@ -670,11 +670,14 @@
   </ul>
   <div class="lang-switcher">
     <a href="index.html" title="Italiano">🇮🇹</a>
-    <a href="index.en.html" title="English" class="active">🇬🇧</a>
+    <a href="index.en.html" title="English">🇬🇧</a>
     <a href="index.de.html" title="Deutsch">🇩🇪</a>
-    <a href="index.fr.html" title="Français">🇫🇷</a>
+    <a href="index.fr.html" title="Français" class="active">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
+    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 

--- a/index.html
+++ b/index.html
@@ -675,6 +675,9 @@
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
+    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 

--- a/index.ja.html
+++ b/index.ja.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ja">
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
@@ -11,10 +11,10 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Your unified bank ledger, on your computer</title>
-  <meta name="description" content="Spendify automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
-  <meta property="og:title" content="Spendify — Your unified bank ledger" />
-  <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
+  <title>Spendify — あなたのコンピュータで動く、統合銀行台帳</title>
+  <meta name="description" content="Spendifyは複数の銀行の取引ファイルを自動的に1つの台帳に集約します — 重複なし、サブスクリプションなし、データを誰にも送信しません。" />
+  <meta property="og:title" content="Spendify — あなたの統合銀行台帳" />
+  <meta property="og:description" content="あなたのコンピュータ上で動作するオープンソースの個人向け家計台帳。データはあなたのものです。" />
   <meta property="og:type" content="website" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -39,7 +39,7 @@
     body {
       background: var(--bg);
       color: var(--text);
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "Meiryo", Helvetica, Arial, sans-serif;
       font-size: 16px;
       line-height: 1.6;
     }
@@ -662,84 +662,84 @@
 <nav>
   <a class="nav-logo" href="#">💰 <span>Spend</span>ify</a>
   <ul class="nav-links">
-    <li><a href="#how-it-works">How it works</a></li>
-    <li><a href="#privacy">Privacy</a></li>
-    <li><a href="#features">Features</a></li>
-    <li><a href="#developer">Developer</a></li>
+    <li><a href="#how-it-works">仕組み</a></li>
+    <li><a href="#privacy">プライバシー</a></li>
+    <li><a href="#features">機能</a></li>
+    <li><a href="#developer">開発者向け</a></li>
     <li><a href="https://github.com/drake69/spendify" target="_blank" class="nav-cta">GitHub ↗</a></li>
   </ul>
   <div class="lang-switcher">
     <a href="index.html" title="Italiano">🇮🇹</a>
-    <a href="index.en.html" title="English" class="active">🇬🇧</a>
+    <a href="index.en.html" title="English">🇬🇧</a>
     <a href="index.de.html" title="Deutsch">🇩🇪</a>
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
     <a href="index.nl.html" title="Nederlands">🇳🇱</a>
-    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.ja.html" title="日本語" class="active">🇯🇵</a>
     <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 
 <!-- ── HERO ─────────────────────────────────────────────────────────────── -->
 <section class="hero">
-  <div class="hero-badge">Open source · <strong>Offline-first</strong> · No subscription</div>
-  <h1>Your <span class="accent">unified</span> bank ledger,<br>on your computer</h1>
+  <div class="hero-badge">オープンソース · <strong>オフラインファースト</strong> · サブスクリプションなし</div>
+  <h1>あなたの<span class="accent">統合</span>銀行台帳を、<br>ご自身のコンピュータで</h1>
   <p class="hero-sub">
-    Import files from all your banks. Spendify merges them, eliminates double-counting,
-    classifies every transaction — and your data never leaves your disk.
+    すべての銀行のファイルをインポートします。Spendifyがそれらを統合し、二重計上を排除し、
+    すべての取引を分類します — そしてデータがディスクから出ることは決してありません。
   </p>
   <div class="hero-actions">
-    <a class="btn btn-primary" href="#install">▶ Install now</a>
+    <a class="btn btn-primary" href="#install">▶ 今すぐインストール</a>
     <a class="btn btn-secondary" href="https://github.com/drake69/spendify" target="_blank">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-      View on GitHub
+      GitHubで見る
     </a>
   </div>
-  <p class="hero-note">Python · Streamlit · SQLite · Ollama · no account required</p>
+  <p class="hero-note">Python · Streamlit · SQLite · Ollama · アカウント登録不要</p>
 </section>
 
 <!-- ── TRUST BAR ─────────────────────────────────────────────────────────── -->
 <div class="trust-bar">
-  <div class="trust-item"><span class="ico">🔒</span> Data only on your computer</div>
-  <div class="trust-item"><span class="ico">🔁</span> Idempotent SHA-256 import</div>
-  <div class="trust-item"><span class="ico">🏦</span> Multi-bank, multi-format</div>
-  <div class="trust-item"><span class="ico">🤖</span> Local or cloud AI with PII redaction</div>
-  <div class="trust-item"><span class="ico">🧪</span> 199 tests, zero external dependencies</div>
+  <div class="trust-item"><span class="ico">🔒</span> データはご自身のコンピュータの中だけ</div>
+  <div class="trust-item"><span class="ico">🔁</span> SHA-256による冪等なインポート</div>
+  <div class="trust-item"><span class="ico">🏦</span> 複数銀行・複数フォーマット対応</div>
+  <div class="trust-item"><span class="ico">🤖</span> ローカルまたはクラウドAI、PIIマスキング付き</div>
+  <div class="trust-item"><span class="ico">🧪</span> 199個のテスト、外部依存ゼロ</div>
 </div>
 
 <!-- ── PROBLEM ──────────────────────────────────────────────────────────── -->
 <section id="problema">
   <div class="container">
-    <div class="section-label">The problem</div>
-    <h2>Three banks, three files, one mess</h2>
+    <div class="section-label">課題</div>
+    <h2>3つの銀行、3つのファイル、1つの混乱</h2>
     <p class="section-sub">
-      Every month: download, open Excel, paste, fix the signs, find the duplicates.
-      And every time something doesn't add up.
+      毎月の作業 — ダウンロード、Excelで開く、貼り付け、符号の修正、重複の探索。
+      そして毎回どこかが合わない。
     </p>
 
     <div class="problem-grid fade-in">
       <div class="problem-card">
-        <h3>😩 The monthly routine everyone hates</h3>
-        <p>Three movements files from three different banking portals, incompatible CSV formats,
-        dates in different formats, amounts with random signs. Merging them by hand takes hours
-        and always produces errors.</p>
+        <h3>😩 誰もが嫌う毎月のルーティン</h3>
+        <p>3つの異なる銀行ポータルから取得した3つの取引ファイル、互換性のないCSVフォーマット、
+        異なる形式の日付、ばらばらな符号の金額。これらを手作業で統合するのは何時間もかかり、
+        必ずエラーが発生します。</p>
       </div>
       <div class="problem-card highlight">
-        <h3>🔴 The problem of all problems: double-counting</h3>
-        <p>The supermarket purchase appears in the credit card statement <em>and</em> in the current account
-        as a monthly aggregate charge. Adding everything up, your expenses look double
-        what they actually are. No common tool solves this automatically.</p>
+        <h3>🔴 すべての問題の根源 — 二重計上</h3>
+        <p>スーパーでの買い物がクレジットカード明細<em>と</em>当座預金口座の両方に表示されます。
+        後者は月次の集計請求として計上されるためです。すべてを合計すると、支出が実際の2倍に見えてしまいます。
+        一般的なツールではこれを自動的に解決できません。</p>
       </div>
       <div class="problem-card">
-        <h3>🔄 Internal transfers that distort your balance</h3>
-        <p>A wire transfer to a savings account is not an expense. But if you import both accounts,
-        the same transaction appears twice — as an outflow from the current account and as an inflow on the savings account.</p>
+        <h3>🔄 残高をゆがめる口座間振替</h3>
+        <p>普通預金から定期預金への振替は支出ではありません。しかし両方の口座をインポートすると、
+        同じ取引が2回現れてしまいます — 当座預金からの出金として、そして定期預金への入金として。</p>
       </div>
       <div class="problem-card">
-        <h3>📋 The categorisation that never ends</h3>
-        <p>Classifying 300 transactions per month by hand is a job. Cloud apps do it,
-        but they send your banking data to their servers and charge you a monthly subscription.</p>
+        <h3>📋 終わりのないカテゴリ分類</h3>
+        <p>毎月300件の取引を手作業で分類するのは大変な労力です。クラウド型のアプリはそれを行いますが、
+        あなたの銀行データを自社のサーバーへ送信し、月額料金を請求します。</p>
       </div>
     </div>
   </div>
@@ -750,27 +750,26 @@
 <!-- ── HOW IT WORKS ──────────────────────────────────────────────────────── -->
 <section id="how-it-works">
   <div class="container">
-    <div class="section-label">How it works</div>
-    <h2>Three steps, no black magic</h2>
-    <p class="section-sub">No banking integrations, no account, no per-file configuration.</p>
+    <div class="section-label">仕組み</div>
+    <h2>3ステップ、ブラックボックスなし</h2>
+    <p class="section-sub">銀行とのAPI連携なし、アカウント不要、ファイルごとの設定もありません。</p>
 
     <div class="steps fade-in">
       <div class="step">
-        <h3>Download files from your bank</h3>
-        <p>Export movements files as CSV or XLSX from your bank's portal.
-        Works with any bank — Spendify automatically detects
-        the format with no manual configuration.</p>
+        <h3>銀行からファイルをダウンロード</h3>
+        <p>銀行のポータルから取引ファイルをCSVまたはXLSX形式でエクスポートします。
+        どの銀行でも動作します — Spendifyは手動設定なしで自動的にフォーマットを検出します。</p>
       </div>
       <div class="step">
-        <h3>Drag them into Spendify and click Process</h3>
-        <p>Select all files at once, even from different banks, even from different years.
-        Spendify detects the document type, corrects signs, eliminates double-counting
-        between card and account, and classifies every transaction.</p>
+        <h3>Spendifyにドラッグして「処理」をクリック</h3>
+        <p>すべてのファイルを一度に選択できます。異なる銀行のものでも、異なる年のものでも構いません。
+        Spendifyはドキュメントの種類を識別し、符号を修正し、カードと口座の二重計上を排除し、
+        すべての取引を分類します。</p>
       </div>
       <div class="step">
-        <h3>See where your money goes</h3>
-        <p>The unified ledger shows everything in one place: charts, filters, export,
-        and the certainty that every euro is counted <strong>exactly once</strong>.</p>
+        <h3>お金の行き先を確認</h3>
+        <p>統合された台帳がすべてを一箇所に表示します — グラフ、フィルタ、エクスポート。
+        そして、すべての金額が<strong>正確に1回だけ</strong>カウントされている確かさが得られます。</p>
       </div>
     </div>
   </div>
@@ -781,45 +780,44 @@
 <!-- ── DIFFERENTIATORS ───────────────────────────────────────────────────── -->
 <section id="algoritmi">
   <div class="container">
-    <div class="section-label">What no one else does automatically</div>
-    <h2>Algorithms that solve real problems</h2>
-    <p class="section-sub">This is not a generic budgeting app. It is designed around the specific problems of people with multiple bank accounts.</p>
+    <div class="section-label">他では自動化されていないこと</div>
+    <h2>現実の問題を解くアルゴリズム</h2>
+    <p class="section-sub">これは汎用の家計簿アプリではありません。複数の銀行口座を持つ人々が抱える具体的な課題を中心に設計されています。</p>
 
     <div class="diff-grid fade-in">
       <div class="diff-card">
         <div class="tag">RF-03</div>
-        <h3>Credit card–current account reconciliation</h3>
-        <p>When the credit card charges the monthly amount to the current account,
-        Spendify recognises the relationship and removes the double-counting automatically.</p>
+        <h3>クレジットカードと当座預金口座の照合</h3>
+        <p>クレジットカードが月次金額を当座預金口座から引き落とす際、
+        Spendifyはその関係を認識し、二重計上を自動的に取り除きます。</p>
         <p style="margin-top:.75rem; color: var(--muted); font-size:.88rem;">
-          Time window ±45 days · 3 matching phases:
-          sliding window → subset sum for split amounts → partial reconciliation
+          時間枠 ±45日間 · 3段階のマッチング処理:
+          スライディングウィンドウ → 分割金額に対する部分和探索 → 部分照合
         </p>
       </div>
       <div class="diff-card">
         <div class="tag">RF-04</div>
-        <h3>Internal transfer detection</h3>
-        <p>A wire transfer from a current account to a savings account is neither an expense nor
-        income: it is an internal transfer. Spendify recognises it by comparing
-        amounts, dates, and account holder names in the descriptions — even if the two files
-        were imported at different times.</p>
+        <h3>口座間振替の検出</h3>
+        <p>当座預金から定期預金への振替は、支出でも収入でもなく、内部の資金移動です。
+        Spendifyは金額、日付、説明欄に含まれる口座名義を比較してこれを認識します —
+        2つのファイルが別のタイミングでインポートされていても問題ありません。</p>
       </div>
       <div class="diff-card">
         <div class="tag">Dedup</div>
-        <h3>Idempotent deduplication</h3>
-        <p>Every transaction has a unique ID calculated from its content (SHA-256).
-        If you import the same file twice, nothing happens.
-        You can re-import your entire transaction history without fear of duplicates.</p>
+        <h3>冪等な重複排除</h3>
+        <p>すべての取引は、その内容から計算される一意のID(SHA-256)を持ちます。
+        同じファイルを2回インポートしても、何も起こりません。
+        重複を心配することなく、過去のすべての取引履歴を再インポートできます。</p>
       </div>
       <div class="diff-card">
         <div class="tag">Categories</div>
-        <h3>Cascading hybrid classification</h3>
-        <p>Categorisation uses four levels in sequence:</p>
+        <h3>カスケード式のハイブリッド分類</h3>
+        <p>カテゴリ分類は4階層を順番に使用します:</p>
         <ul class="cascade-list">
-          <li><span class="num">1</span><span><strong>Your rules</strong> — "CONAD" → Groceries (applied retroactively)</span></li>
-          <li><span class="num">2</span><span><strong>Static regex</strong> — predefined patterns for common categories</span></li>
-          <li><span class="num">3</span><span><strong>LLM</strong> — for everything else, local or cloud AI</span></li>
-          <li><span class="num">4</span><span><strong>Fallback</strong> — "To review" if everything else fails</span></li>
+          <li><span class="num">1</span><span><strong>独自ルール</strong> — 「CONAD」 → 食料品 (過去に遡って適用)</span></li>
+          <li><span class="num">2</span><span><strong>静的な正規表現</strong> — よくあるカテゴリ向けの定義済みパターン</span></li>
+          <li><span class="num">3</span><span><strong>LLM</strong> — 残りすべてに対して、ローカルまたはクラウドのAIが処理</span></li>
+          <li><span class="num">4</span><span><strong>フォールバック</strong> — どれも当てはまらなければ「要レビュー」</span></li>
         </ul>
       </div>
     </div>
@@ -831,39 +829,39 @@
 <!-- ── PRIVACY ───────────────────────────────────────────────────────────── -->
 <section id="privacy" class="privacy-section">
   <div class="container">
-    <div class="section-label">Privacy</div>
-    <h2>Your data stays yours. Seriously.</h2>
-    <p class="section-sub">It is not just a slogan. It is the architecture.</p>
+    <div class="section-label">プライバシー</div>
+    <h2>あなたのデータはあなたのもの。本気でそう考えています。</h2>
+    <p class="section-sub">これは単なるスローガンではありません。アーキテクチャそのものです。</p>
 
     <div class="privacy-grid fade-in">
       <div class="privacy-card">
         <div class="ico-big">🏠</div>
-        <h3>Offline-first by default</h3>
-        <p>Spendify uses <strong>Ollama locally</strong> by default: an AI engine that runs
-        on your computer, with no internet connection. Your movements files never
-        leave your disk.</p>
+        <h3>標準でオフラインファースト</h3>
+        <p>Spendifyはデフォルトで<strong>Ollamaをローカル実行</strong>します。インターネット接続なしで
+        ご自身のコンピュータ上で動作するAIエンジンです。取引ファイルがディスクから外へ出ることは
+        ありません。</p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">🛡️</div>
-        <h3>Automatic PII redaction</h3>
-        <p>If you use OpenAI or Claude, Spendify automatically removes all
-        identifying data before any remote call:</p>
+        <h3>PIIの自動マスキング</h3>
+        <p>OpenAIまたはClaudeを使用する場合、Spendifyはリモート呼び出しの前に
+        個人を特定できるすべての情報を自動的に削除します:</p>
         <div class="pii-chips">
           <span class="pii-chip">IBAN → &lt;ACCOUNT_ID&gt;</span>
           <span class="pii-chip">PAN → &lt;CARD_ID&gt;</span>
-          <span class="pii-chip">Tax ID → &lt;FISCAL_ID&gt;</span>
-          <span class="pii-chip">Name → fictitious alias</span>
+          <span class="pii-chip">納税者番号 → &lt;FISCAL_ID&gt;</span>
+          <span class="pii-chip">氏名 → 仮名のエイリアス</span>
         </div>
         <p style="margin-top:.75rem; font-size:.83rem; color:var(--muted)">
-          If the check fails, the call is blocked — not silently degraded.
+          チェックに失敗した場合は呼び出しがブロックされます — 黙って劣化することはありません。
         </p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">💾</div>
-        <h3>Portable local database</h3>
-        <p>Data is stored in a SQLite file on your computer. You can copy it, move it,
-        back it up like any other file. No mandatory cloud,
-        no account, no subscription.</p>
+        <h3>ポータブルなローカルデータベース</h3>
+        <p>データはご自身のコンピュータ上のSQLiteファイルに保存されます。他のファイルと同様に
+        コピー、移動、バックアップが可能です。必須のクラウドも、アカウントも、サブスクリプションも
+        ありません。</p>
       </div>
     </div>
   </div>
@@ -874,43 +872,43 @@
 <!-- ── FOR WHO ───────────────────────────────────────────────────────────── -->
 <section id="per-chi">
   <div class="container">
-    <div class="section-label">Who Spendify is for</div>
-    <h2>Not for everyone. For those who want real control.</h2>
-    <p class="section-sub">Four profiles that find in Spendify something alternatives do not offer.</p>
+    <div class="section-label">Spendifyが向いている方</div>
+    <h2>万人向けではありません。本当の制御を求める方のために。</h2>
+    <p class="section-sub">代替手段では得られない価値を、Spendifyに見出す4つのプロフィール。</p>
 
     <div class="audience-grid fade-in">
       <div class="audience-card">
         <div class="ico-circle">🏦</div>
         <div>
-          <h3>People with accounts at multiple banks</h3>
-          <p>Current account + credit card + savings account + trading account?
-          Spendify unifies them all into a single ledger without having to do anything manually.</p>
+          <h3>複数の銀行に口座を持つ方</h3>
+          <p>当座預金 + クレジットカード + 定期預金 + 証券口座をお使いですか?
+          Spendifyはそれらすべてを1つの台帳に統合します。手作業は一切不要です。</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">📊</div>
         <div>
-          <h3>People who track their finances seriously</h3>
-          <p>If you use Excel for your expenses, Spendify can replace that routine:
-          you import the files once, Spendify unifies and classifies, you review
-          only the exceptions.</p>
+          <h3>本格的に家計を管理する方</h3>
+          <p>家計の管理にExcelを使っているなら、Spendifyがその習慣に置き換わります。
+          ファイルを一度インポートすれば、Spendifyが統合・分類し、
+          あなたは例外だけを確認すればよくなります。</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">🔐</div>
         <div>
-          <h3>People who do not trust the cloud</h3>
-          <p>No mandatory remote backend, no account, no registration.
-          Your banking data stays where it belongs: on your computer.</p>
+          <h3>クラウドを信頼しない方</h3>
+          <p>必須のリモートバックエンドなし、アカウントなし、登録なし。
+          銀行データはあるべき場所 — ご自身のコンピュータの中 — にとどまります。</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">👨‍💻</div>
         <div>
-          <h3>Developers</h3>
-          <p>Open source Python project with modular architecture, LLM pipeline on structured data,
-          full test suite. A starting point for experimenting or
-          building custom integrations.</p>
+          <h3>開発者の方</h3>
+          <p>モジュール化されたアーキテクチャ、構造化データに対するLLMパイプライン、
+          完全なテストスイートを備えたオープンソースのPythonプロジェクトです。
+          実験やカスタム連携を構築するための出発点として活用できます。</p>
         </div>
       </div>
     </div>
@@ -922,58 +920,58 @@
 <!-- ── FEATURES ──────────────────────────────────────────────────────────── -->
 <section id="features">
   <div class="container">
-    <div class="section-label">Features</div>
-    <h2>Everything you need, nothing more</h2>
+    <div class="section-label">機能</div>
+    <h2>必要なものはすべて、それ以上は何もない</h2>
     <br>
 
     <div class="features-grid fade-in">
       <div class="feature-row">
-        <span class="feature-name">Multi-bank import</span>
-        <span class="feature-desc">CSV and XLSX from any bank</span>
+        <span class="feature-name">複数銀行のインポート</span>
+        <span class="feature-desc">どの銀行のCSVおよびXLSXにも対応</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Auto-detect format</span>
-        <span class="feature-desc">No manual configuration for each file type</span>
+        <span class="feature-name">フォーマット自動検出</span>
+        <span class="feature-desc">ファイル種類ごとの手動設定は不要</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Unified ledger</span>
-        <span class="feature-desc">All transactions in chronological order, filterable by date / account / category / context</span>
+        <span class="feature-name">統合台帳</span>
+        <span class="feature-desc">すべての取引を時系列で表示。日付/口座/カテゴリ/コンテキストでフィルタ可能</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Automatic classification</span>
-        <span class="feature-desc">15 expense categories + 7 income categories with subcategories</span>
+        <span class="feature-name">自動カテゴリ分類</span>
+        <span class="feature-desc">15の支出カテゴリ + 7の収入カテゴリ、サブカテゴリも対応</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Customisable taxonomy</span>
-        <span class="feature-desc">Add / edit categories without restarting the app</span>
+        <span class="feature-name">カスタマイズ可能な分類体系</span>
+        <span class="feature-desc">アプリを再起動せずにカテゴリを追加・編集可能</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Deterministic rules</span>
-        <span class="feature-desc">"ESSELUNGA → Groceries" rules applied retroactively</span>
+        <span class="feature-name">決定論的なルール</span>
+        <span class="feature-desc">「ESSELUNGA → 食料品」のようなルールが過去に遡って適用される</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Interactive analytics</span>
-        <span class="feature-desc">7 charts: monthly trend, cumulative balance, category pie, top 10 merchants</span>
+        <span class="feature-name">インタラクティブな分析</span>
+        <span class="feature-desc">7種類のグラフ: 月次推移、累積残高、カテゴリ円グラフ、加盟店トップ10</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Life contexts</span>
-        <span class="feature-desc">Segment expenses by Work / Vacation / Daily life</span>
+        <span class="feature-name">ライフコンテキスト</span>
+        <span class="feature-desc">仕事 / 旅行 / 日常生活で支出を分類</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Check List</span>
-        <span class="feature-desc">Month × account pivot table: see which months you have not imported yet</span>
+        <span class="feature-name">チェックリスト</span>
+        <span class="feature-desc">月 × 口座のピボットテーブル: まだインポートしていない月を確認できる</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Export</span>
-        <span class="feature-desc">Standalone HTML (with charts), CSV, XLSX</span>
+        <span class="feature-name">エクスポート</span>
+        <span class="feature-desc">スタンドアロンHTML(グラフ付き)、CSV、XLSX</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Configurable LLM</span>
-        <span class="feature-desc">Ollama, OpenAI, Claude, Groq, Gemini, LM Studio, any compatible API</span>
+        <span class="feature-name">設定可能なLLM</span>
+        <span class="feature-desc">Ollama、OpenAI、Claude、Groq、Gemini、LM Studio、その他互換APIに対応</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">PII sanitization</span>
-        <span class="feature-desc">Automatic IBAN / card number / tax ID / name protection before remote calls</span>
+        <span class="feature-name">PIIサニタイズ</span>
+        <span class="feature-desc">リモート呼び出し前にIBAN / カード番号 / 納税者番号 / 氏名を自動的に保護</span>
       </div>
     </div>
   </div>
@@ -984,9 +982,9 @@
 <!-- ── INSTALL ───────────────────────────────────────────────────────────── -->
 <section id="install" class="install-section">
   <div class="container">
-    <div class="section-label">Installation</div>
-    <h2>One command, app ready</h2>
-    <p class="section-sub">Native desktop app with local AI included. No Docker, no Terminal kept open.</p>
+    <div class="section-label">インストール</div>
+    <h2>1コマンドで、アプリの準備完了</h2>
+    <p class="section-sub">ローカルAI同梱のネイティブデスクトップアプリです。Dockerは不要、ターミナルを開いたままにする必要もありません。</p>
 
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
@@ -1003,7 +1001,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'mac')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'mac')">コピー</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
@@ -1019,7 +1017,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">コピー</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
@@ -1035,7 +1033,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">コピー</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
@@ -1051,7 +1049,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">powershell</span>
-          <button class="copy-btn" onclick="copyCode(this, 'win')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'win')">コピー</button>
         </div>
         <div class="code-body">
           <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
@@ -1060,20 +1058,20 @@
     </div>
 
     <p class="install-post">
-      The script detects your hardware, downloads the optimal AI model for your RAM (1–7 GB) and sets everything up — <strong>zero intervention</strong>.<br>
-      The app appears in Launchpad / Start Menu / file manager, ready to use.
+      スクリプトはハードウェアを検出し、お使いのRAMに最適なAIモデル(1〜7 GB)をダウンロードしてすべての設定を行います — <strong>ユーザーの作業は不要</strong>です。<br>
+      アプリはLaunchpad / スタートメニュー / ファイルマネージャに表示され、すぐに使える状態になります。
     </p>
 
     <p class="install-dev-link">
-      Developer or manual install? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Full guide</a>
+      開発者向け、または手動インストールをお望みですか? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">完全ガイド</a>
     </p>
 
     <!-- ── Docker (alternative) ──────────────────────────────────────── -->
     <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
-      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Prefer Docker?</h3>
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Dockerをご希望ですか?</h3>
       <p style="color: var(--muted); margin-bottom: 1.2rem;">
-        Only <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> required. Official container from GitHub Container Registry, browser at <strong>http://localhost:8501</strong>.
+        必要なのは<a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>のみです。GitHub Container Registryからの公式コンテナを利用し、ブラウザで<strong>http://localhost:8501</strong>を開きます。
       </p>
 
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
@@ -1103,8 +1101,8 @@
 <!-- ── Community / support ─────────────────────────────────────────────── -->
 <div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
   <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
-    🆘 <strong style="color: var(--text);">Need help?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Open an issue on GitHub</a> — bugs, questions, feature requests.<br>
-    ⭐ <strong style="color: var(--text);">Like Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Give us a star</a> — it helps us reach the official package registries (Homebrew Core, winget).
+    🆘 <strong style="color: var(--text);">サポートが必要ですか?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">GitHubでissueを開いてください</a> — バグ、質問、機能リクエストを受け付けています。<br>
+    ⭐ <strong style="color: var(--text);">Spendif.aiを気に入っていただけましたか?</strong> <a href="https://github.com/drake69/spendify" target="_blank">スターをお願いします</a> — 公式パッケージレジストリ(Homebrew Core、winget)への到達を後押しします。
   </p>
 </div>
 
@@ -1113,20 +1111,20 @@
 <!-- ── STACK ─────────────────────────────────────────────────────────────── -->
 <section id="stack">
   <div class="container">
-    <div class="section-label">Tech stack</div>
-    <h2>Mature technologies, no exotic dependencies</h2>
-    <p class="section-sub">No LLM framework (no LangChain) — AI backends use the official SDKs directly.</p>
+    <div class="section-label">技術スタック</div>
+    <h2>枯れた技術、特殊な依存関係なし</h2>
+    <p class="section-sub">LLMフレームワーク(LangChainなど)は使用せず — AIバックエンドは公式SDKを直接利用しています。</p>
 
     <div class="stack-grid fade-in">
       <div class="stack-badge"><strong>Python 3.13</strong> <span>+ pandas</span></div>
-      <div class="stack-badge"><strong>Streamlit</strong> <span>web interface</span></div>
+      <div class="stack-badge"><strong>Streamlit</strong> <span>Webインターフェース</span></div>
       <div class="stack-badge"><strong>SQLite</strong> <span>+ SQLAlchemy</span></div>
-      <div class="stack-badge"><strong>Pydantic v2</strong> <span>schema validation</span></div>
-      <div class="stack-badge"><strong>Plotly</strong> <span>interactive charts</span></div>
-      <div class="stack-badge"><strong>uv</strong> <span>package manager</span></div>
-      <div class="stack-badge"><strong>Ollama</strong> <span>local AI</span></div>
-      <div class="stack-badge"><strong>chardet</strong> <span>encoding detection</span></div>
-      <div class="stack-badge"><strong>openpyxl</strong> <span>Excel parsing</span></div>
+      <div class="stack-badge"><strong>Pydantic v2</strong> <span>スキーマ検証</span></div>
+      <div class="stack-badge"><strong>Plotly</strong> <span>インタラクティブなグラフ</span></div>
+      <div class="stack-badge"><strong>uv</strong> <span>パッケージマネージャ</span></div>
+      <div class="stack-badge"><strong>Ollama</strong> <span>ローカルAI</span></div>
+      <div class="stack-badge"><strong>chardet</strong> <span>エンコーディング検出</span></div>
+      <div class="stack-badge"><strong>openpyxl</strong> <span>Excelパース</span></div>
     </div>
   </div>
 </section>
@@ -1136,8 +1134,8 @@
 <!-- ── DEVELOPER ─────────────────────────────────────────────────────────── -->
 <section id="developer">
   <div class="container">
-    <div class="section-label">For developers</div>
-    <h2>Modular architecture, full test suite</h2>
+    <div class="section-label">開発者の方へ</div>
+    <h2>モジュール化されたアーキテクチャと完全なテストスイート</h2>
 
     <div class="pipeline-box fade-in">
 <span class="ph">CSV/XLSX File</span>
@@ -1155,20 +1153,20 @@
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🔌 New LLM backends</h3>
-        <p>Implement <code>LLMBackend</code> (3 methods) and register it in <code>BackendFactory</code>. Works with any OpenAI-compatible API.</p>
+        <h3>🔌 新しいLLMバックエンド</h3>
+        <p><code>LLMBackend</code>(3つのメソッド)を実装し、<code>BackendFactory</code>に登録してください。OpenAI互換のあらゆるAPIで動作します。</p>
       </div>
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>Flow 2 recognises them automatically via LLM without code changes. The schema is saved and reused in subsequent imports.</p>
+        <h3>🏦 新しい銀行フォーマット</h3>
+        <p>フロー2はコード変更なしでLLMによりそれらを自動的に認識します。スキーマは保存され、以降のインポートで再利用されます。</p>
       </div>
       <div class="contribute-card">
-        <h3>🏷️ New categories</h3>
-        <p>From the Taxonomy page, without touching the code. The taxonomy is fully configurable from the interface.</p>
+        <h3>🏷️ 新しいカテゴリ</h3>
+        <p>分類体系のページから、コードに触れることなく追加できます。分類体系は画面から完全に設定可能です。</p>
       </div>
       <div class="contribute-card">
         <h3>🚀 REST API</h3>
-        <p>The <code>process_file()</code> pipeline is completely separate from the UI — it can be exposed via FastAPI without changes.</p>
+        <p><code>process_file()</code>パイプラインはUIから完全に分離されており — 変更なしでFastAPIにより公開できます。</p>
       </div>
     </div>
 
@@ -1178,11 +1176,11 @@
         <div class="code-dots">
           <span class="d1"></span><span class="d2"></span><span class="d3"></span>
         </div>
-        <span class="code-label">bash — test suite</span>
+        <span class="code-label">bash — テストスイート</span>
       </div>
       <div class="code-body">
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199 tests, zero external dependencies</span></div>
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># coverage of business logic layer</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199個のテスト、外部依存ゼロ</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># ビジネスロジック層のカバレッジ</span></div>
       </div>
     </div>
   </div>
@@ -1193,19 +1191,19 @@
 <!-- ── ROADMAP ───────────────────────────────────────────────────────────── -->
 <section id="roadmap">
   <div class="container">
-    <div class="section-label">Roadmap</div>
-    <h2>What is coming</h2>
+    <div class="section-label">ロードマップ</div>
+    <h2>これから提供予定の機能</h2>
     <br>
     <ul class="roadmap-list fade-in">
-      <li><span class="dot"></span>PDF support — native parsing of PDF movements files</li>
-      <li><span class="dot"></span>Monthly budget per category with alerting</li>
-      <li><span class="dot"></span>Automatic import via Open Banking (PSD2)</li>
-      <li><span class="dot"></span>REST API for external integrations</li>
-      <li><span class="dot"></span>Multi-user version with authentication</li>
-      <li><span class="dot"></span>Mobile app — ledger and analytics viewer</li>
-      <li><span class="dot"></span>Distribution via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
-      <li><span class="dot"></span><code>.deb</code> and <code>.rpm</code> packages as GitHub release assets</li>
-      <li><span class="dot"></span>Distribution via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
+      <li><span class="dot"></span>PDF対応 — PDF形式の取引ファイルのネイティブパース</li>
+      <li><span class="dot"></span>カテゴリ別の月次予算とアラート機能</li>
+      <li><span class="dot"></span>オープンバンキング(PSD2)による自動インポート</li>
+      <li><span class="dot"></span>外部連携用のREST API</li>
+      <li><span class="dot"></span>認証付きのマルチユーザー版</li>
+      <li><span class="dot"></span>モバイルアプリ — 台帳と分析のビューワー</li>
+      <li><span class="dot"></span><strong>Homebrew</strong>(macOS)経由での配布 — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>GitHubリリースのアセットとして<code>.deb</code>および<code>.rpm</code>パッケージを提供</li>
+      <li><span class="dot"></span><strong>winget</strong>(Windows)経由での配布 — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1215,26 +1213,26 @@
 <!-- ── CONTRIBUTE ────────────────────────────────────────────────────────── -->
 <section id="contribuire">
   <div class="container">
-    <div class="section-label">Open source</div>
-    <h2>Contributions are welcome</h2>
-    <p class="section-sub">Areas where contributions are most useful:</p>
+    <div class="section-label">オープンソース</div>
+    <h2>コントリビューションを歓迎します</h2>
+    <p class="section-sub">特に役立つ貢献分野:</p>
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>If your bank is not automatically recognised, open an issue with an anonymised CSV sample.</p>
+        <h3>🏦 新しい銀行フォーマット</h3>
+        <p>あなたの銀行が自動的に認識されない場合は、匿名化されたCSVサンプルを添えてissueを開いてください。</p>
       </div>
       <div class="contribute-card">
-        <h3>🧪 UI tests</h3>
-        <p>The suite covers the business logic layer but not yet the Streamlit interface. There is room to contribute.</p>
+        <h3>🧪 UIテスト</h3>
+        <p>テストスイートはビジネスロジック層をカバーしていますが、Streamlitインターフェースはまだです。貢献の余地があります。</p>
       </div>
       <div class="contribute-card">
-        <h3>🌍 Internationalisation</h3>
-        <p>The architecture already supports multiple languages for descriptions. The UI is in Italian — there is scope to add other languages.</p>
+        <h3>🌍 国際化</h3>
+        <p>アーキテクチャ自体は説明文の多言語対応をすでにサポートしています。UIはイタリア語であり、他の言語を追加する余地があります。</p>
       </div>
       <div class="contribute-card">
-        <h3>⚡ Performance</h3>
-        <p>Batch categorisation is the bottleneck with a local LLM. There is room for parallelisation.</p>
+        <h3>⚡ パフォーマンス</h3>
+        <p>ローカルLLMを使うとバッチ分類がボトルネックになります。並列化の余地があります。</p>
       </div>
     </div>
 
@@ -1242,7 +1240,7 @@
     <div style="text-align:center; margin-top: 1rem;">
       <a class="btn btn-primary" href="https://github.com/drake69/spendify" target="_blank">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Go to GitHub
+        GitHubへ移動
       </a>
     </div>
   </div>
@@ -1251,14 +1249,13 @@
 <!-- ── FOOTER ─────────────────────────────────────────────────────────────── -->
 <footer>
   <p>
-    <strong>Spendify</strong> is open source —
+    <strong>Spendify</strong> はオープンソースです —
     <a href="https://github.com/drake69/spendify" target="_blank">github.com/drake69/spendify</a>
   </p>
   <p class="disclaimer">
-    Spendify is not a cloud service. It is a program that runs on your computer.
-    Your banking data is never sent to third-party servers, unless you explicitly choose
-    a remote LLM backend — in that case, all identifying data is
-    removed before transmission.
+    Spendifyはクラウドサービスではありません。ご自身のコンピュータ上で動作するプログラムです。
+    銀行データが第三者のサーバーに送信されることはありません。ただし、明示的にリモートのLLMバックエンドを
+    選択した場合のみ送信されます — その場合でも、すべての個人特定情報は送信前に除去されます。
   </p>
 </footer>
 
@@ -1291,8 +1288,8 @@
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {
-      btn.textContent = 'Copied ✓';
-      setTimeout(() => btn.textContent = 'Copy', 2000);
+      btn.textContent = 'コピーしました ✓';
+      setTimeout(() => btn.textContent = 'コピー', 2000);
     });
   }
 </script>

--- a/index.nl.html
+++ b/index.nl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="nl">
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
@@ -11,10 +11,10 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Your unified bank ledger, on your computer</title>
-  <meta name="description" content="Spendify automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
-  <meta property="og:title" content="Spendify — Your unified bank ledger" />
-  <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
+  <title>Spendify — Je geünificeerde rekeningoverzicht, op je eigen computer</title>
+  <meta name="description" content="Spendify voegt automatisch transactiebestanden van verschillende banken samen tot één overzicht — geen duplicaten, geen abonnementen, geen verzending van je gegevens naar wie dan ook." />
+  <meta property="og:title" content="Spendify — Je geünificeerde rekeningoverzicht" />
+  <meta property="og:description" content="Een open source persoonlijk financieel grootboek dat draait op je eigen computer. Je gegevens blijven van jou." />
   <meta property="og:type" content="website" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -662,20 +662,20 @@
 <nav>
   <a class="nav-logo" href="#">💰 <span>Spend</span>ify</a>
   <ul class="nav-links">
-    <li><a href="#how-it-works">How it works</a></li>
+    <li><a href="#how-it-works">Hoe het werkt</a></li>
     <li><a href="#privacy">Privacy</a></li>
-    <li><a href="#features">Features</a></li>
+    <li><a href="#features">Functies</a></li>
     <li><a href="#developer">Developer</a></li>
     <li><a href="https://github.com/drake69/spendify" target="_blank" class="nav-cta">GitHub ↗</a></li>
   </ul>
   <div class="lang-switcher">
     <a href="index.html" title="Italiano">🇮🇹</a>
-    <a href="index.en.html" title="English" class="active">🇬🇧</a>
+    <a href="index.en.html" title="English">🇬🇧</a>
     <a href="index.de.html" title="Deutsch">🇩🇪</a>
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
-    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.nl.html" title="Nederlands" class="active">🇳🇱</a>
     <a href="index.ja.html" title="日本語">🇯🇵</a>
     <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
@@ -683,63 +683,63 @@
 
 <!-- ── HERO ─────────────────────────────────────────────────────────────── -->
 <section class="hero">
-  <div class="hero-badge">Open source · <strong>Offline-first</strong> · No subscription</div>
-  <h1>Your <span class="accent">unified</span> bank ledger,<br>on your computer</h1>
+  <div class="hero-badge">Open source · <strong>Offline-first</strong> · Geen abonnement</div>
+  <h1>Je <span class="accent">geünificeerde</span> rekeningoverzicht,<br>op je eigen computer</h1>
   <p class="hero-sub">
-    Import files from all your banks. Spendify merges them, eliminates double-counting,
-    classifies every transaction — and your data never leaves your disk.
+    Importeer bestanden van al je banken. Spendify voegt ze samen, voorkomt dubbeltellingen,
+    classificeert elke transactie — en je gegevens verlaten nooit je harde schijf.
   </p>
   <div class="hero-actions">
-    <a class="btn btn-primary" href="#install">▶ Install now</a>
+    <a class="btn btn-primary" href="#install">▶ Nu installeren</a>
     <a class="btn btn-secondary" href="https://github.com/drake69/spendify" target="_blank">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-      View on GitHub
+      Bekijk op GitHub
     </a>
   </div>
-  <p class="hero-note">Python · Streamlit · SQLite · Ollama · no account required</p>
+  <p class="hero-note">Python · Streamlit · SQLite · Ollama · geen account vereist</p>
 </section>
 
 <!-- ── TRUST BAR ─────────────────────────────────────────────────────────── -->
 <div class="trust-bar">
-  <div class="trust-item"><span class="ico">🔒</span> Data only on your computer</div>
-  <div class="trust-item"><span class="ico">🔁</span> Idempotent SHA-256 import</div>
-  <div class="trust-item"><span class="ico">🏦</span> Multi-bank, multi-format</div>
-  <div class="trust-item"><span class="ico">🤖</span> Local or cloud AI with PII redaction</div>
-  <div class="trust-item"><span class="ico">🧪</span> 199 tests, zero external dependencies</div>
+  <div class="trust-item"><span class="ico">🔒</span> Gegevens alleen op je eigen computer</div>
+  <div class="trust-item"><span class="ico">🔁</span> Idempotente SHA-256-import</div>
+  <div class="trust-item"><span class="ico">🏦</span> Multi-bank, multi-formaat</div>
+  <div class="trust-item"><span class="ico">🤖</span> Lokale of cloud-AI met PII-redactie</div>
+  <div class="trust-item"><span class="ico">🧪</span> 199 tests, geen externe afhankelijkheden</div>
 </div>
 
 <!-- ── PROBLEM ──────────────────────────────────────────────────────────── -->
 <section id="problema">
   <div class="container">
-    <div class="section-label">The problem</div>
-    <h2>Three banks, three files, one mess</h2>
+    <div class="section-label">Het probleem</div>
+    <h2>Drie banken, drie bestanden, één chaos</h2>
     <p class="section-sub">
-      Every month: download, open Excel, paste, fix the signs, find the duplicates.
-      And every time something doesn't add up.
+      Elke maand: downloaden, Excel openen, plakken, de tekens corrigeren, de duplicaten zoeken.
+      En elke keer klopt er iets niet.
     </p>
 
     <div class="problem-grid fade-in">
       <div class="problem-card">
-        <h3>😩 The monthly routine everyone hates</h3>
-        <p>Three movements files from three different banking portals, incompatible CSV formats,
-        dates in different formats, amounts with random signs. Merging them by hand takes hours
-        and always produces errors.</p>
+        <h3>😩 De maandelijkse routine waar iedereen een hekel aan heeft</h3>
+        <p>Drie transactiebestanden van drie verschillende bankportalen, incompatibele CSV-formaten,
+        datums in verschillende formaten, bedragen met willekeurige tekens. Ze handmatig samenvoegen kost uren
+        en levert altijd fouten op.</p>
       </div>
       <div class="problem-card highlight">
-        <h3>🔴 The problem of all problems: double-counting</h3>
-        <p>The supermarket purchase appears in the credit card statement <em>and</em> in the current account
-        as a monthly aggregate charge. Adding everything up, your expenses look double
-        what they actually are. No common tool solves this automatically.</p>
+        <h3>🔴 Het probleem der problemen: dubbeltellingen</h3>
+        <p>De boodschappen verschijnen op het creditcardafschrift <em>én</em> op de betaalrekening
+        als maandelijkse verzamelafschrijving. Tel je alles op, dan lijken je uitgaven het dubbele
+        van wat ze werkelijk zijn. Geen enkele gangbare tool lost dit automatisch op.</p>
       </div>
       <div class="problem-card">
-        <h3>🔄 Internal transfers that distort your balance</h3>
-        <p>A wire transfer to a savings account is not an expense. But if you import both accounts,
-        the same transaction appears twice — as an outflow from the current account and as an inflow on the savings account.</p>
+        <h3>🔄 Interne overboekingen die je saldo vertekenen</h3>
+        <p>Een overboeking naar een spaarrekening is geen uitgave. Maar als je beide rekeningen importeert,
+        verschijnt dezelfde transactie tweemaal — als uitgave op de betaalrekening en als inkomende op de spaarrekening.</p>
       </div>
       <div class="problem-card">
-        <h3>📋 The categorisation that never ends</h3>
-        <p>Classifying 300 transactions per month by hand is a job. Cloud apps do it,
-        but they send your banking data to their servers and charge you a monthly subscription.</p>
+        <h3>📋 De categorisatie die nooit eindigt</h3>
+        <p>300 transacties per maand handmatig classificeren is een baan op zich. Cloud-apps doen het wel,
+        maar ze sturen je bankgegevens naar hun servers en rekenen een maandelijks abonnement.</p>
       </div>
     </div>
   </div>
@@ -750,27 +750,27 @@
 <!-- ── HOW IT WORKS ──────────────────────────────────────────────────────── -->
 <section id="how-it-works">
   <div class="container">
-    <div class="section-label">How it works</div>
-    <h2>Three steps, no black magic</h2>
-    <p class="section-sub">No banking integrations, no account, no per-file configuration.</p>
+    <div class="section-label">Hoe het werkt</div>
+    <h2>Drie stappen, geen zwarte magie</h2>
+    <p class="section-sub">Geen bankintegraties, geen account, geen configuratie per bestand.</p>
 
     <div class="steps fade-in">
       <div class="step">
-        <h3>Download files from your bank</h3>
-        <p>Export movements files as CSV or XLSX from your bank's portal.
-        Works with any bank — Spendify automatically detects
-        the format with no manual configuration.</p>
+        <h3>Download bestanden van je bank</h3>
+        <p>Exporteer transactiebestanden als CSV of XLSX vanuit het portaal van je bank.
+        Werkt met elke bank — Spendify herkent het formaat automatisch
+        zonder handmatige configuratie.</p>
       </div>
       <div class="step">
-        <h3>Drag them into Spendify and click Process</h3>
-        <p>Select all files at once, even from different banks, even from different years.
-        Spendify detects the document type, corrects signs, eliminates double-counting
-        between card and account, and classifies every transaction.</p>
+        <h3>Sleep ze in Spendify en klik op Verwerken</h3>
+        <p>Selecteer alle bestanden tegelijk, ook van verschillende banken, ook uit verschillende jaren.
+        Spendify herkent het documenttype, corrigeert tekens, voorkomt dubbeltellingen
+        tussen kaart en rekening, en classificeert elke transactie.</p>
       </div>
       <div class="step">
-        <h3>See where your money goes</h3>
-        <p>The unified ledger shows everything in one place: charts, filters, export,
-        and the certainty that every euro is counted <strong>exactly once</strong>.</p>
+        <h3>Zie waar je geld naartoe gaat</h3>
+        <p>Het geünificeerde grootboek toont alles op één plek: grafieken, filters, export,
+        en de zekerheid dat elke euro <strong>precies één keer</strong> wordt geteld.</p>
       </div>
     </div>
   </div>
@@ -781,45 +781,45 @@
 <!-- ── DIFFERENTIATORS ───────────────────────────────────────────────────── -->
 <section id="algoritmi">
   <div class="container">
-    <div class="section-label">What no one else does automatically</div>
-    <h2>Algorithms that solve real problems</h2>
-    <p class="section-sub">This is not a generic budgeting app. It is designed around the specific problems of people with multiple bank accounts.</p>
+    <div class="section-label">Wat niemand anders automatisch doet</div>
+    <h2>Algoritmes die echte problemen oplossen</h2>
+    <p class="section-sub">Dit is geen generieke budget-app. Het is ontworpen rond de specifieke problemen van mensen met meerdere rekeningen.</p>
 
     <div class="diff-grid fade-in">
       <div class="diff-card">
         <div class="tag">RF-03</div>
-        <h3>Credit card–current account reconciliation</h3>
-        <p>When the credit card charges the monthly amount to the current account,
-        Spendify recognises the relationship and removes the double-counting automatically.</p>
+        <h3>Reconciliatie creditcard–betaalrekening</h3>
+        <p>Wanneer de creditcard het maandbedrag afschrijft van de betaalrekening,
+        herkent Spendify het verband en verwijdert de dubbeltelling automatisch.</p>
         <p style="margin-top:.75rem; color: var(--muted); font-size:.88rem;">
-          Time window ±45 days · 3 matching phases:
-          sliding window → subset sum for split amounts → partial reconciliation
+          Tijdvenster ±45 dagen · 3 matchingfasen:
+          glijdend venster → subset sum voor opgesplitste bedragen → gedeeltelijke reconciliatie
         </p>
       </div>
       <div class="diff-card">
         <div class="tag">RF-04</div>
-        <h3>Internal transfer detection</h3>
-        <p>A wire transfer from a current account to a savings account is neither an expense nor
-        income: it is an internal transfer. Spendify recognises it by comparing
-        amounts, dates, and account holder names in the descriptions — even if the two files
-        were imported at different times.</p>
+        <h3>Detectie van interne overboekingen</h3>
+        <p>Een overboeking van een betaalrekening naar een spaarrekening is geen uitgave en geen
+        inkomen: het is een interne overboeking. Spendify herkent dit door bedragen,
+        datums en rekeninghoudersnamen in de omschrijvingen te vergelijken — zelfs als de twee bestanden
+        op verschillende momenten zijn geïmporteerd.</p>
       </div>
       <div class="diff-card">
         <div class="tag">Dedup</div>
-        <h3>Idempotent deduplication</h3>
-        <p>Every transaction has a unique ID calculated from its content (SHA-256).
-        If you import the same file twice, nothing happens.
-        You can re-import your entire transaction history without fear of duplicates.</p>
+        <h3>Idempotente deduplicatie</h3>
+        <p>Elke transactie heeft een unieke ID berekend uit de inhoud (SHA-256).
+        Als je hetzelfde bestand twee keer importeert, gebeurt er niets.
+        Je kunt je hele transactiehistorie opnieuw importeren zonder angst voor duplicaten.</p>
       </div>
       <div class="diff-card">
         <div class="tag">Categories</div>
-        <h3>Cascading hybrid classification</h3>
-        <p>Categorisation uses four levels in sequence:</p>
+        <h3>Hybride classificatie in cascade</h3>
+        <p>De categorisatie gebruikt vier niveaus achter elkaar:</p>
         <ul class="cascade-list">
-          <li><span class="num">1</span><span><strong>Your rules</strong> — "CONAD" → Groceries (applied retroactively)</span></li>
-          <li><span class="num">2</span><span><strong>Static regex</strong> — predefined patterns for common categories</span></li>
-          <li><span class="num">3</span><span><strong>LLM</strong> — for everything else, local or cloud AI</span></li>
-          <li><span class="num">4</span><span><strong>Fallback</strong> — "To review" if everything else fails</span></li>
+          <li><span class="num">1</span><span><strong>Je eigen regels</strong> — "ALBERT HEIJN" → Boodschappen (met terugwerkende kracht toegepast)</span></li>
+          <li><span class="num">2</span><span><strong>Statische regex</strong> — vooraf gedefinieerde patronen voor gangbare categorieën</span></li>
+          <li><span class="num">3</span><span><strong>LLM</strong> — voor al het overige, lokale of cloud-AI</span></li>
+          <li><span class="num">4</span><span><strong>Fallback</strong> — "Te beoordelen" als al het andere faalt</span></li>
         </ul>
       </div>
     </div>
@@ -832,38 +832,38 @@
 <section id="privacy" class="privacy-section">
   <div class="container">
     <div class="section-label">Privacy</div>
-    <h2>Your data stays yours. Seriously.</h2>
-    <p class="section-sub">It is not just a slogan. It is the architecture.</p>
+    <h2>Je gegevens blijven van jou. Echt waar.</h2>
+    <p class="section-sub">Het is geen slogan. Het is de architectuur.</p>
 
     <div class="privacy-grid fade-in">
       <div class="privacy-card">
         <div class="ico-big">🏠</div>
-        <h3>Offline-first by default</h3>
-        <p>Spendify uses <strong>Ollama locally</strong> by default: an AI engine that runs
-        on your computer, with no internet connection. Your movements files never
-        leave your disk.</p>
+        <h3>Standaard offline-first</h3>
+        <p>Spendify gebruikt standaard <strong>Ollama lokaal</strong>: een AI-engine die draait
+        op je eigen computer, zonder internetverbinding. Je transactiebestanden verlaten nooit
+        je harde schijf.</p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">🛡️</div>
-        <h3>Automatic PII redaction</h3>
-        <p>If you use OpenAI or Claude, Spendify automatically removes all
-        identifying data before any remote call:</p>
+        <h3>Automatische PII-redactie</h3>
+        <p>Als je OpenAI of Claude gebruikt, verwijdert Spendify automatisch alle
+        identificerende gegevens vóór elke remote-aanroep:</p>
         <div class="pii-chips">
           <span class="pii-chip">IBAN → &lt;ACCOUNT_ID&gt;</span>
           <span class="pii-chip">PAN → &lt;CARD_ID&gt;</span>
-          <span class="pii-chip">Tax ID → &lt;FISCAL_ID&gt;</span>
-          <span class="pii-chip">Name → fictitious alias</span>
+          <span class="pii-chip">BSN → &lt;FISCAL_ID&gt;</span>
+          <span class="pii-chip">Naam → fictief alias</span>
         </div>
         <p style="margin-top:.75rem; font-size:.83rem; color:var(--muted)">
-          If the check fails, the call is blocked — not silently degraded.
+          Als de controle faalt, wordt de aanroep geblokkeerd — niet stilzwijgend gedegradeerd.
         </p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">💾</div>
-        <h3>Portable local database</h3>
-        <p>Data is stored in a SQLite file on your computer. You can copy it, move it,
-        back it up like any other file. No mandatory cloud,
-        no account, no subscription.</p>
+        <h3>Portable lokale database</h3>
+        <p>De gegevens worden opgeslagen in een SQLite-bestand op je computer. Je kunt het kopiëren, verplaatsen
+        of er een back-up van maken zoals van elk ander bestand. Geen verplichte cloud,
+        geen account, geen abonnement.</p>
       </div>
     </div>
   </div>
@@ -874,43 +874,43 @@
 <!-- ── FOR WHO ───────────────────────────────────────────────────────────── -->
 <section id="per-chi">
   <div class="container">
-    <div class="section-label">Who Spendify is for</div>
-    <h2>Not for everyone. For those who want real control.</h2>
-    <p class="section-sub">Four profiles that find in Spendify something alternatives do not offer.</p>
+    <div class="section-label">Voor wie is Spendify</div>
+    <h2>Niet voor iedereen. Voor wie echte controle wil.</h2>
+    <p class="section-sub">Vier profielen die in Spendify iets vinden wat alternatieven niet bieden.</p>
 
     <div class="audience-grid fade-in">
       <div class="audience-card">
         <div class="ico-circle">🏦</div>
         <div>
-          <h3>People with accounts at multiple banks</h3>
-          <p>Current account + credit card + savings account + trading account?
-          Spendify unifies them all into a single ledger without having to do anything manually.</p>
+          <h3>Mensen met rekeningen bij meerdere banken</h3>
+          <p>Betaalrekening + creditcard + spaarrekening + beleggingsrekening?
+          Spendify voegt ze allemaal samen tot één overzicht zonder dat je iets handmatig hoeft te doen.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">📊</div>
         <div>
-          <h3>People who track their finances seriously</h3>
-          <p>If you use Excel for your expenses, Spendify can replace that routine:
-          you import the files once, Spendify unifies and classifies, you review
-          only the exceptions.</p>
+          <h3>Mensen die hun financiën serieus volgen</h3>
+          <p>Als je Excel gebruikt voor je uitgaven, kan Spendify die routine vervangen:
+          je importeert de bestanden één keer, Spendify voegt samen en classificeert, en jij beoordeelt
+          alleen de uitzonderingen.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">🔐</div>
         <div>
-          <h3>People who do not trust the cloud</h3>
-          <p>No mandatory remote backend, no account, no registration.
-          Your banking data stays where it belongs: on your computer.</p>
+          <h3>Mensen die de cloud niet vertrouwen</h3>
+          <p>Geen verplichte remote backend, geen account, geen registratie.
+          Je bankgegevens blijven waar ze horen: op je eigen computer.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">👨‍💻</div>
         <div>
           <h3>Developers</h3>
-          <p>Open source Python project with modular architecture, LLM pipeline on structured data,
-          full test suite. A starting point for experimenting or
-          building custom integrations.</p>
+          <p>Open source Python-project met modulaire architectuur, LLM-pipeline op gestructureerde data,
+          volledige testsuite. Een startpunt om mee te experimenteren of
+          op maat gemaakte integraties te bouwen.</p>
         </div>
       </div>
     </div>
@@ -922,58 +922,58 @@
 <!-- ── FEATURES ──────────────────────────────────────────────────────────── -->
 <section id="features">
   <div class="container">
-    <div class="section-label">Features</div>
-    <h2>Everything you need, nothing more</h2>
+    <div class="section-label">Functies</div>
+    <h2>Alles wat je nodig hebt, niets meer</h2>
     <br>
 
     <div class="features-grid fade-in">
       <div class="feature-row">
-        <span class="feature-name">Multi-bank import</span>
-        <span class="feature-desc">CSV and XLSX from any bank</span>
+        <span class="feature-name">Multi-bank-import</span>
+        <span class="feature-desc">CSV en XLSX van elke bank</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Auto-detect format</span>
-        <span class="feature-desc">No manual configuration for each file type</span>
+        <span class="feature-name">Auto-detectie van formaat</span>
+        <span class="feature-desc">Geen handmatige configuratie per bestandstype</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Unified ledger</span>
-        <span class="feature-desc">All transactions in chronological order, filterable by date / account / category / context</span>
+        <span class="feature-name">Geünificeerd grootboek</span>
+        <span class="feature-desc">Alle transacties op chronologische volgorde, filterbaar op datum / rekening / categorie / context</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Automatic classification</span>
-        <span class="feature-desc">15 expense categories + 7 income categories with subcategories</span>
+        <span class="feature-name">Automatische classificatie</span>
+        <span class="feature-desc">15 uitgavencategorieën + 7 inkomstencategorieën met subcategorieën</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Customisable taxonomy</span>
-        <span class="feature-desc">Add / edit categories without restarting the app</span>
+        <span class="feature-name">Aanpasbare taxonomie</span>
+        <span class="feature-desc">Categorieën toevoegen / bewerken zonder de app opnieuw te starten</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Deterministic rules</span>
-        <span class="feature-desc">"ESSELUNGA → Groceries" rules applied retroactively</span>
+        <span class="feature-name">Deterministische regels</span>
+        <span class="feature-desc">Regels als "ALBERT HEIJN → Boodschappen", met terugwerkende kracht toegepast</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Interactive analytics</span>
-        <span class="feature-desc">7 charts: monthly trend, cumulative balance, category pie, top 10 merchants</span>
+        <span class="feature-name">Interactieve analytics</span>
+        <span class="feature-desc">7 grafieken: maandelijkse trend, cumulatief saldo, categorie-pie, top 10 verkopers</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Life contexts</span>
-        <span class="feature-desc">Segment expenses by Work / Vacation / Daily life</span>
+        <span class="feature-name">Levenscontexten</span>
+        <span class="feature-desc">Segmenteer uitgaven op Werk / Vakantie / Dagelijks leven</span>
       </div>
       <div class="feature-row">
         <span class="feature-name">Check List</span>
-        <span class="feature-desc">Month × account pivot table: see which months you have not imported yet</span>
+        <span class="feature-desc">Pivot-tabel maand × rekening: zie welke maanden je nog niet hebt geïmporteerd</span>
       </div>
       <div class="feature-row">
         <span class="feature-name">Export</span>
-        <span class="feature-desc">Standalone HTML (with charts), CSV, XLSX</span>
+        <span class="feature-desc">Standalone HTML (met grafieken), CSV, XLSX</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Configurable LLM</span>
-        <span class="feature-desc">Ollama, OpenAI, Claude, Groq, Gemini, LM Studio, any compatible API</span>
+        <span class="feature-name">Configureerbare LLM</span>
+        <span class="feature-desc">Ollama, OpenAI, Claude, Groq, Gemini, LM Studio, elke compatibele API</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">PII sanitization</span>
-        <span class="feature-desc">Automatic IBAN / card number / tax ID / name protection before remote calls</span>
+        <span class="feature-name">PII-sanitatie</span>
+        <span class="feature-desc">Automatische bescherming van IBAN / kaartnummer / BSN / naam vóór remote-aanroepen</span>
       </div>
     </div>
   </div>
@@ -984,9 +984,9 @@
 <!-- ── INSTALL ───────────────────────────────────────────────────────────── -->
 <section id="install" class="install-section">
   <div class="container">
-    <div class="section-label">Installation</div>
-    <h2>One command, app ready</h2>
-    <p class="section-sub">Native desktop app with local AI included. No Docker, no Terminal kept open.</p>
+    <div class="section-label">Installatie</div>
+    <h2>Eén commando, app klaar voor gebruik</h2>
+    <p class="section-sub">Native desktop-app met lokale AI inbegrepen. Geen Docker, geen Terminal die openblijft.</p>
 
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
@@ -1003,7 +1003,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'mac')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'mac')">Kopiëren</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
@@ -1019,7 +1019,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Kopiëren</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
@@ -1035,7 +1035,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Kopiëren</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
@@ -1051,7 +1051,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">powershell</span>
-          <button class="copy-btn" onclick="copyCode(this, 'win')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'win')">Kopiëren</button>
         </div>
         <div class="code-body">
           <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
@@ -1060,20 +1060,20 @@
     </div>
 
     <p class="install-post">
-      The script detects your hardware, downloads the optimal AI model for your RAM (1–7 GB) and sets everything up — <strong>zero intervention</strong>.<br>
-      The app appears in Launchpad / Start Menu / file manager, ready to use.
+      Het script detecteert je hardware, downloadt het optimale AI-model voor je RAM (1–7 GB) en regelt alles — <strong>zonder enige tussenkomst</strong>.<br>
+      De app verschijnt in Launchpad / Startmenu / bestandsbeheer, klaar voor gebruik.
     </p>
 
     <p class="install-dev-link">
-      Developer or manual install? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Full guide</a>
+      Developer of handmatige installatie? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Volledige handleiding</a>
     </p>
 
     <!-- ── Docker (alternative) ──────────────────────────────────────── -->
     <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
-      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Prefer Docker?</h3>
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Liever Docker?</h3>
       <p style="color: var(--muted); margin-bottom: 1.2rem;">
-        Only <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> required. Official container from GitHub Container Registry, browser at <strong>http://localhost:8501</strong>.
+        Alleen <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> vereist. Officiële container van GitHub Container Registry, browser op <strong>http://localhost:8501</strong>.
       </p>
 
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
@@ -1103,8 +1103,8 @@
 <!-- ── Community / support ─────────────────────────────────────────────── -->
 <div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
   <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
-    🆘 <strong style="color: var(--text);">Need help?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Open an issue on GitHub</a> — bugs, questions, feature requests.<br>
-    ⭐ <strong style="color: var(--text);">Like Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Give us a star</a> — it helps us reach the official package registries (Homebrew Core, winget).
+    🆘 <strong style="color: var(--text);">Hulp nodig?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Open een issue op GitHub</a> — bugs, vragen, feature-verzoeken.<br>
+    ⭐ <strong style="color: var(--text);">Vind je Spendif.ai leuk?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Geef ons een ster</a> — het helpt ons de officiële package registries te bereiken (Homebrew Core, winget).
   </p>
 </div>
 
@@ -1114,19 +1114,19 @@
 <section id="stack">
   <div class="container">
     <div class="section-label">Tech stack</div>
-    <h2>Mature technologies, no exotic dependencies</h2>
-    <p class="section-sub">No LLM framework (no LangChain) — AI backends use the official SDKs directly.</p>
+    <h2>Volwassen technologieën, geen exotische afhankelijkheden</h2>
+    <p class="section-sub">Geen LLM-framework (geen LangChain) — AI-backends gebruiken direct de officiële SDK's.</p>
 
     <div class="stack-grid fade-in">
       <div class="stack-badge"><strong>Python 3.13</strong> <span>+ pandas</span></div>
-      <div class="stack-badge"><strong>Streamlit</strong> <span>web interface</span></div>
+      <div class="stack-badge"><strong>Streamlit</strong> <span>web-interface</span></div>
       <div class="stack-badge"><strong>SQLite</strong> <span>+ SQLAlchemy</span></div>
-      <div class="stack-badge"><strong>Pydantic v2</strong> <span>schema validation</span></div>
-      <div class="stack-badge"><strong>Plotly</strong> <span>interactive charts</span></div>
+      <div class="stack-badge"><strong>Pydantic v2</strong> <span>schemavalidatie</span></div>
+      <div class="stack-badge"><strong>Plotly</strong> <span>interactieve grafieken</span></div>
       <div class="stack-badge"><strong>uv</strong> <span>package manager</span></div>
-      <div class="stack-badge"><strong>Ollama</strong> <span>local AI</span></div>
-      <div class="stack-badge"><strong>chardet</strong> <span>encoding detection</span></div>
-      <div class="stack-badge"><strong>openpyxl</strong> <span>Excel parsing</span></div>
+      <div class="stack-badge"><strong>Ollama</strong> <span>lokale AI</span></div>
+      <div class="stack-badge"><strong>chardet</strong> <span>encoding-detectie</span></div>
+      <div class="stack-badge"><strong>openpyxl</strong> <span>Excel-parsing</span></div>
     </div>
   </div>
 </section>
@@ -1136,8 +1136,8 @@
 <!-- ── DEVELOPER ─────────────────────────────────────────────────────────── -->
 <section id="developer">
   <div class="container">
-    <div class="section-label">For developers</div>
-    <h2>Modular architecture, full test suite</h2>
+    <div class="section-label">Voor developers</div>
+    <h2>Modulaire architectuur, volledige testsuite</h2>
 
     <div class="pipeline-box fade-in">
 <span class="ph">CSV/XLSX File</span>
@@ -1155,20 +1155,20 @@
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🔌 New LLM backends</h3>
-        <p>Implement <code>LLMBackend</code> (3 methods) and register it in <code>BackendFactory</code>. Works with any OpenAI-compatible API.</p>
+        <h3>🔌 Nieuwe LLM-backends</h3>
+        <p>Implementeer <code>LLMBackend</code> (3 methoden) en registreer hem in <code>BackendFactory</code>. Werkt met elke OpenAI-compatibele API.</p>
       </div>
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>Flow 2 recognises them automatically via LLM without code changes. The schema is saved and reused in subsequent imports.</p>
+        <h3>🏦 Nieuwe bankformaten</h3>
+        <p>Flow 2 herkent ze automatisch via LLM zonder codewijzigingen. Het schema wordt opgeslagen en hergebruikt bij volgende imports.</p>
       </div>
       <div class="contribute-card">
-        <h3>🏷️ New categories</h3>
-        <p>From the Taxonomy page, without touching the code. The taxonomy is fully configurable from the interface.</p>
+        <h3>🏷️ Nieuwe categorieën</h3>
+        <p>Vanuit de pagina Taxonomie, zonder de code aan te raken. De taxonomie is volledig configureerbaar vanuit de interface.</p>
       </div>
       <div class="contribute-card">
         <h3>🚀 REST API</h3>
-        <p>The <code>process_file()</code> pipeline is completely separate from the UI — it can be exposed via FastAPI without changes.</p>
+        <p>De pipeline <code>process_file()</code> staat volledig los van de UI — hij kan zonder wijzigingen via FastAPI worden ontsloten.</p>
       </div>
     </div>
 
@@ -1178,11 +1178,11 @@
         <div class="code-dots">
           <span class="d1"></span><span class="d2"></span><span class="d3"></span>
         </div>
-        <span class="code-label">bash — test suite</span>
+        <span class="code-label">bash — testsuite</span>
       </div>
       <div class="code-body">
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199 tests, zero external dependencies</span></div>
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># coverage of business logic layer</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199 tests, geen externe afhankelijkheden</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># coverage van de business-logic-laag</span></div>
       </div>
     </div>
   </div>
@@ -1194,18 +1194,18 @@
 <section id="roadmap">
   <div class="container">
     <div class="section-label">Roadmap</div>
-    <h2>What is coming</h2>
+    <h2>Wat eraan komt</h2>
     <br>
     <ul class="roadmap-list fade-in">
-      <li><span class="dot"></span>PDF support — native parsing of PDF movements files</li>
-      <li><span class="dot"></span>Monthly budget per category with alerting</li>
-      <li><span class="dot"></span>Automatic import via Open Banking (PSD2)</li>
-      <li><span class="dot"></span>REST API for external integrations</li>
-      <li><span class="dot"></span>Multi-user version with authentication</li>
-      <li><span class="dot"></span>Mobile app — ledger and analytics viewer</li>
-      <li><span class="dot"></span>Distribution via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
-      <li><span class="dot"></span><code>.deb</code> and <code>.rpm</code> packages as GitHub release assets</li>
-      <li><span class="dot"></span>Distribution via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
+      <li><span class="dot"></span>PDF-ondersteuning — native parsing van PDF-transactiebestanden</li>
+      <li><span class="dot"></span>Maandbudget per categorie met alerting</li>
+      <li><span class="dot"></span>Automatische import via Open Banking (PSD2)</li>
+      <li><span class="dot"></span>REST API voor externe integraties</li>
+      <li><span class="dot"></span>Multi-user-versie met authenticatie</li>
+      <li><span class="dot"></span>Mobiele app — viewer voor grootboek en analytics</li>
+      <li><span class="dot"></span>Distributie via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span><code>.deb</code>- en <code>.rpm</code>-packages als GitHub release-assets</li>
+      <li><span class="dot"></span>Distributie via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1216,25 +1216,25 @@
 <section id="contribuire">
   <div class="container">
     <div class="section-label">Open source</div>
-    <h2>Contributions are welcome</h2>
-    <p class="section-sub">Areas where contributions are most useful:</p>
+    <h2>Bijdragen zijn welkom</h2>
+    <p class="section-sub">Gebieden waar bijdragen het meest van pas komen:</p>
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>If your bank is not automatically recognised, open an issue with an anonymised CSV sample.</p>
+        <h3>🏦 Nieuwe bankformaten</h3>
+        <p>Als jouw bank niet automatisch wordt herkend, open dan een issue met een geanonimiseerd CSV-voorbeeld.</p>
       </div>
       <div class="contribute-card">
-        <h3>🧪 UI tests</h3>
-        <p>The suite covers the business logic layer but not yet the Streamlit interface. There is room to contribute.</p>
+        <h3>🧪 UI-tests</h3>
+        <p>De suite dekt de business-logic-laag, maar nog niet de Streamlit-interface. Hier is ruimte om bij te dragen.</p>
       </div>
       <div class="contribute-card">
-        <h3>🌍 Internationalisation</h3>
-        <p>The architecture already supports multiple languages for descriptions. The UI is in Italian — there is scope to add other languages.</p>
+        <h3>🌍 Internationalisatie</h3>
+        <p>De architectuur ondersteunt al meerdere talen voor omschrijvingen. De UI is in het Italiaans — er is ruimte om andere talen toe te voegen.</p>
       </div>
       <div class="contribute-card">
         <h3>⚡ Performance</h3>
-        <p>Batch categorisation is the bottleneck with a local LLM. There is room for parallelisation.</p>
+        <p>Batch-categorisatie is de bottleneck met een lokale LLM. Er is ruimte voor parallellisatie.</p>
       </div>
     </div>
 
@@ -1242,7 +1242,7 @@
     <div style="text-align:center; margin-top: 1rem;">
       <a class="btn btn-primary" href="https://github.com/drake69/spendify" target="_blank">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Go to GitHub
+        Naar GitHub
       </a>
     </div>
   </div>
@@ -1255,10 +1255,10 @@
     <a href="https://github.com/drake69/spendify" target="_blank">github.com/drake69/spendify</a>
   </p>
   <p class="disclaimer">
-    Spendify is not a cloud service. It is a program that runs on your computer.
-    Your banking data is never sent to third-party servers, unless you explicitly choose
-    a remote LLM backend — in that case, all identifying data is
-    removed before transmission.
+    Spendify is geen cloud-dienst. Het is een programma dat draait op je eigen computer.
+    Je bankgegevens worden nooit naar servers van derden gestuurd, tenzij je expliciet kiest
+    voor een remote LLM-backend — in dat geval worden alle identificerende gegevens
+    verwijderd vóór verzending.
   </p>
 </footer>
 
@@ -1291,8 +1291,8 @@
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {
-      btn.textContent = 'Copied ✓';
-      setTimeout(() => btn.textContent = 'Copy', 2000);
+      btn.textContent = 'Gekopieerd ✓';
+      setTimeout(() => btn.textContent = 'Kopiëren', 2000);
     });
   }
 </script>

--- a/index.pl.html
+++ b/index.pl.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pl">
 <head>
   <!-- Google tag (gtag.js) -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
@@ -11,10 +11,10 @@
   </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Your unified bank ledger, on your computer</title>
-  <meta name="description" content="Spendify automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
-  <meta property="og:title" content="Spendify — Your unified bank ledger" />
-  <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
+  <title>Spendify — Twoja ujednolicona księga bankowa, na Twoim komputerze</title>
+  <meta name="description" content="Spendify automatycznie agreguje pliki z transakcjami z różnych banków w jedną księgę — bez duplikatów, bez subskrypcji, bez wysyłania danych komukolwiek." />
+  <meta property="og:title" content="Spendify — Twoja ujednolicona księga bankowa" />
+  <meta property="og:description" content="Otwartoźródłowa osobista księga finansowa działająca na Twoim komputerze. Twoje dane pozostają Twoje." />
   <meta property="og:type" content="website" />
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -662,84 +662,84 @@
 <nav>
   <a class="nav-logo" href="#">💰 <span>Spend</span>ify</a>
   <ul class="nav-links">
-    <li><a href="#how-it-works">How it works</a></li>
-    <li><a href="#privacy">Privacy</a></li>
-    <li><a href="#features">Features</a></li>
-    <li><a href="#developer">Developer</a></li>
+    <li><a href="#how-it-works">Jak to działa</a></li>
+    <li><a href="#privacy">Prywatność</a></li>
+    <li><a href="#features">Funkcje</a></li>
+    <li><a href="#developer">Dla developerów</a></li>
     <li><a href="https://github.com/drake69/spendify" target="_blank" class="nav-cta">GitHub ↗</a></li>
   </ul>
   <div class="lang-switcher">
     <a href="index.html" title="Italiano">🇮🇹</a>
-    <a href="index.en.html" title="English" class="active">🇬🇧</a>
+    <a href="index.en.html" title="English">🇬🇧</a>
     <a href="index.de.html" title="Deutsch">🇩🇪</a>
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português">🇵🇹</a>
     <a href="index.nl.html" title="Nederlands">🇳🇱</a>
     <a href="index.ja.html" title="日本語">🇯🇵</a>
-    <a href="index.pl.html" title="Polski">🇵🇱</a>
+    <a href="index.pl.html" title="Polski" class="active">🇵🇱</a>
   </div>
 </nav>
 
 <!-- ── HERO ─────────────────────────────────────────────────────────────── -->
 <section class="hero">
-  <div class="hero-badge">Open source · <strong>Offline-first</strong> · No subscription</div>
-  <h1>Your <span class="accent">unified</span> bank ledger,<br>on your computer</h1>
+  <div class="hero-badge">Open source · <strong>Offline-first</strong> · Bez subskrypcji</div>
+  <h1>Twoja <span class="accent">ujednolicona</span> księga bankowa,<br>na Twoim komputerze</h1>
   <p class="hero-sub">
-    Import files from all your banks. Spendify merges them, eliminates double-counting,
-    classifies every transaction — and your data never leaves your disk.
+    Importuj pliki ze wszystkich swoich banków. Spendify scala je, eliminuje podwójne księgowanie,
+    klasyfikuje każdą transakcję — a Twoje dane nigdy nie opuszczają Twojego dysku.
   </p>
   <div class="hero-actions">
-    <a class="btn btn-primary" href="#install">▶ Install now</a>
+    <a class="btn btn-primary" href="#install">▶ Zainstaluj teraz</a>
     <a class="btn btn-secondary" href="https://github.com/drake69/spendify" target="_blank">
       <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-      View on GitHub
+      Zobacz na GitHubie
     </a>
   </div>
-  <p class="hero-note">Python · Streamlit · SQLite · Ollama · no account required</p>
+  <p class="hero-note">Python · Streamlit · SQLite · Ollama · konto niewymagane</p>
 </section>
 
 <!-- ── TRUST BAR ─────────────────────────────────────────────────────────── -->
 <div class="trust-bar">
-  <div class="trust-item"><span class="ico">🔒</span> Data only on your computer</div>
-  <div class="trust-item"><span class="ico">🔁</span> Idempotent SHA-256 import</div>
-  <div class="trust-item"><span class="ico">🏦</span> Multi-bank, multi-format</div>
-  <div class="trust-item"><span class="ico">🤖</span> Local or cloud AI with PII redaction</div>
-  <div class="trust-item"><span class="ico">🧪</span> 199 tests, zero external dependencies</div>
+  <div class="trust-item"><span class="ico">🔒</span> Dane tylko na Twoim komputerze</div>
+  <div class="trust-item"><span class="ico">🔁</span> Idempotentny import SHA-256</div>
+  <div class="trust-item"><span class="ico">🏦</span> Wiele banków, wiele formatów</div>
+  <div class="trust-item"><span class="ico">🤖</span> AI lokalnie lub w chmurze z redakcją PII</div>
+  <div class="trust-item"><span class="ico">🧪</span> 199 testów, zero zewnętrznych zależności</div>
 </div>
 
 <!-- ── PROBLEM ──────────────────────────────────────────────────────────── -->
 <section id="problema">
   <div class="container">
-    <div class="section-label">The problem</div>
-    <h2>Three banks, three files, one mess</h2>
+    <div class="section-label">Problem</div>
+    <h2>Trzy banki, trzy pliki, jeden bałagan</h2>
     <p class="section-sub">
-      Every month: download, open Excel, paste, fix the signs, find the duplicates.
-      And every time something doesn't add up.
+      Każdego miesiąca: pobierz, otwórz Excela, wklej, popraw znaki, znajdź duplikaty.
+      I za każdym razem coś się nie zgadza.
     </p>
 
     <div class="problem-grid fade-in">
       <div class="problem-card">
-        <h3>😩 The monthly routine everyone hates</h3>
-        <p>Three movements files from three different banking portals, incompatible CSV formats,
-        dates in different formats, amounts with random signs. Merging them by hand takes hours
-        and always produces errors.</p>
+        <h3>😩 Comiesięczna rutyna, której wszyscy nienawidzą</h3>
+        <p>Trzy pliki z transakcjami z trzech różnych portali bankowych, niekompatybilne formaty CSV,
+        daty w różnych formatach, kwoty z losowymi znakami. Łączenie ich ręcznie zajmuje godziny
+        i zawsze prowadzi do błędów.</p>
       </div>
       <div class="problem-card highlight">
-        <h3>🔴 The problem of all problems: double-counting</h3>
-        <p>The supermarket purchase appears in the credit card statement <em>and</em> in the current account
-        as a monthly aggregate charge. Adding everything up, your expenses look double
-        what they actually are. No common tool solves this automatically.</p>
+        <h3>🔴 Problem nad problemami: podwójne księgowanie</h3>
+        <p>Zakup w supermarkecie pojawia się na wyciągu z karty kredytowej <em>oraz</em> na koncie bieżącym
+        jako miesięczne obciążenie zbiorcze. Sumując wszystko, wydatki wyglądają na dwukrotnie
+        większe niż w rzeczywistości. Żadne popularne narzędzie nie rozwiązuje tego automatycznie.</p>
       </div>
       <div class="problem-card">
-        <h3>🔄 Internal transfers that distort your balance</h3>
-        <p>A wire transfer to a savings account is not an expense. But if you import both accounts,
-        the same transaction appears twice — as an outflow from the current account and as an inflow on the savings account.</p>
+        <h3>🔄 Przelewy wewnętrzne, które fałszują saldo</h3>
+        <p>Przelew na konto oszczędnościowe to nie wydatek. Ale jeśli zaimportujesz oba konta,
+        ta sama transakcja pojawi się dwukrotnie — jako wypływ z konta bieżącego i jako wpływ na konto oszczędnościowe.</p>
       </div>
       <div class="problem-card">
-        <h3>📋 The categorisation that never ends</h3>
-        <p>Classifying 300 transactions per month by hand is a job. Cloud apps do it,
-        but they send your banking data to their servers and charge you a monthly subscription.</p>
+        <h3>📋 Kategoryzacja, która nigdy się nie kończy</h3>
+        <p>Klasyfikowanie 300 transakcji miesięcznie ręcznie to praca na pełen etat. Aplikacje chmurowe to robią,
+        ale wysyłają Twoje dane bankowe na swoje serwery i pobierają miesięczną opłatę abonamentową.</p>
       </div>
     </div>
   </div>
@@ -750,27 +750,27 @@
 <!-- ── HOW IT WORKS ──────────────────────────────────────────────────────── -->
 <section id="how-it-works">
   <div class="container">
-    <div class="section-label">How it works</div>
-    <h2>Three steps, no black magic</h2>
-    <p class="section-sub">No banking integrations, no account, no per-file configuration.</p>
+    <div class="section-label">Jak to działa</div>
+    <h2>Trzy kroki, żadnej czarnej magii</h2>
+    <p class="section-sub">Bez integracji bankowych, bez konta, bez konfiguracji per plik.</p>
 
     <div class="steps fade-in">
       <div class="step">
-        <h3>Download files from your bank</h3>
-        <p>Export movements files as CSV or XLSX from your bank's portal.
-        Works with any bank — Spendify automatically detects
-        the format with no manual configuration.</p>
+        <h3>Pobierz pliki ze swojego banku</h3>
+        <p>Eksportuj pliki z transakcjami w formacie CSV lub XLSX z portalu swojego banku.
+        Działa z każdym bankiem — Spendify automatycznie wykrywa
+        format bez żadnej ręcznej konfiguracji.</p>
       </div>
       <div class="step">
-        <h3>Drag them into Spendify and click Process</h3>
-        <p>Select all files at once, even from different banks, even from different years.
-        Spendify detects the document type, corrects signs, eliminates double-counting
-        between card and account, and classifies every transaction.</p>
+        <h3>Przeciągnij je do Spendify i kliknij Przetwórz</h3>
+        <p>Wybierz wszystkie pliki naraz, nawet z różnych banków, nawet z różnych lat.
+        Spendify wykrywa typ dokumentu, koryguje znaki, eliminuje podwójne księgowanie
+        między kartą a kontem i klasyfikuje każdą transakcję.</p>
       </div>
       <div class="step">
-        <h3>See where your money goes</h3>
-        <p>The unified ledger shows everything in one place: charts, filters, export,
-        and the certainty that every euro is counted <strong>exactly once</strong>.</p>
+        <h3>Zobacz, dokąd idą Twoje pieniądze</h3>
+        <p>Ujednolicona księga pokazuje wszystko w jednym miejscu: wykresy, filtry, eksport
+        i pewność, że każde euro jest policzone <strong>dokładnie raz</strong>.</p>
       </div>
     </div>
   </div>
@@ -781,45 +781,45 @@
 <!-- ── DIFFERENTIATORS ───────────────────────────────────────────────────── -->
 <section id="algoritmi">
   <div class="container">
-    <div class="section-label">What no one else does automatically</div>
-    <h2>Algorithms that solve real problems</h2>
-    <p class="section-sub">This is not a generic budgeting app. It is designed around the specific problems of people with multiple bank accounts.</p>
+    <div class="section-label">To, czego nikt inny nie robi automatycznie</div>
+    <h2>Algorytmy, które rozwiązują realne problemy</h2>
+    <p class="section-sub">To nie jest ogólna aplikacja do budżetowania. Jest zaprojektowana wokół konkretnych problemów osób z wieloma kontami bankowymi.</p>
 
     <div class="diff-grid fade-in">
       <div class="diff-card">
         <div class="tag">RF-03</div>
-        <h3>Credit card–current account reconciliation</h3>
-        <p>When the credit card charges the monthly amount to the current account,
-        Spendify recognises the relationship and removes the double-counting automatically.</p>
+        <h3>Uzgadnianie karta kredytowa–konto bieżące</h3>
+        <p>Gdy karta kredytowa obciąża miesięczną kwotą konto bieżące,
+        Spendify rozpoznaje tę zależność i automatycznie usuwa podwójne księgowanie.</p>
         <p style="margin-top:.75rem; color: var(--muted); font-size:.88rem;">
-          Time window ±45 days · 3 matching phases:
-          sliding window → subset sum for split amounts → partial reconciliation
+          Okno czasowe ±45 dni · 3 fazy dopasowania:
+          okno przesuwne → suma podzbioru dla podzielonych kwot → częściowe uzgodnienie
         </p>
       </div>
       <div class="diff-card">
         <div class="tag">RF-04</div>
-        <h3>Internal transfer detection</h3>
-        <p>A wire transfer from a current account to a savings account is neither an expense nor
-        income: it is an internal transfer. Spendify recognises it by comparing
-        amounts, dates, and account holder names in the descriptions — even if the two files
-        were imported at different times.</p>
+        <h3>Wykrywanie przelewów wewnętrznych</h3>
+        <p>Przelew z konta bieżącego na konto oszczędnościowe nie jest ani wydatkiem, ani
+        przychodem: to transfer wewnętrzny. Spendify rozpoznaje go porównując
+        kwoty, daty i nazwiska właścicieli kont w opisach — nawet jeśli oba pliki
+        zostały zaimportowane w różnych momentach.</p>
       </div>
       <div class="diff-card">
         <div class="tag">Dedup</div>
-        <h3>Idempotent deduplication</h3>
-        <p>Every transaction has a unique ID calculated from its content (SHA-256).
-        If you import the same file twice, nothing happens.
-        You can re-import your entire transaction history without fear of duplicates.</p>
+        <h3>Idempotentna deduplikacja</h3>
+        <p>Każda transakcja ma unikalny identyfikator obliczony z jej zawartości (SHA-256).
+        Jeśli zaimportujesz ten sam plik dwukrotnie, nic się nie stanie.
+        Możesz ponownie zaimportować całą historię transakcji bez obaw o duplikaty.</p>
       </div>
       <div class="diff-card">
         <div class="tag">Categories</div>
-        <h3>Cascading hybrid classification</h3>
-        <p>Categorisation uses four levels in sequence:</p>
+        <h3>Kaskadowa klasyfikacja hybrydowa</h3>
+        <p>Kategoryzacja używa czterech poziomów po kolei:</p>
         <ul class="cascade-list">
-          <li><span class="num">1</span><span><strong>Your rules</strong> — "CONAD" → Groceries (applied retroactively)</span></li>
-          <li><span class="num">2</span><span><strong>Static regex</strong> — predefined patterns for common categories</span></li>
-          <li><span class="num">3</span><span><strong>LLM</strong> — for everything else, local or cloud AI</span></li>
-          <li><span class="num">4</span><span><strong>Fallback</strong> — "To review" if everything else fails</span></li>
+          <li><span class="num">1</span><span><strong>Twoje reguły</strong> — "BIEDRONKA" → Zakupy spożywcze (stosowane wstecz)</span></li>
+          <li><span class="num">2</span><span><strong>Statyczne wyrażenia regularne</strong> — predefiniowane wzorce dla typowych kategorii</span></li>
+          <li><span class="num">3</span><span><strong>LLM</strong> — dla wszystkiego innego, AI lokalnie lub w chmurze</span></li>
+          <li><span class="num">4</span><span><strong>Fallback</strong> — "Do przejrzenia", jeśli wszystko inne zawiedzie</span></li>
         </ul>
       </div>
     </div>
@@ -831,39 +831,39 @@
 <!-- ── PRIVACY ───────────────────────────────────────────────────────────── -->
 <section id="privacy" class="privacy-section">
   <div class="container">
-    <div class="section-label">Privacy</div>
-    <h2>Your data stays yours. Seriously.</h2>
-    <p class="section-sub">It is not just a slogan. It is the architecture.</p>
+    <div class="section-label">Prywatność</div>
+    <h2>Twoje dane pozostają Twoje. Naprawdę.</h2>
+    <p class="section-sub">To nie jest tylko slogan. To architektura.</p>
 
     <div class="privacy-grid fade-in">
       <div class="privacy-card">
         <div class="ico-big">🏠</div>
-        <h3>Offline-first by default</h3>
-        <p>Spendify uses <strong>Ollama locally</strong> by default: an AI engine that runs
-        on your computer, with no internet connection. Your movements files never
-        leave your disk.</p>
+        <h3>Offline-first domyślnie</h3>
+        <p>Spendify domyślnie używa <strong>Ollama lokalnie</strong>: silnika AI działającego
+        na Twoim komputerze, bez połączenia z internetem. Twoje pliki z transakcjami nigdy
+        nie opuszczają Twojego dysku.</p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">🛡️</div>
-        <h3>Automatic PII redaction</h3>
-        <p>If you use OpenAI or Claude, Spendify automatically removes all
-        identifying data before any remote call:</p>
+        <h3>Automatyczna redakcja PII</h3>
+        <p>Jeśli używasz OpenAI lub Claude, Spendify automatycznie usuwa wszystkie
+        dane identyfikujące przed jakimkolwiek zdalnym wywołaniem:</p>
         <div class="pii-chips">
           <span class="pii-chip">IBAN → &lt;ACCOUNT_ID&gt;</span>
           <span class="pii-chip">PAN → &lt;CARD_ID&gt;</span>
-          <span class="pii-chip">Tax ID → &lt;FISCAL_ID&gt;</span>
-          <span class="pii-chip">Name → fictitious alias</span>
+          <span class="pii-chip">NIP → &lt;FISCAL_ID&gt;</span>
+          <span class="pii-chip">Imię → fikcyjny alias</span>
         </div>
         <p style="margin-top:.75rem; font-size:.83rem; color:var(--muted)">
-          If the check fails, the call is blocked — not silently degraded.
+          Jeśli weryfikacja zawiedzie, wywołanie jest zablokowane — nie zdegradowane po cichu.
         </p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">💾</div>
-        <h3>Portable local database</h3>
-        <p>Data is stored in a SQLite file on your computer. You can copy it, move it,
-        back it up like any other file. No mandatory cloud,
-        no account, no subscription.</p>
+        <h3>Przenośna lokalna baza danych</h3>
+        <p>Dane są przechowywane w pliku SQLite na Twoim komputerze. Możesz go skopiować, przenieść,
+        zrobić kopię zapasową jak każdego innego pliku. Brak obowiązkowej chmury,
+        brak konta, brak subskrypcji.</p>
       </div>
     </div>
   </div>
@@ -874,43 +874,43 @@
 <!-- ── FOR WHO ───────────────────────────────────────────────────────────── -->
 <section id="per-chi">
   <div class="container">
-    <div class="section-label">Who Spendify is for</div>
-    <h2>Not for everyone. For those who want real control.</h2>
-    <p class="section-sub">Four profiles that find in Spendify something alternatives do not offer.</p>
+    <div class="section-label">Dla kogo jest Spendify</div>
+    <h2>Nie dla każdego. Dla tych, którzy chcą realnej kontroli.</h2>
+    <p class="section-sub">Cztery profile, które znajdują w Spendify coś, czego alternatywy nie oferują.</p>
 
     <div class="audience-grid fade-in">
       <div class="audience-card">
         <div class="ico-circle">🏦</div>
         <div>
-          <h3>People with accounts at multiple banks</h3>
-          <p>Current account + credit card + savings account + trading account?
-          Spendify unifies them all into a single ledger without having to do anything manually.</p>
+          <h3>Osoby z kontami w wielu bankach</h3>
+          <p>Konto bieżące + karta kredytowa + konto oszczędnościowe + rachunek maklerski?
+          Spendify łączy je wszystkie w jedną księgę bez konieczności wykonywania czegokolwiek ręcznie.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">📊</div>
         <div>
-          <h3>People who track their finances seriously</h3>
-          <p>If you use Excel for your expenses, Spendify can replace that routine:
-          you import the files once, Spendify unifies and classifies, you review
-          only the exceptions.</p>
+          <h3>Osoby, które poważnie śledzą swoje finanse</h3>
+          <p>Jeśli używasz Excela do swoich wydatków, Spendify może zastąpić tę rutynę:
+          importujesz pliki raz, Spendify ujednolica i klasyfikuje, a Ty przeglądasz
+          tylko wyjątki.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">🔐</div>
         <div>
-          <h3>People who do not trust the cloud</h3>
-          <p>No mandatory remote backend, no account, no registration.
-          Your banking data stays where it belongs: on your computer.</p>
+          <h3>Osoby, które nie ufają chmurze</h3>
+          <p>Brak obowiązkowego zdalnego backendu, brak konta, brak rejestracji.
+          Twoje dane bankowe pozostają tam, gdzie ich miejsce: na Twoim komputerze.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">👨‍💻</div>
         <div>
-          <h3>Developers</h3>
-          <p>Open source Python project with modular architecture, LLM pipeline on structured data,
-          full test suite. A starting point for experimenting or
-          building custom integrations.</p>
+          <h3>Developerzy</h3>
+          <p>Otwartoźródłowy projekt w Pythonie z modułową architekturą, pipeline LLM na danych strukturalnych,
+          pełna suita testów. Punkt wyjścia do eksperymentowania lub
+          budowania własnych integracji.</p>
         </div>
       </div>
     </div>
@@ -922,58 +922,58 @@
 <!-- ── FEATURES ──────────────────────────────────────────────────────────── -->
 <section id="features">
   <div class="container">
-    <div class="section-label">Features</div>
-    <h2>Everything you need, nothing more</h2>
+    <div class="section-label">Funkcje</div>
+    <h2>Wszystko, czego potrzebujesz, nic więcej</h2>
     <br>
 
     <div class="features-grid fade-in">
       <div class="feature-row">
-        <span class="feature-name">Multi-bank import</span>
-        <span class="feature-desc">CSV and XLSX from any bank</span>
+        <span class="feature-name">Import wielobankowy</span>
+        <span class="feature-desc">CSV i XLSX z dowolnego banku</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Auto-detect format</span>
-        <span class="feature-desc">No manual configuration for each file type</span>
+        <span class="feature-name">Auto-wykrywanie formatu</span>
+        <span class="feature-desc">Bez ręcznej konfiguracji dla każdego typu pliku</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Unified ledger</span>
-        <span class="feature-desc">All transactions in chronological order, filterable by date / account / category / context</span>
+        <span class="feature-name">Ujednolicona księga</span>
+        <span class="feature-desc">Wszystkie transakcje w porządku chronologicznym, filtrowalne według daty / konta / kategorii / kontekstu</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Automatic classification</span>
-        <span class="feature-desc">15 expense categories + 7 income categories with subcategories</span>
+        <span class="feature-name">Automatyczna klasyfikacja</span>
+        <span class="feature-desc">15 kategorii wydatków + 7 kategorii przychodów z podkategoriami</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Customisable taxonomy</span>
-        <span class="feature-desc">Add / edit categories without restarting the app</span>
+        <span class="feature-name">Konfigurowalna taksonomia</span>
+        <span class="feature-desc">Dodawaj / edytuj kategorie bez restartowania aplikacji</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Deterministic rules</span>
-        <span class="feature-desc">"ESSELUNGA → Groceries" rules applied retroactively</span>
+        <span class="feature-name">Reguły deterministyczne</span>
+        <span class="feature-desc">Reguły typu "BIEDRONKA → Zakupy spożywcze" stosowane wstecz</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Interactive analytics</span>
-        <span class="feature-desc">7 charts: monthly trend, cumulative balance, category pie, top 10 merchants</span>
+        <span class="feature-name">Interaktywna analityka</span>
+        <span class="feature-desc">7 wykresów: trend miesięczny, saldo skumulowane, koło kategorii, top 10 sprzedawców</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Life contexts</span>
-        <span class="feature-desc">Segment expenses by Work / Vacation / Daily life</span>
+        <span class="feature-name">Konteksty życiowe</span>
+        <span class="feature-desc">Segmentuj wydatki według Praca / Wakacje / Codzienność</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Check List</span>
-        <span class="feature-desc">Month × account pivot table: see which months you have not imported yet</span>
+        <span class="feature-name">Lista kontrolna</span>
+        <span class="feature-desc">Tabela przestawna miesiąc × konto: zobacz, których miesięcy jeszcze nie zaimportowałeś</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Export</span>
-        <span class="feature-desc">Standalone HTML (with charts), CSV, XLSX</span>
+        <span class="feature-name">Eksport</span>
+        <span class="feature-desc">Samodzielny HTML (z wykresami), CSV, XLSX</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">Configurable LLM</span>
-        <span class="feature-desc">Ollama, OpenAI, Claude, Groq, Gemini, LM Studio, any compatible API</span>
+        <span class="feature-name">Konfigurowalny LLM</span>
+        <span class="feature-desc">Ollama, OpenAI, Claude, Groq, Gemini, LM Studio, dowolne kompatybilne API</span>
       </div>
       <div class="feature-row">
-        <span class="feature-name">PII sanitization</span>
-        <span class="feature-desc">Automatic IBAN / card number / tax ID / name protection before remote calls</span>
+        <span class="feature-name">Sanityzacja PII</span>
+        <span class="feature-desc">Automatyczna ochrona IBAN / numeru karty / NIP / nazwiska przed zdalnymi wywołaniami</span>
       </div>
     </div>
   </div>
@@ -984,9 +984,9 @@
 <!-- ── INSTALL ───────────────────────────────────────────────────────────── -->
 <section id="install" class="install-section">
   <div class="container">
-    <div class="section-label">Installation</div>
-    <h2>One command, app ready</h2>
-    <p class="section-sub">Native desktop app with local AI included. No Docker, no Terminal kept open.</p>
+    <div class="section-label">Instalacja</div>
+    <h2>Jedno polecenie, aplikacja gotowa</h2>
+    <p class="section-sub">Natywna aplikacja desktopowa z lokalnym AI w komplecie. Bez Dockera, bez utrzymywania otwartego terminala.</p>
 
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
@@ -1003,7 +1003,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'mac')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'mac')">Kopiuj</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash</span></div>
@@ -1019,7 +1019,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'deb')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'deb')">Kopiuj</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-debian.sh | bash</span></div>
@@ -1035,7 +1035,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">bash</span>
-          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'rhel')">Kopiuj</button>
         </div>
         <div class="code-body">
           <div><span class="p">$ </span><span class="c">curl</span><span class="a"> -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/linux/install-redhat.sh | bash</span></div>
@@ -1051,7 +1051,7 @@
             <span class="d1"></span><span class="d2"></span><span class="d3"></span>
           </div>
           <span class="code-label">powershell</span>
-          <button class="copy-btn" onclick="copyCode(this, 'win')">Copy</button>
+          <button class="copy-btn" onclick="copyCode(this, 'win')">Kopiuj</button>
         </div>
         <div class="code-body">
           <div><span class="p">PS&gt; </span><span class="c">irm</span><span class="a"> https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex</span></div>
@@ -1060,20 +1060,20 @@
     </div>
 
     <p class="install-post">
-      The script detects your hardware, downloads the optimal AI model for your RAM (1–7 GB) and sets everything up — <strong>zero intervention</strong>.<br>
-      The app appears in Launchpad / Start Menu / file manager, ready to use.
+      Skrypt wykrywa Twój sprzęt, pobiera optymalny model AI dla Twojej pamięci RAM (1–7 GB) i wszystko konfiguruje — <strong>zero interwencji</strong>.<br>
+      Aplikacja pojawia się w Launchpadzie / Menu Start / menedżerze plików, gotowa do użycia.
     </p>
 
     <p class="install-dev-link">
-      Developer or manual install? →
-      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Full guide</a>
+      Developer lub instalacja ręczna? →
+      <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Pełny przewodnik</a>
     </p>
 
     <!-- ── Docker (alternative) ──────────────────────────────────────── -->
     <div style="margin-top: 2.5rem; padding-top: 2rem; border-top: 1px solid var(--border);">
-      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Prefer Docker?</h3>
+      <h3 style="color: var(--blue); margin-bottom: 0.5rem;">🐳 Wolisz Docker?</h3>
       <p style="color: var(--muted); margin-bottom: 1.2rem;">
-        Only <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a> required. Official container from GitHub Container Registry, browser at <strong>http://localhost:8501</strong>.
+        Wymagany jest tylko <a href="https://www.docker.com/products/docker-desktop/" target="_blank" style="color:var(--blue)">Docker Desktop</a>. Oficjalny kontener z GitHub Container Registry, przeglądarka pod adresem <strong>http://localhost:8501</strong>.
       </p>
 
       <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem;">
@@ -1103,8 +1103,8 @@
 <!-- ── Community / support ─────────────────────────────────────────────── -->
 <div style="text-align: center; padding: 2.5rem 1rem 1rem; max-width: 760px; margin: 0 auto;">
   <p style="color: var(--muted); font-size: 0.95rem; line-height: 1.8;">
-    🆘 <strong style="color: var(--text);">Need help?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Open an issue on GitHub</a> — bugs, questions, feature requests.<br>
-    ⭐ <strong style="color: var(--text);">Like Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Give us a star</a> — it helps us reach the official package registries (Homebrew Core, winget).
+    🆘 <strong style="color: var(--text);">Potrzebujesz pomocy?</strong> <a href="https://github.com/drake69/spendify/issues" target="_blank">Otwórz zgłoszenie na GitHubie</a> — błędy, pytania, prośby o nowe funkcje.<br>
+    ⭐ <strong style="color: var(--text);">Podoba Ci się Spendif.ai?</strong> <a href="https://github.com/drake69/spendify" target="_blank">Daj nam gwiazdkę</a> — pomaga nam dotrzeć do oficjalnych rejestrów pakietów (Homebrew Core, winget).
   </p>
 </div>
 
@@ -1113,20 +1113,20 @@
 <!-- ── STACK ─────────────────────────────────────────────────────────────── -->
 <section id="stack">
   <div class="container">
-    <div class="section-label">Tech stack</div>
-    <h2>Mature technologies, no exotic dependencies</h2>
-    <p class="section-sub">No LLM framework (no LangChain) — AI backends use the official SDKs directly.</p>
+    <div class="section-label">Stos technologiczny</div>
+    <h2>Dojrzałe technologie, bez egzotycznych zależności</h2>
+    <p class="section-sub">Bez frameworka LLM (bez LangChain) — backendy AI używają oficjalnych SDK bezpośrednio.</p>
 
     <div class="stack-grid fade-in">
       <div class="stack-badge"><strong>Python 3.13</strong> <span>+ pandas</span></div>
-      <div class="stack-badge"><strong>Streamlit</strong> <span>web interface</span></div>
+      <div class="stack-badge"><strong>Streamlit</strong> <span>interfejs webowy</span></div>
       <div class="stack-badge"><strong>SQLite</strong> <span>+ SQLAlchemy</span></div>
-      <div class="stack-badge"><strong>Pydantic v2</strong> <span>schema validation</span></div>
-      <div class="stack-badge"><strong>Plotly</strong> <span>interactive charts</span></div>
-      <div class="stack-badge"><strong>uv</strong> <span>package manager</span></div>
-      <div class="stack-badge"><strong>Ollama</strong> <span>local AI</span></div>
-      <div class="stack-badge"><strong>chardet</strong> <span>encoding detection</span></div>
-      <div class="stack-badge"><strong>openpyxl</strong> <span>Excel parsing</span></div>
+      <div class="stack-badge"><strong>Pydantic v2</strong> <span>walidacja schematów</span></div>
+      <div class="stack-badge"><strong>Plotly</strong> <span>interaktywne wykresy</span></div>
+      <div class="stack-badge"><strong>uv</strong> <span>menedżer pakietów</span></div>
+      <div class="stack-badge"><strong>Ollama</strong> <span>lokalne AI</span></div>
+      <div class="stack-badge"><strong>chardet</strong> <span>wykrywanie kodowania</span></div>
+      <div class="stack-badge"><strong>openpyxl</strong> <span>parsowanie Excel</span></div>
     </div>
   </div>
 </section>
@@ -1136,8 +1136,8 @@
 <!-- ── DEVELOPER ─────────────────────────────────────────────────────────── -->
 <section id="developer">
   <div class="container">
-    <div class="section-label">For developers</div>
-    <h2>Modular architecture, full test suite</h2>
+    <div class="section-label">Dla developerów</div>
+    <h2>Modułowa architektura, pełna suita testów</h2>
 
     <div class="pipeline-box fade-in">
 <span class="ph">CSV/XLSX File</span>
@@ -1155,20 +1155,20 @@
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🔌 New LLM backends</h3>
-        <p>Implement <code>LLMBackend</code> (3 methods) and register it in <code>BackendFactory</code>. Works with any OpenAI-compatible API.</p>
+        <h3>🔌 Nowe backendy LLM</h3>
+        <p>Zaimplementuj <code>LLMBackend</code> (3 metody) i zarejestruj go w <code>BackendFactory</code>. Działa z dowolnym API kompatybilnym z OpenAI.</p>
       </div>
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>Flow 2 recognises them automatically via LLM without code changes. The schema is saved and reused in subsequent imports.</p>
+        <h3>🏦 Nowe formaty bankowe</h3>
+        <p>Flow 2 rozpoznaje je automatycznie poprzez LLM bez zmian w kodzie. Schemat jest zapisywany i ponownie używany przy kolejnych importach.</p>
       </div>
       <div class="contribute-card">
-        <h3>🏷️ New categories</h3>
-        <p>From the Taxonomy page, without touching the code. The taxonomy is fully configurable from the interface.</p>
+        <h3>🏷️ Nowe kategorie</h3>
+        <p>Ze strony Taksonomia, bez dotykania kodu. Taksonomia jest w pełni konfigurowalna z poziomu interfejsu.</p>
       </div>
       <div class="contribute-card">
         <h3>🚀 REST API</h3>
-        <p>The <code>process_file()</code> pipeline is completely separate from the UI — it can be exposed via FastAPI without changes.</p>
+        <p>Pipeline <code>process_file()</code> jest całkowicie oddzielony od UI — może zostać udostępniony przez FastAPI bez zmian.</p>
       </div>
     </div>
 
@@ -1178,11 +1178,11 @@
         <div class="code-dots">
           <span class="d1"></span><span class="d2"></span><span class="d3"></span>
         </div>
-        <span class="code-label">bash — test suite</span>
+        <span class="code-label">bash — suita testów</span>
       </div>
       <div class="code-body">
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199 tests, zero external dependencies</span></div>
-        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># coverage of business logic layer</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ -v</span>         <span class="co"># 199 testów, zero zewnętrznych zależności</span></div>
+        <div><span class="p">$ </span><span class="c">uv run pytest</span><span class="a"> tests/ --cov=core</span>  <span class="co"># pokrycie warstwy logiki biznesowej</span></div>
       </div>
     </div>
   </div>
@@ -1193,19 +1193,19 @@
 <!-- ── ROADMAP ───────────────────────────────────────────────────────────── -->
 <section id="roadmap">
   <div class="container">
-    <div class="section-label">Roadmap</div>
-    <h2>What is coming</h2>
+    <div class="section-label">Roadmapa</div>
+    <h2>Co nadchodzi</h2>
     <br>
     <ul class="roadmap-list fade-in">
-      <li><span class="dot"></span>PDF support — native parsing of PDF movements files</li>
-      <li><span class="dot"></span>Monthly budget per category with alerting</li>
-      <li><span class="dot"></span>Automatic import via Open Banking (PSD2)</li>
-      <li><span class="dot"></span>REST API for external integrations</li>
-      <li><span class="dot"></span>Multi-user version with authentication</li>
-      <li><span class="dot"></span>Mobile app — ledger and analytics viewer</li>
-      <li><span class="dot"></span>Distribution via <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
-      <li><span class="dot"></span><code>.deb</code> and <code>.rpm</code> packages as GitHub release assets</li>
-      <li><span class="dot"></span>Distribution via <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
+      <li><span class="dot"></span>Wsparcie dla PDF — natywne parsowanie plików PDF z transakcjami</li>
+      <li><span class="dot"></span>Miesięczny budżet na kategorię z alertowaniem</li>
+      <li><span class="dot"></span>Automatyczny import przez Open Banking (PSD2)</li>
+      <li><span class="dot"></span>REST API do integracji zewnętrznych</li>
+      <li><span class="dot"></span>Wersja wieloużytkownikowa z uwierzytelnianiem</li>
+      <li><span class="dot"></span>Aplikacja mobilna — przeglądarka księgi i analityki</li>
+      <li><span class="dot"></span>Dystrybucja przez <strong>Homebrew</strong> (macOS) — <code>brew install --cask spendifai</code></li>
+      <li><span class="dot"></span>Pakiety <code>.deb</code> i <code>.rpm</code> jako artefakty wydań GitHub</li>
+      <li><span class="dot"></span>Dystrybucja przez <strong>winget</strong> (Windows) — <code>winget install SpendifAi.SpendifAi</code></li>
     </ul>
   </div>
 </section>
@@ -1216,25 +1216,25 @@
 <section id="contribuire">
   <div class="container">
     <div class="section-label">Open source</div>
-    <h2>Contributions are welcome</h2>
-    <p class="section-sub">Areas where contributions are most useful:</p>
+    <h2>Wkład w projekt mile widziany</h2>
+    <p class="section-sub">Obszary, w których wkład jest najbardziej przydatny:</p>
 
     <div class="contribute-grid fade-in">
       <div class="contribute-card">
-        <h3>🏦 New bank formats</h3>
-        <p>If your bank is not automatically recognised, open an issue with an anonymised CSV sample.</p>
+        <h3>🏦 Nowe formaty bankowe</h3>
+        <p>Jeśli Twój bank nie jest automatycznie rozpoznawany, otwórz zgłoszenie z anonimizowaną próbką CSV.</p>
       </div>
       <div class="contribute-card">
-        <h3>🧪 UI tests</h3>
-        <p>The suite covers the business logic layer but not yet the Streamlit interface. There is room to contribute.</p>
+        <h3>🧪 Testy UI</h3>
+        <p>Suita pokrywa warstwę logiki biznesowej, ale nie obejmuje jeszcze interfejsu Streamlit. Jest pole do współpracy.</p>
       </div>
       <div class="contribute-card">
-        <h3>🌍 Internationalisation</h3>
-        <p>The architecture already supports multiple languages for descriptions. The UI is in Italian — there is scope to add other languages.</p>
+        <h3>🌍 Internacjonalizacja</h3>
+        <p>Architektura już wspiera wiele języków dla opisów. UI jest po włosku — jest miejsce na dodanie kolejnych języków.</p>
       </div>
       <div class="contribute-card">
-        <h3>⚡ Performance</h3>
-        <p>Batch categorisation is the bottleneck with a local LLM. There is room for parallelisation.</p>
+        <h3>⚡ Wydajność</h3>
+        <p>Wsadowa kategoryzacja jest wąskim gardłem przy lokalnym LLM. Jest miejsce na zrównoleglenie.</p>
       </div>
     </div>
 
@@ -1242,7 +1242,7 @@
     <div style="text-align:center; margin-top: 1rem;">
       <a class="btn btn-primary" href="https://github.com/drake69/spendify" target="_blank">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        Go to GitHub
+        Przejdź na GitHub
       </a>
     </div>
   </div>
@@ -1251,14 +1251,14 @@
 <!-- ── FOOTER ─────────────────────────────────────────────────────────────── -->
 <footer>
   <p>
-    <strong>Spendify</strong> is open source —
+    <strong>Spendify</strong> jest open source —
     <a href="https://github.com/drake69/spendify" target="_blank">github.com/drake69/spendify</a>
   </p>
   <p class="disclaimer">
-    Spendify is not a cloud service. It is a program that runs on your computer.
-    Your banking data is never sent to third-party servers, unless you explicitly choose
-    a remote LLM backend — in that case, all identifying data is
-    removed before transmission.
+    Spendify nie jest usługą chmurową. To program, który działa na Twoim komputerze.
+    Twoje dane bankowe nigdy nie są wysyłane na serwery osób trzecich, chyba że samodzielnie
+    wybierzesz zdalny backend LLM — w takim przypadku wszystkie dane identyfikujące są
+    usuwane przed transmisją.
   </p>
 </footer>
 
@@ -1291,8 +1291,8 @@
   };
   function copyCode(btn, os) {
     navigator.clipboard.writeText(installCmds[os] || installCmds.mac).then(() => {
-      btn.textContent = 'Copied ✓';
-      setTimeout(() => btn.textContent = 'Copy', 2000);
+      btn.textContent = 'Skopiowano ✓';
+      setTimeout(() => btn.textContent = 'Kopiuj', 2000);
     });
   }
 </script>

--- a/index.pt.html
+++ b/index.pt.html
@@ -675,6 +675,9 @@
     <a href="index.fr.html" title="Français">🇫🇷</a>
     <a href="index.es.html" title="Español">🇪🇸</a>
     <a href="index.pt.html" title="Português" class="active">🇵🇹</a>
+    <a href="index.nl.html" title="Nederlands">🇳🇱</a>
+    <a href="index.ja.html" title="日本語">🇯🇵</a>
+    <a href="index.pl.html" title="Polski">🇵🇱</a>
   </div>
 </nav>
 


### PR DESCRIPTION
## Summary
- Three new landing translations: `index.nl.html`, `index.ja.html`, `index.pl.html` (LLM-only, not yet human-verified — tracked in AI-15).
- Extend the lang-switcher across all nine locales (it / en / de / fr / es / pt / nl / ja / pl).
- Fix a pre-existing bug: in `index.fr.html` and `index.es.html` the `class="active"` flag was on EN instead of the local language — now corrected.
- `index.ja.html` adds a CJK font fallback in the `body` CSS rule (`Hiragino Sans`, `Yu Gothic`, `Meiryo`) so Japanese glyphs render natively on macOS / Windows.
- Where natural, example merchants are localised (Albert Heijn for NL, Biedronka for PL).

## Test plan
- [ ] After GH Pages rebuild, open https://drake69.github.io/spendify/index.nl.html , `.ja.html` , `.pl.html` and confirm they load.
- [ ] Click through every flag in the switcher from each language — confirm 9 destinations are reachable, the active flag matches the current page, and no 404s.
- [ ] On Japanese landing, verify glyphs render with a real Japanese font (no tofu boxes) on macOS Safari and Chrome.
- [ ] Spot-check one section per language for tone and obvious translation errors (this is the LLM-only baseline — known to be imperfect, formal verification deferred to AI-15).
- [ ] Confirm the install one-liners in the OS tabs are unchanged across all 9 locales.