### PR TITLE
Landing: wire GoatCounter analytics (cookie-less, replaces GA)

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Ihr einheitliches Bankbuch" />
   <meta property="og:description" content="Ein persönliches Open-Source-Finanzbuch, das auf Ihrem Computer läuft. Ihre Daten bleiben Ihre." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.en.html
+++ b/index.en.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Your unified bank ledger" />
   <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.es.html
+++ b/index.es.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Su libro de cuentas bancario unificado" />
   <meta property="og:description" content="Un libro de cuentas financiero personal de código abierto que se ejecuta en su ordenador. Sus datos siguen siendo suyos." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.fr.html
+++ b/index.fr.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Votre registre bancaire unifié" />
   <meta property="og:description" content="Un registre financier personnel open source qui tourne sur votre ordinateur. Vos données restent les vôtres." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendif.ai — I tuoi movimenti unificati" />
   <meta property="og:description" content="Un registro finanziario personale open source che gira sul tuo computer. I tuoi dati restano tuoi." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.ja.html
+++ b/index.ja.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — あなたの統合銀行台帳" />
   <meta property="og:description" content="あなたのコンピュータ上で動作するオープンソースの個人向け家計台帳。データはあなたのものです。" />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.nl.html
+++ b/index.nl.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Je geünificeerde rekeningoverzicht" />
   <meta property="og:description" content="Een open source persoonlijk financieel grootboek dat draait op je eigen computer. Je gegevens blijven van jou." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.pl.html
+++ b/index.pl.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Twoja ujednolicona księga bankowa" />
   <meta property="og:description" content="Otwartoźródłowa osobista księga finansowa działająca na Twoim komputerze. Twoje dane pozostają Twoje." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/index.pt.html
+++ b/index.pt.html
@@ -8,6 +8,11 @@
   <meta property="og:title" content="Spendify — Seu extrato bancário unificado" />
   <meta property="og:description" content="Um extrato financeiro pessoal open source que roda no seu computador. Seus dados continuam sendo seus." />
   <meta property="og:type" content="website" />
+
+  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
+  <script data-goatcounter="https://spendifai.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
+
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 


### PR DESCRIPTION
## Summary
Add the [GoatCounter](https://www.goatcounter.com/) beacon to all 9 landing pages as the cookie-less replacement for the Google Analytics tag dropped in #97.

- Endpoint: `https://spendifai.goatcounter.com/count`
- Loaded `async` from `gc.zgo.at`, `<head>` of each landing
- Beacon comment in source identifies the script for future readers

### Why GoatCounter

- No cookies, no fingerprinting → no GDPR cookie-consent banner needed
- Free for OSS / small projects (< 100k pv/month)
- Hosted by goatcounter.com — no infrastructure to maintain
- Author (Martin Tournoij) is well-known in OSS

Coherent with the "no telemetry / your data stays yours" claim on the page: GoatCounter records aggregate page views only, no per-user tracking.

## Test plan
- [ ] After GH Pages rebuilds, view-source on each landing and confirm the GoatCounter beacon line is present.
- [ ] DevTools → Network on the live page should show one request to `gc.zgo.at`, and exactly zero requests to `googletagmanager.com` / `google-analytics.com`.
- [ ] Visit each of the 9 landings once and check the GoatCounter dashboard `https://spendifai.goatcounter.com` shows 9 pageviews on 9 distinct paths within ~1 minute.
- [ ] Verify CI is green (doc-only / `<head>` change, no functional impact expected).