### PR TITLE
Docs: complete IT/EN coverage + Translations contributor guide

### DIFF
--- a/CHANGELOG.it.md
+++ b/CHANGELOG.it.md
@@ -1,0 +1,41 @@
+# Changelog
+
+*English version: [CHANGELOG.md](CHANGELOG.md).*
+
+Tutti i cambiamenti rilevanti di Spendif.ai sono documentati in questo file.
+Il formato segue [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+Il versioning segue [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- App desktop nativa: finestra pywebview che incorpora Streamlit (niente Terminal, niente browser)
+- Download automatico del modello LLM consigliato in base al rilevamento hardware (RAM/GPU)
+- Setup llama.cpp zero-config al primo avvio
+- Splash screen con barra di avanzamento del download
+- Installer macOS (`packaging/macos/install.sh`) con launcher per finestra nativa
+- Installer Windows (`packaging/windows/install.ps1`) con launcher per finestra nativa
+- Installer Ubuntu/Debian (`packaging/linux/install-debian.sh`) e builder .deb
+- Installer Red Hat/Fedora (`packaging/linux/install-redhat.sh`) e builder .rpm
+- File spec PyInstaller per generare .app standalone (macOS) e .exe (Windows)
+- Script di disinstallazione per macOS, Windows (con flag `-Silent`) e Linux
+- Registrazione in Add/Remove Programs di Windows durante l'installazione
+- Workflow CI Linux (`release-linux.yml`): build di .deb/.rpm, smoke test in container, allegati alla GitHub Release
+- Identificatore winget rinominato in `SpendifAi.SpendifAi`
+
+### Fixed
+- Auto-invalidazione degli schemi: gli schemi in cache (Flow 1) con parse rate < 10% vengono eliminati automaticamente e ritentati con Flow 2 (riclassificazione LLM)
+- Pulizia schemi orfani: la migration di avvio rimuove le righe `document_schema` senza `header_sha256`, prevenendo voci stale irraggiungibili
+- Header SHA256 sempre popolato sullo schema prima del persist, evitando la creazione di schemi orfani
+
+## [0.1.0] - 2026-04-06
+
+### Added
+- Prima release
+- Import di estratti conto CSV/XLSX (9 strumenti finanziari italiani)
+- Categorizzazione AI locale via llama.cpp (Qwen3.5, Gemma4, Phi4, Llama3.2)
+- Matching delle controparti con consapevolezza NSI/OSI
+- Cache storica, regole utente, personalizzazione della tassonomia
+- App bundle macOS, integrazione con Spotlight
+- Installer Windows via winget/PowerShell
+- Dashboard di analytics interattiva (in arrivo)

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -1,0 +1,290 @@
+# Contributing to Spendif.ai
+
+*Italian version: [CONTRIBUTING.md](CONTRIBUTING.md).*
+
+Thanks for your interest! These guidelines describe how to report issues, propose features, and contribute code.
+
+---
+
+## Table of contents
+
+1. [Priority system](#priority-system)
+2. [Reporting a bug](#reporting-a-bug)
+3. [Proposing a feature](#proposing-a-feature)
+4. [Contributing code](#contributing-code)
+5. [Translating Spendif.ai](#translating-spendifai)
+6. [Development environment setup](#development-environment-setup)
+7. [Conventions](#conventions)
+
+---
+
+## Priority system
+
+Every issue carries a priority label. The system has 4 levels:
+
+| Label | Color | Meaning | When we use it |
+|-------|-------|---------|----------------|
+| 🔴 **P0 · now** | Red | Blocks the beta or is a quick UX fix | Critical bugs, regressions, pre-release quick wins |
+| 🟡 **P1 · v2.5** | Yellow | Completes the core workflow | Features that close existing usage loops |
+| 🔵 **P2 · v3.0** | Blue | Significant product expansion | New modules, integrations, deep improvements |
+| ⚪ **P3 · roadmap** | Gray | Long-term vision | Important ideas without a defined timeline |
+
+### Practical rules
+
+- **P0** → open a PR within the current sprint; if you can't, flag it in the issue comments
+- **P1** → target release `v2.5`; milestone assigned when the issue is picked up
+- **P2** → target release `v3.0`; can be moved up if an external contribution lands
+- **P3** → no timeline; contributions welcome, but quick review is not guaranteed
+
+### How to propose a priority change
+
+Open a comment on the issue with your reasoning. The maintainer re-evaluates and updates the label.
+
+---
+
+## Reporting a bug
+
+1. Search the [open issues](https://github.com/drake69/spendify/issues) — it may already exist
+2. Open a new issue using the **Bug report** template
+3. Include:
+   - Spendif.ai version (or commit hash)
+   - OS and Docker/Python version
+   - Steps to reproduce
+   - Expected vs actual behavior
+   - Relevant logs (`docker compose logs spendifai`)
+
+---
+
+## Proposing a feature
+
+1. Check the [backlog](https://github.com/drake69/spendify/issues) — it may already exist as a P2/P3 issue
+2. Open an issue using the **Feature request** template
+3. Describe:
+   - The problem it solves (not just the solution)
+   - Who benefits (end user, developer, ops)
+   - Estimated impact on privacy, performance, complexity
+
+---
+
+## Contributing code
+
+### Standard flow
+
+```
+fork → branch → commit → PR → review → merge
+```
+
+1. **Fork** the repository
+2. Create a branch: `git checkout -b feat/feature-name` or `fix/bug-name`
+3. Develop with tests — see [Setup](#development-environment-setup)
+4. Open a **Pull Request** against `main`
+5. Link the PR to the issue with `Closes #N` in the body
+
+### What to expect from review
+
+- Feedback within ~3 business days for P0/P1
+- Feedback within ~1 week for P2/P3
+- The PR is merged only if CI is green (tests + lint + Docker smoke test)
+
+---
+
+## Translating Spendif.ai
+
+Translations are one of the most welcome contributions: all you need is a text editor and a few minutes. You don't need to be a developer.
+
+### Current language status
+
+| Language | Streamlit UI | Landing page (HTML) |
+|----------|--------------|---------------------|
+| 🇮🇹 Italiano | ✅ master (human-verified) | ✅ master (human-verified) |
+| 🇬🇧 English | ✅ LLM-translated, partially verified | ✅ LLM-translated, partially verified |
+| 🇩🇪 / 🇫🇷 / 🇪🇸 / 🇵🇹 / 🇳🇱 / 🇯🇵 / 🇵🇱 | ❌ not available | ✅ LLM-translated, **not yet human-verified** |
+
+LLM-only translations are an imperfect baseline: they all need human eyes. If you're a native speaker or have skills in one of these languages, your contribution makes a difference.
+
+### Translation architecture
+
+Spendif.ai has **two areas** that require separate translations:
+
+1. **Streamlit UI** — `sw_artifacts/ui/i18n/<lang>.json` — a flat key→string file per language. Loaded at runtime by the app. The key schema follows the convention `area.element` and `area.element.desc` for descriptions (e.g. `nav.import` + `nav.import.desc`).
+
+2. **Landing page** — `sw_artifacts/index.<lang>.html` — a complete HTML file per language. **Schema in transition**: we're migrating these to a JSON system similar to `ui/i18n/` (tracked in `backlog.json` AI-14). Until that refactor lands, landing translations are done by editing the HTML directly — see the [Landing page (transitional)](#landing-page-transitional) section below.
+
+### Translating the Streamlit UI (recommended — the easiest flow)
+
+#### Step 1 — Pick a language
+
+Example: you want to add German (`de`).
+
+#### Step 2 — Copy the master
+
+```bash
+cp sw_artifacts/ui/i18n/en.json sw_artifacts/ui/i18n/de.json
+```
+
+Start from `en.json` as the master (it's the reference baseline). Never start from `it.json` unless you're Italian: you risk linguistic calques.
+
+#### Step 3 — Edit the file
+
+Open `sw_artifacts/ui/i18n/de.json` with your editor of choice. The structure is simple:
+
+```json
+{
+  "_language_name": "Deutsch",
+  "nav.import": "📥 Importieren",
+  "nav.import.desc": "CSV/XLSX-Dateien aus deinen Bankkonten importieren",
+  "nav.history": "📜 Importverlauf"
+}
+```
+
+Rules:
+
+- **Change `_language_name`** to the language name in the language itself (e.g. `Deutsch`, not `German`)
+- **Keep keys unchanged** — they are identifiers, not text to translate
+- **Keep emoji and formatting unchanged** where present — they are part of the design
+- **Keep `{var}` or `%(name)s` substitutions** — they are placeholders for dynamic values
+- **`.desc` keys** are longer descriptions used as hints or tooltips — don't skip them
+
+#### Step 4 — Recommended editors for non-developers
+
+If you're not familiar with JSON, any of these makes life easier:
+
+- [**BabelEdit**](https://www.codeandweb.com/babeledit) — free for open source projects. Side-by-side EN/target language UI, highlights missing keys, flags double spaces.
+- [**Tolgee Cloud**](https://tolgee.io/) — side-by-side web interface with built-in AI suggestions. Free tier is sufficient.
+- [**VS Code**](https://code.visualstudio.com/) with the "JSON Tools" extension — for those who just want a solid editor.
+- [**JSONedit**](https://tomeko.net/software/JSONedit/) — Windows desktop, free, lightweight.
+
+#### Step 5 — Validate and PR
+
+```bash
+# Verify that the JSON is valid
+python -c "import json; json.load(open('sw_artifacts/ui/i18n/de.json'))"
+```
+
+Open a PR following the standard flow ([Contributing code](#contributing-code)).
+
+In the PR body include:
+- The language added or updated
+- How many keys you translated / verified
+- Any non-obvious terminology decisions (e.g. "I rendered `ledger` as `Hauptbuch` because...")
+
+### Landing page (transitional)
+
+**Current workflow (transitional)**: edit `sw_artifacts/index.<lang>.html` directly. Open `index.en.html` alongside as a reference, change only visible text (NOT CSS, JS, or `href` URLs), save, PR.
+
+Practical tips:
+
+- Keep two editors or two tabs side by side: EN on the left, target language on the right
+- Search for `<h1>`, `<h2>`, `<h3>`, `<p>`, `<title>`, `<meta>` to find translatable strings
+- **Do NOT translate**: `<style>`, `<script>`, `href="..."`, shell snippets in `<code-body>` (curl/irm/bash), id tags (`id="install"`), tab labels (`🍎 macOS`), proper names (Spendify, Ollama, Streamlit, GitHub)
+- Update `<html lang="...">` at the top
+
+**Future workflow (post AI-14)**: we're working to bring landings onto a JSON system similar to `ui/i18n/`. Once it's ready, contributing a language will mean editing a single `i18n/landing/<lang>.json` file instead of an entire HTML. If you want to help unblock this refactor, see backlog item AI-14.
+
+### Human review of existing LLM translations
+
+Even just rereading and correcting an existing translation is a valuable contribution. If you find errors, awkward-sounding phrases, or wrong technical terms, open a PR with the fixes. Note in the commit message:
+
+```
+i18n(de): fix awkward LLM phrasings in nav and analytics sections
+i18n(ja): correct technical term for "ledger" — 元帳 → 取引履歴
+```
+
+---
+
+## Development environment setup
+
+### Prerequisites
+
+| Tool | Minimum version |
+|------|-----------------|
+| Python | 3.13 |
+| uv | any |
+| Docker Desktop | any (for local smoke test) |
+
+### Installation
+
+```bash
+git clone https://github.com/drake69/spendify.git
+cd spendifai
+uv sync
+cp .env.example .env
+
+# Startup script (recommended)
+./start.sh          # UI only (default)
+./start.sh api      # REST API only
+./start.sh all      # UI + API
+
+# Or manually
+uv run streamlit run app.py
+```
+
+### Running tests
+
+```bash
+# Tests with coverage
+uv run pytest tests/ -v --cov=. --cov-report=term-missing
+
+# A single module
+uv run pytest tests/test_normalizer.py -v
+
+# Local Docker smoke test
+docker compose -f docker/docker-compose.yml build
+docker compose -f docker/docker-compose.yml up -d
+curl -sf http://localhost:8501/_stcore/health
+docker compose -f docker/docker-compose.yml down -v
+```
+
+### Expected coverage thresholds
+
+| Module | Minimum coverage |
+|--------|------------------|
+| `core/normalizer.py` | 100% |
+| `core/description_cleaner.py` | 100% |
+| `core/classifier.py` | ≥ 99% |
+| All others | ≥ 80% |
+
+---
+
+## Conventions
+
+### Commit messages
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add context filtering in the ledger
+fix: correct amount parsing with European separator
+test: add coverage for detect_internal_transfers
+docs: update installation guide for Docker arm64
+refactor: extract pairing logic into a separate function
+chore: remove dead code in support/core_logic.py
+```
+
+### Branch naming
+
+```
+feat/crea-regola-da-ledger
+fix/encoding-windows-1252
+test/phase0-preprocessing
+docs/guida-installazione-en
+```
+
+### Code style
+
+- **Formatter**: `ruff format` (configured in `pyproject.toml`)
+- **Linter**: `ruff check`
+- **Type hints**: required for public functions in `core/` modules
+- **Decimal**: monetary amounts always use `Decimal`, never `float`
+
+```bash
+# Local check before committing
+uv run ruff check .
+uv run ruff format --check .
+```
+
+---
+
+## Questions?
+
+Open a [Discussion](https://github.com/drake69/spendify/discussions) or write in the comments of the issue closest to your case.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,9 @@ Grazie per l'interesse! Queste linee guida descrivono come segnalare problemi, p
 2. [Segnalare un bug](#segnalare-un-bug)
 3. [Proporre una funzionalità](#proporre-una-funzionalità)
 4. [Contribuire codice](#contribuire-codice)
-5. [Setup ambiente di sviluppo](#setup-ambiente-di-sviluppo)
-6. [Convenzioni](#convenzioni)
+5. [Tradurre Spendif.ai](#tradurre-spendifai)
+6. [Setup ambiente di sviluppo](#setup-ambiente-di-sviluppo)
+7. [Convenzioni](#convenzioni)
 
 ---
 
@@ -82,6 +83,110 @@ fork → branch → commit → PR → review → merge
 - Feedback entro ~3 giorni lavorativi per P0/P1
 - Feedback entro ~1 settimana per P2/P3
 - La PR viene mergiata solo se la CI è verde (test + lint + Docker smoke test)
+
+---
+
+## Tradurre Spendif.ai
+
+Le traduzioni sono uno dei contributi più graditi: ti bastano un editor di testo e qualche minuto. Non serve essere developer.
+
+### Stato attuale delle lingue
+
+| Lingua | UI Streamlit | Landing page (HTML) |
+|--------|--------------|---------------------|
+| 🇮🇹 Italiano | ✅ master (verifica umana) | ✅ master (verifica umana) |
+| 🇬🇧 English | ✅ tradotta da LLM, parzialmente verificata | ✅ tradotta da LLM, parzialmente verificata |
+| 🇩🇪 / 🇫🇷 / 🇪🇸 / 🇵🇹 / 🇳🇱 / 🇯🇵 / 🇵🇱 | ❌ non disponibile | ✅ tradotta da LLM, **non ancora verificata da umano** |
+
+Le traduzioni LLM-only sono una baseline imperfetta: c'è bisogno di occhi umani su tutte. Se sei madrelingua o hai competenze in una di queste lingue, il tuo contributo fa la differenza.
+
+### Architettura delle traduzioni
+
+Spendif.ai ha **due aree** che richiedono traduzioni separate:
+
+1. **UI Streamlit** — `sw_artifacts/ui/i18n/<lang>.json` — un file flat key→string per ogni lingua. Caricato a runtime dall'app. Lo schema chiavi segue la convenzione `area.elemento` e `area.elemento.desc` per le descrizioni (es. `nav.import` + `nav.import.desc`).
+
+2. **Landing page** — `sw_artifacts/index.<lang>.html` — un file HTML completo per ogni lingua. **Schema in transizione**: stiamo migrando anche queste a un sistema JSON simile a `ui/i18n/` (tracked in `backlog.json` AI-14). Fino a quel refactor, le traduzioni della landing si fanno editando direttamente l'HTML — vedi sezione [Landing page (transizione)](#landing-page-transizione) qui sotto.
+
+### Tradurre la UI Streamlit (raccomandato — il flusso più semplice)
+
+#### Passo 1 — Scegli la lingua
+
+Esempio: vuoi aggiungere il tedesco (`de`).
+
+#### Passo 2 — Copia il master
+
+```bash
+cp sw_artifacts/ui/i18n/en.json sw_artifacts/ui/i18n/de.json
+```
+
+Parti da `en.json` come master (è la baseline di riferimento). Mai partire da `it.json` se non sei italiano: rischi calchi linguistici.
+
+#### Passo 3 — Modifica il file
+
+Apri `sw_artifacts/ui/i18n/de.json` con un editor a tua scelta. La struttura è semplice:
+
+```json
+{
+  "_language_name": "Deutsch",
+  "nav.import": "📥 Importieren",
+  "nav.import.desc": "CSV/XLSX-Dateien aus deinen Bankkonten importieren",
+  "nav.history": "📜 Importverlauf"
+}
+```
+
+Regole:
+
+- **Cambia `_language_name`** con il nome della lingua nella lingua stessa (es. `Deutsch`, non `German`)
+- **Mantieni le chiavi invariate** — sono identificatori, non testo da tradurre
+- **Mantieni emoji e formattazione** dove presenti — fanno parte del design
+- **Mantieni le sostituzioni `{var}` o `%(name)s`** — sono placeholder per valori dinamici
+- **Le chiavi `.desc`** sono descrizioni più lunghe usate come hint o tooltip — non saltarle
+
+#### Passo 4 — Editor consigliati per non-developer
+
+Se non sei abituato a JSON, qualsiasi di questi semplifica la vita:
+
+- [**BabelEdit**](https://www.codeandweb.com/babeledit) — gratis per progetti open source. UI side-by-side EN/target lingua, evidenzia chiavi mancanti, segnala doppi spazi.
+- [**Tolgee Cloud**](https://tolgee.io/) — interfaccia web side-by-side, suggerimenti AI integrati. Free tier sufficiente.
+- [**VS Code**](https://code.visualstudio.com/) con estensione "JSON Tools" — per chi vuole solo un editor solido.
+- [**JSONedit**](https://tomeko.net/software/JSONedit/) — Windows desktop, gratuito, leggero.
+
+#### Passo 5 — Verifica e PR
+
+```bash
+# Verifica che il JSON sia valido
+python -c "import json; json.load(open('sw_artifacts/ui/i18n/de.json'))"
+```
+
+Apri una PR seguendo il flusso standard ([Contribuire codice](#contribuire-codice)).
+
+Nel body della PR includi:
+- La lingua aggiunta o aggiornata
+- Quante chiavi hai tradotto / verificato
+- Eventuali decisioni terminologiche non ovvie (es. "ho reso `ledger` come `Hauptbuch` perché...")
+
+### Landing page (transizione)
+
+**Workflow attuale (transitorio)**: edita direttamente `sw_artifacts/index.<lang>.html`. Apri in parallelo `index.en.html` come riferimento, modifica solo i testi visibili (NON CSS, JS o `href` URL), salva, PR.
+
+Suggerimenti pratici:
+
+- Tieni due editor o due tab affiancati: EN a sinistra, lingua target a destra
+- Cerca `<h1>`, `<h2>`, `<h3>`, `<p>`, `<title>`, `<meta>` per trovare le stringhe traducibili
+- **NON tradurre**: `<style>`, `<script>`, `href="..."`, snippet shell nei `<code-body>` (curl/irm/bash), tag id (`id="install"`), label nei tab (`🍎 macOS`), nomi propri (Spendify, Ollama, Streamlit, GitHub)
+- Aggiorna `<html lang="...">` in alto
+
+**Workflow futuro (post AI-14)**: stiamo lavorando per portare anche le landing su un sistema JSON simile a `ui/i18n/`. Quando sarà pronto, contribuire una lingua significherà editare un solo file `i18n/landing/<lang>.json` invece di un HTML intero. Se vuoi aiutare a sbloccare questo refactor, vedi backlog item AI-14.
+
+### Verifica umana di traduzioni LLM esistenti
+
+Anche solo rileggere e correggere una traduzione esistente è un contributo prezioso. Se trovi errori, frasi che suonano artificiali, o termini tecnici sbagliati, apri una PR con i fix. Indica nel commit message:
+
+```
+i18n(de): fix awkward LLM phrasings in nav and analytics sections
+i18n(ja): correct technical term for "ledger" — 元帳 → 取引履歴
+```
 
 ---
 

--- a/SECURITY.it.md
+++ b/SECURITY.it.md
@@ -1,0 +1,68 @@
+# Politica di sicurezza
+
+*English version: [SECURITY.md](SECURITY.md).*
+
+## Versioni supportate
+
+| Versione | Supportata |
+|----------|-----------|
+| latest   | Sì        |
+| < latest | No — aggiorna |
+
+## Segnalazione di una vulnerabilità
+
+Se scopri una vulnerabilità di sicurezza in Spendif.ai, **per favore non aprire una issue pubblica.**
+
+Segnala invece in privato:
+
+1. **GitHub Security Advisories** (preferito): vai alla [scheda Security](https://github.com/drake69/spendify/security/advisories) e clicca **"Report a vulnerability"**
+2. **Email**: invia i dettagli al proprietario del repository tramite l'indirizzo elencato nel [profilo GitHub](https://github.com/drake69)
+
+### Cosa includere
+
+- Descrizione della vulnerabilità
+- Passi per riprodurla
+- Versione/i interessate
+- Impatto potenziale
+- Fix suggerito (se ne hai uno)
+
+### Tempi di risposta
+
+| Passaggio | Tempistica |
+|-----------|-----------|
+| Conferma di ricezione | Entro 48 ore |
+| Valutazione iniziale | Entro 7 giorni |
+| Rilascio patch | Entro 30 giorni (critica: entro 7 giorni) |
+| Disclosure pubblico | Dopo il rilascio della patch |
+
+## Scope
+
+Sono **in scope**:
+
+- Codice applicativo in `core/`, `services/`, `ui/`, `db/`, `api/`
+- Workflow GitHub Actions (`.github/workflows/`)
+- Configurazione, gestione dei secret e layer di PII-redaction applicato prima delle chiamate LLM remote
+
+Sono **fuori scope**:
+
+- Vulnerabilità in dipendenze upstream (segnalare al rispettivo progetto; tracciate via Dependabot / pip-audit)
+- Attacchi di social engineering
+- Attacchi denial of service
+
+## Misure di sicurezza
+
+Spendif.ai adotta le seguenti pratiche:
+
+- **Analisi statica** — Bandit e pattern proibiti vengono eseguiti su ogni PR (workflow CI `security.yml`)
+- **CodeQL** — analisi semantica con la query suite `security-and-quality` (pianificata, tracciata nel backlog)
+- **Validazione input** — schemi Pydantic v2 ai confini delle API; controlli espliciti per campo nel service layer
+- **Niente funzioni pericolose** — `eval()`, `exec()`, `subprocess shell=True`, `pickle.load()`, `yaml.load()` senza `SafeLoader` sono vietati e bloccati in CI
+- **Ruff linting** — applicato in CI con le regole di sicurezza in stile bandit (`S`) abilitate
+- **Gestione dipendenze** — `uv.lock` garantisce installazioni riproducibili; `pip-audit` segnala CVE note
+- **PII redaction** — IBAN, numero di carta, codice fiscale e nome dell'intestatario vengono sostituiti automaticamente con placeholder prima di qualsiasi chiamata LLM remota. Il service layer rifiuta input non sanitizzati. Vedi `core/pii_redactor.py` e la sezione privacy della landing per la lista completa
+- **AI local-first** — il backend LLM di default (`local_llama_cpp`) mantiene tutti i dati sulla macchina dell'utente; i backend remoti sono opt-in
+- **Integrità dei prompt** — i file di prompt hanno hash SHA-256 verificati all'avvio così che modifiche non autorizzate vengano rilevate (pianificata, tracciata nel backlog)
+
+## Riconoscimenti
+
+Apprezziamo la disclosure responsabile. I ricercatori che segnalano vulnerabilità valide vengono accreditati nelle release notes (a meno che preferiscano l'anonimato).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security Policy
+
+*Italian version: [SECURITY.it.md](SECURITY.it.md).*
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| latest  | Yes       |
+| < latest | No — please upgrade |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Spendif.ai, **please do not open a public issue.**
+
+Instead, report it privately:
+
+1. **GitHub Security Advisories** (preferred): go to the [Security tab](https://github.com/drake69/spendify/security/advisories) and click **"Report a vulnerability"**
+2. **Email**: send details to the repository owner via the email listed on the [GitHub profile](https://github.com/drake69)
+
+### What to include
+
+- Description of the vulnerability
+- Steps to reproduce
+- Affected version(s)
+- Potential impact
+- Suggested fix (if any)
+
+### Response timeline
+
+| Step | Timeline |
+|------|----------|
+| Acknowledgment | Within 48 hours |
+| Initial assessment | Within 7 days |
+| Patch release | Within 30 days (critical: within 7 days) |
+| Public disclosure | After patch is released |
+
+## Scope
+
+The following are **in scope**:
+
+- Application code in `core/`, `services/`, `ui/`, `db/`, `api/`
+- GitHub Actions workflows (`.github/workflows/`)
+- Configuration, secret handling, and the PII-redaction layer applied before remote LLM calls
+
+The following are **out of scope**:
+
+- Vulnerabilities in upstream dependencies (report to the respective project; we will track via Dependabot / pip-audit)
+- Social engineering attacks
+- Denial of service attacks
+
+## Security Measures
+
+Spendif.ai employs the following security practices:
+
+- **Static analysis** — Bandit and forbidden-pattern guards run on every PR (CI workflow `security.yml`)
+- **CodeQL** — semantic analysis with the `security-and-quality` query suite (planned, tracked in backlog)
+- **Input validation** — Pydantic v2 schemas at API boundaries; explicit field-level checks in the service layer
+- **No dangerous functions** — `eval()`, `exec()`, `subprocess shell=True`, `pickle.load()`, `yaml.load()` without `SafeLoader` are forbidden and CI-blocked
+- **Ruff linting** — enforced in CI with the bandit-style security rules (`S`) enabled
+- **Dependency management** — `uv.lock` provides reproducible installs; `pip-audit` flags known CVEs
+- **PII redaction** — IBAN, card number, fiscal code and account-holder name are automatically replaced with placeholders before any remote LLM call. The service layer rejects unsanitised input. See `core/pii_redactor.py` and the privacy section of the landing page for the full list of handled identifiers
+- **Local-first AI** — the default LLM backend (`local_llama_cpp`) keeps all data on the user's machine; remote backends are opt-in
+- **Prompt integrity** — prompt files have SHA-256 hashes verified at startup so unauthorised modifications are detected (planned, tracked in backlog)
+
+## Acknowledgments
+
+We appreciate responsible disclosure. Security researchers who report valid vulnerabilities will be credited in the release notes (unless they prefer anonymity).

--- a/docs/installation_macos.it.md
+++ b/docs/installation_macos.it.md
@@ -1,0 +1,387 @@
+# Spendif.ai — Guida all'installazione su macOS
+
+*English version: [installation_macos.md](installation_macos.md).*
+
+> **Ambito:** questa guida copre l'installazione nativa su macOS di Spendif.ai
+> tramite l'installer del bundle `.app`. Per Linux, Docker o Windows vedi
+> [installazione.md](installazione.md).
+
+---
+
+## Requisiti di sistema
+
+| Requisito | Minimo | Consigliato |
+|---|---|---|
+| macOS | 12 Monterey | 13 Ventura o successivo |
+| RAM | 8 GB | 16 GB (per LLM da 12B parametri) |
+| Disco | 5 GB liberi | 10 GB (modelli + dati) |
+| Python | 3.11 | 3.13 (installato dalla modalità `--brew`) |
+| Xcode CLT | richiesto | richiesto |
+| Homebrew | opzionale | necessario solo per la modalità `--brew` |
+
+**Apple Silicon (M1/M2/M3/M4):** l'inferenza GPU tramite Metal è abilitata
+automaticamente durante l'installazione — nessuna configurazione manuale richiesta.
+
+**Mac Intel:** Metal non è disponibile per l'inferenza LLM su Intel; l'app gira
+in modalità solo CPU. Tutto funziona correttamente, ma l'inferenza è più lenta.
+
+### Xcode Command Line Tools
+
+L'installer richiede `git`, incluso negli Xcode CLT. Se i CLT non sono
+installati, lo script attiverà automaticamente il dialog di installazione.
+Puoi anche installarli manualmente prima di lanciare l'installer:
+
+```bash
+xcode-select --install
+```
+
+---
+
+## Quick Start — One-liner
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh | bash
+```
+
+Questo esegue l'installer in **modalità default** (Python di sistema + uv).
+Vedi le sezioni sotto per le opzioni.
+
+Per ispezionare lo script prima di eseguirlo:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/packaging/macos/install.sh -o install.sh
+less install.sh
+bash install.sh
+```
+
+---
+
+## Due modalità di installazione
+
+### Modalità default (Python di sistema + uv)
+
+```bash
+bash install.sh
+```
+
+Usa qualsiasi `python3` già presente nel `PATH` (macOS include Python 3.9+;
+molti sviluppatori hanno una versione più recente installata). `uv` (il package
+manager basato su Rust) viene scaricato automaticamente se assente.
+
+**Pro:**
+- Nessun Homebrew richiesto — zero dipendenze oltre a `git` e `curl`
+- Setup più veloce (nessun bootstrap del package manager)
+- Funziona allo stesso modo su qualsiasi Python >= 3.11
+
+**Contro:**
+- La versione di Python dipende da quella già installata
+- Il Python di sistema di macOS (3.9 sulle release più vecchie) è troppo
+  datato — vedi [Troubleshooting](#troubleshooting) se il check fallisce
+
+### Modalità Homebrew (`--brew`)
+
+```bash
+bash install.sh --brew
+```
+
+Installa Homebrew se assente, poi installa Python 3.13 tramite
+`brew install python@3.13`, e usa quel Python per il virtual environment.
+
+**Pro:**
+- Fornisce sempre un Python aggiornato e supportato (3.13)
+- Gestito da Homebrew → facile da aggiornare in seguito con
+  `brew upgrade python@3.13`
+- Ambiente coerente tra macchine diverse
+
+**Contro:**
+- Richiede ~500 MB extra di disco per Homebrew (se non già presente)
+- L'installazione di Homebrew stessa può richiedere qualche minuto su una
+  macchina pulita
+
+### Entrambe le modalità: `uv` per la gestione delle dipendenze
+
+Entrambe le modalità usano `uv sync` per creare il virtual environment e
+installare tutte le dipendenze da `pyproject.toml` / `uv.lock`. Il `.venv`
+risultante è deterministico e riproducibile. `llama-cpp-python` viene compilato
+dai sorgenti con Metal abilitato (`CMAKE_ARGS="-DGGML_METAL=on"`) durante
+`uv sync`.
+
+---
+
+## Tutte le opzioni dell'installer
+
+```
+bash install.sh [OPTIONS]
+
+--brew               Installa Python 3.13 via Homebrew se non presente
+--install-dir DIR    Directory del codice (default: ~/Applications/Spendif.ai)
+--branch BRANCH      Branch git       (default: main)
+--copy-db PATH       Copia un DB SQLite esistente in ~/.spendifai/spendifai.db
+--copy-models PATH   Copia una directory di modelli in ~/.spendifai/models/
+--launch             Apre l'app immediatamente dopo l'installazione
+--update             Solo aggiornamento (git pull + alembic), non reinstallazione completa
+-h, --help           Mostra l'aiuto
+```
+
+---
+
+## Primo avvio e inizializzazione del database
+
+Al primo avvio:
+1. Streamlit parte su `http://localhost:8501` (si apre una finestra di Terminale)
+2. Il browser viene aperto automaticamente dopo 3 secondi
+3. SQLAlchemy crea `~/.spendifai/spendifai.db` al primo accesso al database
+4. Il wizard di onboarding ti guida nella configurazione del backend LLM
+
+Il database **non viene mai** creato o modificato dall'installer — solo dall'app
+stessa. Questo significa che puoi rieseguire l'installer o lanciare `--update`
+in tutta sicurezza senza toccare i tuoi dati.
+
+### Migrazione da un'installazione esistente
+
+Se hai già un database Spendif.ai altrove, passalo in fase di installazione:
+
+```bash
+bash install.sh --copy-db ~/old_spendifai/ledger.db
+```
+
+L'installer lo copia in `~/.spendifai/spendifai.db` e lancia immediatamente
+`alembic upgrade head` per applicare eventuali migrazioni di schema pendenti.
+
+---
+
+## Come funziona Spotlight con il bundle .app
+
+L'installer crea `/Applications/Spendif.ai.app` — un application bundle
+standard di macOS con la seguente struttura:
+
+```
+/Applications/Spendif.ai.app/
+├── Contents/
+│   ├── Info.plist           (CFBundleIdentifier: ai.spendif.app)
+│   ├── MacOS/
+│   │   └── Spendif.ai       (script launcher eseguibile)
+│   └── Resources/
+│       └── spendifai.icns   (icona dell'app)
+```
+
+Dopo la creazione, l'installer chiama `mdimport` per registrare il bundle con
+Spotlight immediatamente. In pochi secondi puoi:
+
+- Premere **Cmd+Space**, digitare `Spendif` e premere **Invio** per avviare
+- Trovare l'app nel **Launchpad**
+- Trascinarla nel **Dock** da `/Applications`
+- Aggiungerla agli **Elementi di login** tramite Impostazioni di sistema →
+  Generali → Elementi di login
+
+Il launcher del bundle `.app` apre una **finestra di Terminale** che mostra
+l'output del server Streamlit. Chiudendo quella finestra di Terminale si ferma
+il server.
+
+---
+
+## Come funziona la notifica di aggiornamento
+
+Ogni volta che lanci Spendif.ai tramite il bundle `.app`, il launcher esegue in
+background un `git fetch` e confronta il branch locale con `origin/main`.
+
+Se la tua installazione è indietro:
+
+1. Il launcher scrive `~/.spendifai/.update_available` con un messaggio del tipo
+   `"3 commits behind origin/main"`
+2. La **sidebar di Spendif.ai** legge questo file (con cache di 5 minuti) e
+   mostra un badge giallo di avviso in alto:
+
+   > 🔔 **Aggiornamento disponibile** (3 commits behind origin/main)
+   > Per aggiornare, esegui da Terminale: ...
+
+3. Il badge sparisce automaticamente al lancio successivo dopo l'aggiornamento
+
+Questo controllo è completamente **non bloccante** — se `git fetch` fallisce
+(no internet, firewall), l'app parte normalmente senza ritardi e senza messaggi
+di errore.
+
+---
+
+## Aggiornamento manuale
+
+Per aggiornare in qualsiasi momento senza passare dall'installer completo:
+
+```bash
+bash ~/Applications/Spendif.ai/packaging/macos/install.sh --update
+```
+
+`--update` fa esattamente tre cose:
+
+1. `git fetch` + `git pull --ff-only` sul branch corrente
+2. `uv sync` per installare le dipendenze nuove o aggiornate
+3. `alembic upgrade head` per migrare lo schema del database (se il DB esiste)
+
+**Non** ricrea il bundle `.app`, non modifica `.env`, e non tocca i tuoi modelli.
+Dopo `--update`, chiudi e riapri l'app.
+
+---
+
+## Troubleshooting
+
+### La compilazione Metal fallisce durante `uv sync`
+
+**Sintomo:**
+```
+error: command '/usr/bin/clang' failed with exit code 1
+```
+oppure
+```
+GGML_METAL build failed
+```
+
+**Causa:** gli Xcode CLT non sono aggiornati o gli header del Metal SDK sono
+mancanti.
+
+**Fix:**
+```bash
+sudo rm -rf /Library/Developer/CommandLineTools
+xcode-select --install
+# Aspetta che l'installazione finisca, poi riprova:
+bash ~/Applications/Spendif.ai/packaging/macos/install.sh --update
+```
+
+Se hai un'installazione completa di Xcode (non solo i CLT), esegui anche:
+```bash
+sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
+```
+
+L'installer include un fallback solo CPU: se la compilazione Metal fallisce,
+riprova senza i flag Metal. L'app funzionerà, ma l'inferenza LLM sarà più lenta
+su Apple Silicon.
+
+---
+
+### Errore di permessi su `/Applications/`
+
+**Sintomo:**
+```
+mkdir: /Applications/Spendif.ai.app: Permission denied
+```
+
+**Causa:** `/Applications` è gestita dal sistema e il tuo account potrebbe non
+avere accesso in scrittura (raro su setup macOS standard, comune su Mac
+gestiti/aziendali).
+
+**Fix — opzione A (preferita):** installa in una directory custom:
+```bash
+bash install.sh --install-dir ~/Applications/Spendif.ai
+```
+Il bundle `.app` verrà creato nella tua home directory:
+`~/Applications/Spendif.ai.app`
+
+**Fix — opzione B:** concedi l'accesso con sudo (sconsigliato su Mac gestiti):
+```bash
+sudo bash install.sh
+```
+
+---
+
+### Porta 8501 già in uso
+
+**Sintomo:** il browser mostra "This site can't be reached" oppure Streamlit
+stampa:
+```
+Address already in use: port 8501
+```
+
+**Causa:** una sessione precedente di Spendif.ai (o un'altra app Streamlit) è
+ancora in esecuzione.
+
+**Fix:**
+```bash
+# Trova e termina il processo che occupa la porta 8501
+lsof -ti tcp:8501 | xargs kill -9
+# Poi rilancia l'app normalmente
+open -a Spendif.ai
+```
+
+Lo script launcher tenta già di terminare un processo Python esistente sulla
+8501 prima di avviarne uno nuovo. Se persiste dopo un avvio normale, usa il
+comando qui sopra.
+
+---
+
+### Versione di `python3` troppo vecchia (modalità default)
+
+**Sintomo:**
+```
+✖  Python 3.9 found, but >= 3.11 required.
+```
+
+**Fix — opzione A:** usa la modalità Homebrew per ottenere Python 3.13:
+```bash
+bash install.sh --brew
+```
+
+**Fix — opzione B:** installa Python 3.13 manualmente da
+[python.org](https://www.python.org/downloads/) e rilancia l'installer.
+
+---
+
+### `uv sync` si blocca compilando `llama-cpp-python`
+
+Compilare `llama-cpp-python` con il supporto Metal può richiedere
+**5–15 minuti** su macchine più lente. È un costo una tantum. Le installazioni
+successive (es. dopo `--update`) saltano la ricompilazione se il pacchetto non
+è cambiato.
+
+Puoi monitorare il progresso eseguendo l'install in un Terminale visibile
+invece di farlo via pipe da `curl`:
+
+```bash
+bash ~/Applications/Spendif.ai/packaging/macos/install.sh
+```
+
+---
+
+### Icona dell'app non mostrata (icona generica nel Dock)
+
+**Causa:** Pillow non era disponibile quando è stato eseguito `create_icon.py`,
+quindi l'installer ha fatto fallback a un'icona di sistema generica.
+
+**Fix:**
+```bash
+cd ~/Applications/Spendif.ai
+uv pip install Pillow
+uv run python packaging/macos/create_icon.py
+# Copia l'icona generata nel bundle dell'app:
+cp packaging/macos/spendifai.icns /Applications/Spendif.ai.app/Contents/Resources/spendifai.icns
+# Forza il Finder a rinfrescare la cache delle icone:
+touch /Applications/Spendif.ai.app
+killall Dock
+```
+
+---
+
+## Disinstallazione
+
+Esegui il disinstaller interattivo:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/drake69/spendify/main/installer/uninstall.sh | bash
+```
+
+Lo script chiede separatamente se rimuovere ciascun componente:
+
+| Componente | Posizione |
+|---|---|
+| Bundle dell'app | `/Applications/Spendif.ai.app` |
+| Directory del codice | `~/Applications/Spendif.ai` (o `--install-dir` custom) |
+| Database | `~/.spendifai/spendifai.db` |
+| Modelli LLM | `~/.spendifai/models/` |
+| Config e flag | `~/.spendifai/` |
+
+Per disinstallare manualmente senza lo script:
+
+```bash
+rm -rf /Applications/Spendif.ai.app
+rm -rf ~/Applications/Spendif.ai
+# Solo se vuoi anche cancellare i tuoi dati finanziari e i modelli:
+rm -rf ~/.spendifai
+```

--- a/docs/installation_windows.it.md
+++ b/docs/installation_windows.it.md
@@ -1,0 +1,478 @@
+# Spendif.ai — Guida all'installazione su Windows
+
+*English version: [installation_windows.md](installation_windows.md).*
+
+> **Ambito:** questa guida copre l'installazione nativa di Spendif.ai su
+> Windows tramite lo script PowerShell di installazione. Per macOS vedi
+> [installation_macos.md](installation_macos.md). Per Docker vedi
+> [deployment.md](deployment.md).
+
+---
+
+## Requisiti di sistema
+
+| Requisito | Minimo | Consigliato |
+|---|---|---|
+| Windows | 10 21H2 (build 19044) | 11 22H2 o successivo |
+| PowerShell | 5.1 (incluso) | 7.4+ |
+| winget | 1.4+ (opzionale, vedi sotto) | 1.6+ |
+| RAM | 8 GB | 16 GB (per LLM da 12B parametri) |
+| Disco | 5 GB liberi | 12 GB (Python + venv + modelli + dati) |
+| Python | 3.13 (installato automaticamente) | 3.13 |
+| Git | qualsiasi versione recente | installato automaticamente |
+| GPU | opzionale | NVIDIA (per inferenza LLM accelerata via CUDA) |
+| VRAM | — (solo CPU) | >= dimensione del modello (es. 8 GB per 7B Q4) |
+
+**GPU NVIDIA (opzionale):** se viene rilevata una GPU NVIDIA, l'installer installa automaticamente una wheel CUDA 12.x di `llama-cpp-python`. Tutto funziona anche senza GPU — l'inferenza è semplicemente più lenta.
+
+**Selezione del modello in base alla VRAM:** al primo avvio, Spendif.ai rileva la VRAM disponibile tramite `nvidia-smi`. Il modello scaricato automaticamente è dimensionato per stare nella VRAM, non nella RAM di sistema — ad esempio un PC con 32 GB di RAM ma 8 GB di VRAM scaricherà Qwen2.5-3B (2.1 GB), non Gemma-3-12B (6.8 GB).
+
+**AMD / Intel Arc:** viene utilizzata automaticamente la modalità solo CPU. Il supporto Vulkan in `llama-cpp-python` è sperimentale e non viene abilitato da questo installer.
+
+---
+
+## Quick Start — One-Liner
+
+Apri **PowerShell** (non CMD) e incolla:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force; irm https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 | iex
+```
+
+Il prefisso `Set-ExecutionPolicy` è necessario perché PowerShell blocca per default gli script non firmati. Si applica solo alla sessione corrente — la policy di sistema non viene modificata in modo permanente.
+
+Per ispezionare lo script prima di eseguirlo:
+
+```powershell
+# Scarica prima lo script
+Invoke-WebRequest https://raw.githubusercontent.com/drake69/spendify/main/packaging/windows/install.ps1 -OutFile install.ps1
+# Leggilo
+notepad install.ps1
+# Eseguilo (dalla stessa cartella)
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+.\install.ps1
+```
+
+---
+
+## Due modalità di installazione: winget vs Manuale
+
+L'installer rileva se `winget` (Windows Package Manager) è disponibile e lo utilizza per installare Python e Git se necessari. Se winget è assente o fallisce, ricade su download diretti.
+
+### Modalità winget (preferita)
+
+`winget` è incluso in **Windows 10 21H2** e in tutte le release di Windows 11 come parte del pacchetto *App Installer*. L'installer esegue:
+
+```
+winget install Python.Python.3.13
+winget install Git.Git
+```
+
+**Pro:**
+- I pacchetti sono firmati e verificati da Microsoft
+- Il PATH viene registrato automaticamente per l'utente corrente
+- Gestisce correttamente conflitti di versione e aggiornamenti
+- Non richiede interazione tramite browser
+
+**Contro:**
+- Richiede winget 1.4+ (i sistemi più vecchi potrebbero dover aggiornare App Installer)
+- Gli ambienti aziendali a volte bloccano l'accesso di rete di winget
+- Possono comparire dialog di consenso al primo utilizzo se eseguito fuori da un terminale
+
+### Modalità manuale (fallback)
+
+Se winget non viene trovato o fallisce, l'installer scarica direttamente gli installer:
+
+| Pacchetto | URL sorgente |
+|---|---|
+| Python 3.13 | `https://www.python.org/ftp/python/3.13.3/python-3.13.3-amd64.exe` |
+| Git | `https://github.com/git-for-windows/git/releases/...` |
+
+Entrambi vengono eseguiti in modalità silenziosa (`/quiet` / `/VERYSILENT`) con installazione per-utente (nessuna elevazione UAC richiesta) e `PrependPath=1` per registrarli su `%PATH%`.
+
+**Pro:**
+- Funziona su sistemi dove winget non è disponibile o è bloccato
+- Nessuna dipendenza dal Microsoft Store
+
+**Contro:**
+- I download possono essere bloccati da firewall aziendali restrittivi
+- La versione è hardcoded nello script — aggiorna l'URL per release più recenti
+
+### Entrambe le modalità: `uv` per la gestione delle dipendenze
+
+Indipendentemente da come è stato ottenuto Python, entrambe le modalità usano `uv` per creare il virtual environment e installare tutte le dipendenze da `pyproject.toml` / `uv.lock`. `uv` viene installato automaticamente tramite `irm https://astral.sh/uv/install.ps1 | iex`, con fallback a `pip install uv` se lo script di bootstrap fallisce.
+
+---
+
+## Supporto GPU — Auto-rilevamento CUDA
+
+Durante l'installazione lo script verifica la presenza di una GPU NVIDIA:
+
+```powershell
+Get-WmiObject Win32_VideoController | Where-Object { $_.Name -like "*NVIDIA*" }
+```
+
+### GPU NVIDIA trovata
+
+L'installer tenta di installare la wheel pre-compilata CUDA 12.x di `llama-cpp-python` dall'indice non ufficiale di wheel mantenuto dall'autore della libreria:
+
+```
+https://abetlen.github.io/llama-cpp-python/whl/cu124/
+```
+
+Questa wheel è compatibile con i driver CUDA 12.x (versione driver ≥ 525). Se l'installazione della wheel fallisce per qualsiasi motivo (driver vecchio, errore di rete, mismatch ABI), l'installer riprova automaticamente con la wheel standard solo CPU da PyPI — l'app si avvia e funziona correttamente, semplicemente senza accelerazione GPU.
+
+**Verifica dell'inferenza GPU dopo l'installazione:**
+
+Nella pagina Impostazioni di Spendif.ai, sotto *LLM Backend → Local*, vedrai se `llama_cpp` è stato caricato con supporto CUDA. In alternativa:
+
+```powershell
+cd $env:LOCALAPPDATA\Spendif.ai
+.venv\Scripts\python.exe -c "import llama_cpp; print(llama_cpp.llama_supports_gpu_offload())"
+```
+
+Restituisce `True` quando CUDA è attivo.
+
+### Nessuna GPU NVIDIA
+
+Viene installata la wheel solo CPU. L'inferenza funziona su qualsiasi hardware ma è significativamente più lenta per modelli grandi (12B parametri). Considera l'uso di una API key OpenAI o Anthropic per l'uso in produzione su macchine solo CPU.
+
+---
+
+## Struttura dei file dopo l'installazione
+
+| Percorso | Contenuto |
+|---|---|
+| `%LOCALAPPDATA%\Spendif.ai\` | Codice (clone del repository git) |
+| `%LOCALAPPDATA%\Spendif.ai\.venv\` | Virtual environment Python (uv) |
+| `%LOCALAPPDATA%\Spendif.ai\launch.bat` | Launcher dell'app |
+| `%APPDATA%\Spendif.ai\` | Directory dei dati utente |
+| `%APPDATA%\Spendif.ai\spendifai.db` | Database SQLite (creato al primo avvio) |
+| `%APPDATA%\Spendif.ai\models\` | File dei modelli LLM locali (.gguf) |
+| `%APPDATA%\Spendif.ai\.update_available` | Flag di notifica aggiornamento (scritto dal launcher) |
+| `%APPDATA%\Spendif.ai\install_path.txt` | Percorso della directory codice (usato dal verificatore di aggiornamenti) |
+
+---
+
+## Primo avvio e inizializzazione del database
+
+Al primo avvio:
+
+1. Doppio click sul collegamento **Spendif.ai** sul Desktop (oppure trovalo nello Start Menu)
+2. Si apre una finestra dei comandi che mostra l'avvio del server Streamlit
+3. Il browser predefinito si apre automaticamente all'indirizzo `http://localhost:8501` dopo circa 4 secondi
+4. SQLAlchemy crea `%APPDATA%\Spendif.ai\spendifai.db` al primo accesso al database
+5. La procedura di onboarding ti guida nella configurazione del backend LLM
+
+Il database **non viene mai** creato o modificato dall'installer — solo dall'app stessa. Puoi rieseguire l'installer o eseguire `-Update` in sicurezza senza toccare i tuoi dati finanziari.
+
+### Migrazione da un'installazione esistente
+
+Se hai un database Spendif.ai esistente, passalo in fase di installazione:
+
+```powershell
+.\install.ps1 -CopyDb C:\path\to\old_ledger.db
+```
+
+L'installer lo copia in `%APPDATA%\Spendif.ai\spendifai.db` ed esegue immediatamente `alembic upgrade head` per applicare eventuali migrazioni di schema pendenti.
+
+---
+
+## Collegamenti Start Menu e Desktop
+
+L'installer crea due collegamenti `.lnk`:
+
+| Collegamento | Percorso |
+|---|---|
+| Start Menu | `%APPDATA%\Microsoft\Windows\Start Menu\Programs\Spendif.ai.lnk` |
+| Desktop | `%USERPROFILE%\Desktop\Spendif.ai.lnk` |
+
+Entrambi i collegamenti invocano:
+
+```
+cmd.exe /c "%LOCALAPPDATA%\Spendif.ai\launch.bat"
+```
+
+**Icona:** i collegamenti usano `%SystemRoot%\System32\shell32.dll,13`
+(icona moneta/denaro dalla libreria di icone integrata di Windows), che
+non richiede file aggiuntivi. Se `packaging\macos\spendifai_256.png` è
+presente (generata da `create_icon.py`), viene segnalato nell'output
+dell'installer ma per affidabilità del `.lnk` viene comunque usata
+l'icona shell32 — sostituisci la variabile `$IconPath` nello script se
+converti il PNG in `.ico`.
+
+---
+
+## Come funziona la notifica degli aggiornamenti
+
+Ogni volta che avvii Spendif.ai tramite un collegamento, `launch.bat`
+esegue in background un `git fetch` e confronta il branch locale con
+`origin/main`.
+
+Se la tua installazione è indietro:
+
+1. Il launcher scrive `%APPDATA%\Spendif.ai\.update_available` con un
+   messaggio tipo `"3 commits behind origin/main"`
+2. La **sidebar di Spendif.ai** legge questo file tramite
+   `ui/components/update_checker.py` (cache di 5 minuti) e mostra un
+   badge giallo di avviso:
+
+   > Update available (3 commits behind origin/main)
+   > To update, run: .\install.ps1 -Update
+
+3. Il badge scompare automaticamente al successivo avvio dopo
+   l'aggiornamento
+
+Il controllo è completamente **non bloccante** — `launch.bat` avvia il
+git fetch in un processo di background sganciato (`start /b`). Se il
+fetch fallisce (offline, firewall), l'app si avvia normalmente senza
+ritardi e senza messaggi di errore.
+
+Il meccanismo è identico al launcher macOS; `update_checker.py` legge
+lo stesso percorso `~/.spendifai/.update_available` (che su Windows
+viene risolto in `%APPDATA%\Spendif.ai\.update_available` perché
+`Path.home()` di Python restituisce la directory del profilo utente
+su Windows).
+
+> **Nota:** su Windows, `Path.home()` in Python restituisce
+> `C:\Users\<user>`, e ci si aspetta il file di flag in
+> `C:\Users\<user>\AppData\Roaming\Spendif.ai\.update_available`
+> (cioè `%APPDATA%\Spendif.ai\.update_available`). Il file
+> `update_checker.py` attualmente ha hardcoded
+> `Path.home() / ".spendifai" / ".update_available"` — se sei su
+> Windows dovrai allineare il percorso. Vedi l'issue tracker GitHub
+> per il task di tracking del percorso cross-platform.
+
+---
+
+## Aggiornamento manuale
+
+Per aggiornare in qualsiasi momento senza ripassare per l'installer
+completo:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+& "$env:LOCALAPPDATA\Spendif.ai\packaging\windows\install.ps1" -Update
+```
+
+Oppure, se hai scaricato lo script localmente:
+
+```powershell
+.\install.ps1 -Update
+```
+
+`-Update` fa esattamente tre cose:
+
+1. `git fetch` + `git pull --ff-only` sul branch corrente
+2. `uv sync` per installare le dipendenze nuove o aggiornate
+3. `alembic upgrade head` per migrare lo schema del database (se il
+   DB esiste)
+
+**Non** ricrea i collegamenti, non modifica `.env` e non tocca i tuoi
+modelli o il contenuto del database. Dopo `-Update`, chiudi e riapri
+l'app.
+
+---
+
+## Tutti i parametri dell'installer
+
+```
+.\install.ps1 [OPTIONS]
+
+-Brew               No-op (accettato per parità CLI con l'installer macOS)
+-InstallDir <path>  Directory del codice (default: %LOCALAPPDATA%\Spendif.ai)
+-Branch <branch>    Branch git (default: main)
+-CopyDb <path>      Copia un DB SQLite esistente in %APPDATA%\Spendif.ai\spendifai.db
+-CopyModels <path>  Copia la directory dei modelli in %APPDATA%\Spendif.ai\models\
+-Launch             Avvia l'app immediatamente dopo l'installazione
+-Update             Solo aggiornamento (git pull + uv sync + alembic)
+-Help               Mostra l'help
+```
+
+---
+
+## Troubleshooting
+
+### Errore ExecutionPolicy
+
+**Sintomo:**
+```
+File install.ps1 cannot be loaded because running scripts is disabled on this system.
+```
+
+**Soluzione:** esegui questo nella stessa sessione PowerShell prima di
+lanciare lo script:
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+```
+
+Modifica la policy solo per il processo corrente — non incide sulla
+configurazione di sistema e viene resettata alla chiusura di
+PowerShell. Se la tua policy IT impedisce anche gli override
+per-processo, chiedi all'amministratore di permettere l'esecuzione di
+script firmati, oppure usa il deployment basato su Docker.
+
+---
+
+### winget non trovato
+
+**Sintomo:**
+```
+!  winget not found -- will use direct download fallback for Python and Git
+```
+
+**Causa:** winget è incluso in Windows 10 21H2+ come parte del pacchetto
+*App Installer*. Su sistemi più vecchi o edizioni LTSC potrebbe essere
+assente.
+
+**Soluzione — opzione A (consigliata):** aggiorna App Installer dal
+Microsoft Store o scaricalo da https://aka.ms/getwinget
+
+**Soluzione — opzione B:** non fare nulla — l'installer ricadrà
+automaticamente sui download diretti da python.org e git-scm.com.
+
+---
+
+### Python non trovato sul PATH dopo l'installazione
+
+**Sintomo:**
+```
+x  Python installed but 'python' command not found on PATH.
+    Open a new PowerShell and re-run the installer.
+```
+
+**Causa:** l'installer di Python registra `%PATH%` nel registry di
+Windows, ma la sessione PowerShell corrente è iniziata prima
+dell'installazione e non vede la modifica.
+
+**Soluzione:** chiudi la finestra PowerShell, aprine una nuova e
+rilancia:
+```powershell
+.\install.ps1
+```
+
+In alternativa, l'installer tenta di ricaricare automaticamente
+`%PATH%` dal registry — questo funziona nella maggior parte dei casi
+ma non quando la shell di Windows necessita di un riavvio completo
+per propagare la modifica.
+
+---
+
+### Porta 8501 già in uso
+
+**Sintomo:** il browser mostra "This site can't be reached" oppure
+`launch.bat` stampa:
+```
+Error: [Errno 10048] error while attempting to bind on address ('0.0.0.0', 8501): only one usage of each socket address...
+```
+
+**Causa:** una sessione precedente di Spendif.ai (o un'altra app
+Streamlit) è ancora in esecuzione.
+
+**Soluzione:**
+```powershell
+# Trova e termina il processo che usa la porta 8501
+netstat -ano | findstr :8501
+# Annota il PID (ultima colonna), poi:
+taskkill /PID <PID> /F
+```
+
+Quindi rilancia tramite il collegamento.
+
+---
+
+### Installazione della wheel CUDA fallita — fallback su CPU
+
+**Sintomo** (visibile nell'output dell'installer):
+```
+!  CUDA wheel install failed: ... -- falling back to CPU-only build
+v  llama-cpp-python installed (CPU-only fallback)
+```
+
+**Causa:** incompatibilità della wheel CUDA (driver troppo vecchio,
+versione CUDA errata) o errore di rete nel raggiungere
+`abetlen.github.io`.
+
+**Implicazione:** l'app si avvia e funziona correttamente in modalità
+solo CPU. L'inferenza LLM è più lenta su CPU.
+
+**Soluzione — aggiorna il driver NVIDIA:**
+1. Scarica l'ultimo driver Game Ready o Studio da https://www.nvidia.com/drivers
+2. Installa e riavvia
+3. Rilancia l'installer: `.\install.ps1 -Update`
+
+**Soluzione — wheel CUDA manuale:**
+```powershell
+cd $env:LOCALAPPDATA\Spendif.ai
+.venv\Scripts\pip install llama-cpp-python `
+    --extra-index-url https://abetlen.github.io/llama-cpp-python/whl/cu124 `
+    --force-reinstall --no-deps
+```
+
+Sostituisci `cu124` con `cu121` o `cu122` se il tuo driver supporta
+una versione precedente del toolkit CUDA.
+
+---
+
+### uv non trovato dopo il bootstrap
+
+**Sintomo:**
+```
+x  Could not install uv.
+```
+
+**Soluzione — installazione manuale di uv:**
+```powershell
+pip install uv
+```
+oppure scarica l'installer ufficiale da https://docs.astral.sh/uv/getting-started/installation/ e aggiungi `%USERPROFILE%\.local\bin` al tuo `%PATH%`.
+
+---
+
+## Disinstallazione
+
+Non esiste ancora un disinstaller automatico per l'installazione
+nativa Windows. Per rimuovere Spendif.ai manualmente:
+
+**1. Rimuovi il codice e il virtual environment:**
+```powershell
+Remove-Item -Recurse -Force "$env:LOCALAPPDATA\Spendif.ai"
+```
+
+**2. Rimuovi i collegamenti:**
+```powershell
+Remove-Item "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\Spendif.ai.lnk" -ErrorAction SilentlyContinue
+Remove-Item "$env:USERPROFILE\Desktop\Spendif.ai.lnk" -ErrorAction SilentlyContinue
+```
+
+**3. Rimuovi i dati utente (solo se vuoi cancellare il tuo database
+finanziario e i modelli):**
+```powershell
+# ATTENZIONE: questo cancella i tuoi dati finanziari in modo permanente
+Remove-Item -Recurse -Force "$env:APPDATA\Spendif.ai"
+```
+
+Python e Git **non** vengono disinstallati — sono stati installati a
+livello di sistema e potrebbero essere usati da altre applicazioni.
+Disinstallali tramite *Impostazioni → App* se non più necessari.
+
+---
+
+## macOS vs Windows — Differenze principali
+
+| Aspetto | macOS | Windows |
+|---|---|---|
+| Formato installer | Script Bash (`install.sh`) | Script PowerShell (`install.ps1`) |
+| Installazione Python | Homebrew (`--brew`) o Python di sistema | winget o download diretto da python.org |
+| Package manager | `uv` (uguale) | `uv` (uguale) |
+| Accelerazione GPU | Metal (Apple Silicon, automatica) | CUDA 12.x (NVIDIA, auto-rilevata) |
+| Directory del codice | `~/Applications/Spendif.ai/` | `%LOCALAPPDATA%\Spendif.ai\` |
+| Directory dati utente | `~/.spendifai/` | `%APPDATA%\Spendif.ai\` |
+| Percorso database | `~/.spendifai/spendifai.db` | `%APPDATA%\Spendif.ai\spendifai.db` |
+| Launcher dell'app | Bundle `.app` (indicizzato da Spotlight) | `launch.bat` + collegamenti `.lnk` |
+| Avvio da | Spotlight (`Cmd+Space`) / Launchpad | Start Menu / collegamento Desktop |
+| Notifica aggiornamento | `~/.spendifai/.update_available` | `%APPDATA%\Spendif.ai\.update_available` |
+| Comando di aggiornamento | `bash .../install.sh --update` | `.\install.ps1 -Update` |
+| llama-cpp-python | Compilato da sorgente (flag Metal) | Wheel pre-compilata (CPU o CUDA) |
+| ExecutionPolicy | Non applicabile | `Bypass` necessario per script non firmati |
+| Installazione one-liner | `curl ... \| bash` | `irm ... \| iex` |

--- a/docs/release_process.it.md
+++ b/docs/release_process.it.md
@@ -1,0 +1,395 @@
+# Spendif.ai — Processo di rilascio
+
+*English version: [release_process.md](release_process.md).*
+
+Questo documento descrive l'intera pipeline di rilascio: policy di versionamento, checklist,
+firma del codice su macOS, Homebrew, winget e la futura automazione CI/CD.
+
+---
+
+## 1. Policy di Semantic Versioning
+
+Spendif.ai segue [Semantic Versioning 2.0.0](https://semver.org/) — `MAJOR.MINOR.PATCH`.
+
+| Bump | Quando usarlo | Esempi |
+|------|---------------|--------|
+| `PATCH` | Bug fix, aggiornamenti delle dipendenze, correzioni alla documentazione. Nessuna nuova funzionalità, nessuna breaking change. | Fix del crash del parser CSV, aggiornamento del binding di llama.cpp |
+| `MINOR` | Nuove funzionalità retrocompatibili. Nuovi importer bancari, nuovi adapter LLM, nuove pagine UI. | Aggiunta dell'importer BancoBPM, supporto per Gemma4 |
+| `MAJOR` | Breaking change: migrazione obbligatoria dello schema del database, modifica del formato del file di configurazione, rimozione di strumenti supportati. | Migrazione SQLite → DuckDB, rinomina di chiavi di configurazione |
+
+La versione autoritativa è il file `VERSION` nella root del repository.
+Tutti gli altri riferimenti di versione (pyproject.toml, Info.plist, manifest winget, cask Homebrew)
+vengono aggiornati da `packaging/release.sh` e non devono mai essere modificati a mano.
+
+---
+
+## 2. Checklist di rilascio
+
+### Pre-rilascio
+
+- [ ] Tutte le issue pianificate per la milestone sono chiuse o rimandate
+- [ ] `CHANGELOG.md` aggiornato con una sezione `## [X.Y.Z] - YYYY-MM-DD`
+- [ ] Tutti i test passano: `pytest tests/ -v`
+- [ ] Smoke test manuale: importa un CSV, esegui la categorizzazione, controlla la dashboard
+- [ ] Nessuna modifica non committata (`git status` pulito)
+- [ ] Sul branch `main` e allineato con il remote
+- [ ] `gh auth status` conferma l'autenticazione con l'account `drake69`
+
+### Build e pubblicazione
+
+```bash
+# Prima un dry run — verifica tutti gli step senza effetti collaterali
+bash packaging/release.sh --patch --dry-run
+
+# Rilascio effettivo
+bash packaging/release.sh --patch
+```
+
+Lo script gestisce: bump della versione, build del DMG, build dello ZIP, manifest JSON,
+git commit + tag + push, creazione della release GitHub, aggiornamento del tap Homebrew,
+generazione dei manifest winget.
+
+### Post-rilascio
+
+- [ ] Verifica la pagina della release GitHub: https://github.com/drake69/spendify/releases
+- [ ] Scarica e testa il DMG su una macchina macOS pulita
+- [ ] Invia la PR per winget (vedi Sezione 5)
+- [ ] Aggiorna il numero di versione sulla landing page se hardcoded
+- [ ] Annuncia sui canali rilevanti
+
+---
+
+## 3. Distribuzione tramite Homebrew
+
+### Tap Homebrew (approccio attuale)
+
+Il repository del tap `drake69/homebrew-spendifai` (separato dal repo principale del codice)
+contiene un singolo file cask in `Casks/spendifai.rb`.
+
+Installazione lato utente:
+```bash
+brew tap drake69/spendifai
+brew install --cask spendifai
+```
+
+Lo script `packaging/release.sh` aggiorna `version` e `sha256` nel file cask,
+poi committa e fa il push sul repo del tap automaticamente — a condizione che il repo del tap sia
+clonato come directory adiacente:
+```
+Spendify/
+  sw_artifacts/         ← repo principale del codice
+  homebrew-spendifai/   ← repo del tap (sibling)
+```
+
+Per inizializzare il repo del tap la prima volta:
+```bash
+cd /path/to/Spendify
+git clone git@github.com:drake69/homebrew-spendifai.git
+# Crea la directory Casks/ e copia il template
+mkdir -p homebrew-spendifai/Casks
+cp sw_artifacts/packaging/homebrew/spendifai.rb homebrew-spendifai/Casks/spendifai.rb
+cd homebrew-spendifai && git add . && git commit -m "feat: initial cask" && git push
+```
+
+### Homebrew Core (futuro)
+
+Homebrew Core è il repository ufficiale e curato. Requisiti per essere accettati:
+
+- **Popolarità**: ≥75 stelle GitHub al momento della submission
+- **Release stabile**: ≥1 versione stabile (non pre-release) con tag di release
+- **App firmata e notarizzata**: il `.app` macOS deve essere firmato con un certificato
+  Apple Developer ID e notarizzato da Apple (vedi Sezione 4)
+- **Niente phone-home**: l'app non deve controllare aggiornamenti né inviare telemetria all'avvio
+- **URL riproducibile**: l'URL di download deve essere stabile e puntare a un asset
+  versionato della release GitHub (non `latest`)
+
+Processo di submission per Homebrew Core:
+1. Fork di `https://github.com/Homebrew/homebrew-cask`
+2. Aggiungi `Casks/s/spendifai.rb` (sottodirectory alfabetica)
+3. Esegui in locale `brew audit --cask spendifai` e `brew install --cask spendifai`
+4. Apri una pull request — la CI di Homebrew (GitHub Actions) valida automaticamente
+5. Un maintainer Homebrew revisiona ed effettua il merge (di norma 1–4 settimane)
+
+---
+
+## 4. Firma del codice e notarizzazione su macOS
+
+Senza firma del codice, Gatekeeper di macOS blocca l'app al primo avvio con
+"Spendif.ai cannot be opened because the developer cannot be verified."
+La firma è **obbligatoria** per Homebrew Core e fortemente consigliata per
+la distribuzione generale.
+
+### Prerequisiti
+
+- Iscrizione all'Apple Developer Program (€99/anno): https://developer.apple.com/programs/
+- Xcode oppure Xcode Command Line Tools installati
+- Un certificato "Developer ID Application" scaricato nel keychain
+
+### Firma del bundle .app
+
+```bash
+# Elenca le identità di firma disponibili
+security find-identity -v -p codesigning
+
+# Firma (sostituisci TEAM_ID con il tuo Apple Team ID di 10 caratteri)
+codesign \
+  --deep \
+  --force \
+  --verify \
+  --verbose \
+  --sign "Developer ID Application: Your Name (TEAM_ID)" \
+  --options runtime \
+  --entitlements packaging/macos/entitlements.plist \
+  build/Spendif.ai.app
+
+# Verifica
+codesign --verify --deep --strict --verbose=2 build/Spendif.ai.app
+spctl --assess --type execute --verbose build/Spendif.ai.app
+```
+
+Un `entitlements.plist` minimale per un'app Streamlit/Python:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" ...>
+<plist version="1.0"><dict>
+  <key>com.apple.security.cs.allow-jit</key><false/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
+  <key>com.apple.security.cs.disable-library-validation</key><true/>
+</dict></plist>
+```
+
+### Notarizzazione del DMG
+
+```bash
+# Invia il DMG al servizio notary di Apple (richiede una API key di App Store Connect)
+xcrun notarytool submit build/Spendif.ai-0.1.0.dmg \
+  --apple-id "your@apple.id" \
+  --team-id "TEAM_ID" \
+  --password "@keychain:AC_PASSWORD" \
+  --wait
+
+# Allega (staple) il ticket di notarizzazione al DMG
+xcrun stapler staple build/Spendif.ai-0.1.0.dmg
+
+# Verifica
+xcrun stapler validate build/Spendif.ai-0.1.0.dmg
+spctl --assess --type open --context context:primary-signature -v build/Spendif.ai-0.1.0.dmg
+```
+
+Lo script `packaging/release.sh` contiene hook segnaposto per la firma — cerca i commenti
+`# SIGN_APP` e `# NOTARISE_DMG` per abilitarli quando le credenziali saranno
+configurate.
+
+---
+
+## 5. Submission su winget
+
+winget (Windows Package Manager) è il package manager ufficiale di Microsoft.
+I pacchetti risiedono nel repository community `microsoft/winget-pkgs`.
+
+### Setup iniziale (una tantum)
+
+```powershell
+# Installa winget (incluso in Windows 10 1809+ / App Installer)
+# Verifica
+winget --version
+```
+
+Su macOS/Linux per testare i manifest:
+```bash
+# Installa il tool di validazione winget
+pip install winget-manifest-validator  # tool della community, non ufficiale
+```
+
+### Submission per ogni rilascio
+
+Dopo l'esecuzione di `packaging/release.sh`, i manifest si trovano in:
+```
+build/winget/manifests/d/SpendifAi/SpendifAi/<version>/
+  SpendifAi.SpendifAi.yaml
+  SpendifAi.SpendifAi.installer.yaml
+  SpendifAi.SpendifAi.locale.en-US.yaml
+```
+
+Passi per la submission:
+
+1. **Fork** di `https://github.com/microsoft/winget-pkgs` (una tantum)
+
+2. **Crea un branch** nel tuo fork:
+   ```bash
+   git checkout -b SpendifAi.SpendifAi-<version>
+   ```
+
+3. **Copia i manifest** nel percorso corretto del fork:
+   ```bash
+   mkdir -p manifests/d/SpendifAi/SpendifAi/<version>
+   cp build/winget/manifests/d/SpendifAi/SpendifAi/<version>/* \
+      manifests/d/SpendifAi/SpendifAi/<version>/
+   ```
+
+4. **Validazione locale** (opzionale ma consigliata):
+   ```bash
+   winget validate --manifest manifests/d/SpendifAi/SpendifAi/<version>/
+   ```
+
+5. **Push e apertura PR** verso `microsoft/winget-pkgs main`
+
+6. **Validazione del bot**: il `winget-bot`:
+   - Scarica e installa il pacchetto in una VM in sandbox
+   - Esegue test automatici
+   - Commenta con i risultati pass/fail
+
+   Risolvi eventuali fallimenti prima della review dei maintainer.
+
+7. **Merge**: una volta approvato, il pacchetto è disponibile entro ~24 ore:
+   ```powershell
+   winget install SpendifAi.SpendifAi
+   ```
+
+### Aggiornamento di una versione esistente
+
+winget non consente la modifica dei manifest pubblicati. Per una nuova versione, aggiungi una
+nuova directory di versione — non modificare quella vecchia.
+
+---
+
+## 5b. Pacchetti Linux (.deb / .rpm)
+
+### .deb (Ubuntu / Debian / Mint)
+
+Script di build: `packaging/linux/build-deb.sh`
+
+```bash
+cd sw_artifacts
+bash packaging/linux/build-deb.sh              # usa il file VERSION
+bash packaging/linux/build-deb.sh --version 1.2.3  # versione esplicita
+```
+
+Produce: `build/spendifai_<version>_amd64.deb`
+
+Il `.deb` installa il codice sorgente in `/opt/spendifai/`. Lo script `postinst`:
+1. Installa `uv` se non presente
+2. Esegue `uv sync --extra desktop` per creare il venv Python
+3. Rileva la GPU (NVIDIA CUDA)
+4. Scarica il modello AI consigliato da HuggingFace
+5. Configura `.env` con `LLM_BACKEND=local_llama_cpp`
+6. Registra il launcher `.desktop` e aggiorna la cache delle icone
+
+Dipendenze dichiarate in `Depends:`: `python3`, `python3-venv`, `python3-dev`, `python3-gi`, `gir1.2-webkit2-4.1`, `git`, `curl`, `gcc`, `cmake`, `pkg-config`.
+
+Installazione/disinstallazione:
+```bash
+sudo apt install ./build/spendifai_0.1.0_amd64.deb
+sudo apt remove spendifai       # rimuove il codice, preserva ~/.spendifai/
+```
+
+### .rpm (Fedora / RHEL / Rocky / Alma)
+
+Script di build: `packaging/linux/build-rpm.sh`
+
+```bash
+cd sw_artifacts
+bash packaging/linux/build-rpm.sh              # usa il file VERSION
+bash packaging/linux/build-rpm.sh --version 1.2.3
+```
+
+Richiede: `rpm-build` (`sudo dnf install rpm-build`)
+
+Produce: `build/spendifai-<version>-1.noarch.rpm`
+
+Stessa logica post-install del `.deb`. Dipendenze: `python3`, `python3-devel`, `python3-gobject`, `webkit2gtk4.1`, `git`, `curl`, `gcc`, `cmake`.
+
+Installazione/disinstallazione:
+```bash
+sudo dnf install ./build/spendifai-0.1.0-1.noarch.rpm
+sudo dnf remove spendifai
+```
+
+### Installer interattivi (senza package manager)
+
+Per gli utenti che preferiscono non usare .deb/.rpm:
+- Ubuntu/Debian: `bash packaging/linux/install-debian.sh`
+- Red Hat/Fedora: `bash packaging/linux/install-redhat.sh`
+
+Entrambi gli script installano in `~/.local/share/Spendif.ai/` (nessun sudo richiesto per il codice, solo per i pacchetti di sistema).
+
+---
+
+## 6. CI/CD GitHub Actions (futuro)
+
+Una pipeline di rilascio completamente automatizzata via GitHub Actions eliminerebbe la necessità
+di eseguire `release.sh` in locale. Workflow proposto:
+
+```yaml
+# .github/workflows/release.yml
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install create-dmg
+        run: brew install create-dmg
+      - name: Generate icon
+        run: python3 packaging/macos/create_icon.py
+      - name: Build .app and DMG
+        run: bash packaging/release.sh --skip-zip  # DMG only on macOS runner
+      - name: Sign and notarise
+        env:
+          APPLE_CERT_BASE64: ${{ secrets.APPLE_CERT_BASE64 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
+        run: bash packaging/macos/sign_and_notarise.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dmg
+          path: build/*.dmg
+
+  build-windows-zip:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build ZIP
+        run: bash packaging/release.sh --skip-dmg  # ZIP only
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zip
+          path: build/*.zip
+
+  publish:
+    needs: [build-macos, build-windows-zip]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(cat VERSION | tr -d '[:space:]')
+          gh release create "v${VERSION}" \
+            --title "Spendif.ai v${VERSION}" \
+            --generate-notes \
+            dmg/*.dmg zip/*.zip
+      - name: Update Homebrew tap
+        env:
+          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: bash packaging/ci/update_homebrew_tap.sh
+      - name: Generate winget manifests
+        run: bash packaging/ci/generate_winget.sh
+```
+
+Secret necessari:
+- `APPLE_CERT_BASE64` — certificato Developer ID `.p12` codificato in base64
+- `APPLE_CERT_PASSWORD` — password del `.p12`
+- `APPLE_TEAM_ID`, `APPLE_ID`, `APPLE_APP_PASSWORD` — per notarytool
+- `HOMEBREW_TAP_TOKEN` — PAT GitHub con permessi di scrittura su homebrew-spendifai
+- `GITHUB_TOKEN` — fornito automaticamente da Actions
+
+Questo è un obiettivo futuro; l'attuale approccio manuale tramite `release.sh` è sufficiente
+per un solo founder che effettua rilasci poco frequenti.


### PR DESCRIPTION
## Summary
Project-wide documentation cleanup so every public doc is available in both Italian and English (matching the existing `README.md` / `README.it.md` pattern):

**Translation guide (commit 1)**
- `CONTRIBUTING.md`: new **Translations** section explaining how to contribute a UI translation (`sw_artifacts/ui/i18n/<lang>.json`), what to leave untouched, and recommended editors for non-developers (BabelEdit, Tolgee Cloud, VS Code, JSONedit). Documents the current language-status table so contributors know which locales are master, LLM-translated, or pending human review. References AI-14 (the JSON unification roadmap for landing pages).
- `CONTRIBUTING.en.md`: new English counterpart of `CONTRIBUTING.md`.

**Doc IT/EN pairing (commit 2)**
- `SECURITY.md` — created from the blueprint template, populated for Spendif.ai (scope, PII redaction layer, local-first default, dependency policy). Closes a gap in the security blueprint compliance.
- `SECURITY.it.md` — Italian counterpart.
- `CHANGELOG.it.md` — Italian counterpart of `CHANGELOG.md`.
- `docs/installation_macos.it.md`, `docs/installation_windows.it.md`, `docs/release_process.it.md` — Italian counterparts of the three docs that were English-only.
- Every new file has a top-of-page cross-link back to its EN/IT counterpart so readers can switch language easily.

## Test plan
- [ ] `python -c "import json; json.load(open('sw_artifacts/ui/i18n/en.json'))"` still passes (sanity).
- [ ] Open `CONTRIBUTING.md` and `CONTRIBUTING.en.md` on GitHub; verify the Translations anchors render and the cross-link works.
- [ ] Verify `SECURITY.md` is now picked up by the GitHub UI security tab (it should appear automatically once on `main`).
- [ ] Spot-check the IT counterparts: structure mirrors the EN sources, code blocks/URLs/identifiers preserved.
- [ ] Confirm CI is green on doc-only changes.