### PR TITLE
Landing: drop Google Analytics (replace with cookie-less tool later)

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Ihr einheitliches Bankbuch, auf Ihrem Computer</title>

--- a/index.en.html
+++ b/index.en.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Your unified bank ledger, on your computer</title>

--- a/index.es.html
+++ b/index.es.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Su libro de cuentas bancario unificado, en su ordenador</title>

--- a/index.fr.html
+++ b/index.fr.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Votre registre bancaire unifié, sur votre ordinateur</title>

--- a/index.html
+++ b/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="it">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendif.ai — I tuoi movimenti unificati, sul tuo computer</title>

--- a/index.ja.html
+++ b/index.ja.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — あなたのコンピュータで動く、統合銀行台帳</title>

--- a/index.nl.html
+++ b/index.nl.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="nl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Je geünificeerde rekeningoverzicht, op je eigen computer</title>

--- a/index.pl.html
+++ b/index.pl.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="pl">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Twoja ujednolicona księga bankowa, na Twoim komputerze</title>

--- a/index.pt.html
+++ b/index.pt.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="pt">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-M7MGHTEV07"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-M7MGHTEV07');
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spendify — Seu extrato bancário unificado, no seu computador</title>


### PR DESCRIPTION
## Summary
The 9 landing pages claim "no telemetry / your data stays yours" as a core differentiator. Keeping Google Analytics on the website created a perceived contradiction for privacy-conscious visitors and would have required a GDPR cookie consent banner localised across nine languages.

**Decision (option D)**: drop GA entirely. A cookie-less analytics tool (Umami / Plausible / GoatCounter — to be picked) will be wired in a follow-up PR. Tracked in backlog `AI-24`. Until that lands we have no website-traffic metrics, but GitHub stars / clones / referrers remain visible via the GitHub Insights tab.

Branch was originally created as `feat/cookie-consent` to add a banner; we changed direction before any commit. The branch name is left as-is to avoid extra noise.

## Files changed
- `index.html`, `index.en.html`, `index.de.html`, `index.fr.html`, `index.es.html`, `index.pt.html`, `index.nl.html`, `index.ja.html`, `index.pl.html` — 8 lines removed each (gtag block).

## Test plan
- [ ] After GH Pages rebuilds, view-source on each of the 9 landings and confirm no `googletagmanager.com` reference remains.
- [ ] DevTools → Network on each landing should show zero requests to Google domains.
- [ ] Privacy claim "no telemetry / your data stays yours" now matches what the page actually does.