### PR TITLE
Replace GoatCounter with Cloudflare Web Analytics

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Ein persönliches Open-Source-Finanzbuch, das auf Ihrem Computer läuft. Ihre Daten bleiben Ihre." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.en.html
+++ b/index.en.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.es.html
+++ b/index.es.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Un libro de cuentas financiero personal de código abierto que se ejecuta en su ordenador. Sus datos siguen siendo suyos." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.fr.html
+++ b/index.fr.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Un registre financier personnel open source qui tourne sur votre ordinateur. Vos données restent les vôtres." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Un registro finanziario personale open source che gira sul tuo computer. I tuoi dati restano tuoi." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.ja.html
+++ b/index.ja.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="あなたのコンピュータ上で動作するオープンソースの個人向け家計台帳。データはあなたのものです。" />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.nl.html
+++ b/index.nl.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Een open source persoonlijk financieel grootboek dat draait op je eigen computer. Je gegevens blijven van jou." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.pl.html
+++ b/index.pl.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Otwartoźródłowa osobista księga finansowa działająca na Twoim komputerze. Twoje dane pozostają Twoje." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.pt.html
+++ b/index.pt.html
@@ -9,9 +9,8 @@
   <meta property="og:description" content="Um extrato financeiro pessoal open source que roda no seu computador. Seus dados continuam sendo seus." />
   <meta property="og:type" content="website" />
 
-  <!-- GoatCounter — privacy-friendly, cookie-less analytics -->
-  <script data-goatcounter="https://spendifai.goatcounter.com/count"
-          async src="//gc.zgo.at/count.js"></script>
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Summary
- GoatCounter server has been unreachable for over a week — switch analytics to Cloudflare Web Analytics
- Still cookieless and GDPR-friendly, runs on Cloudflare infrastructure (high uptime, free)
- Applied to all 9 locale landing pages under `sw_artifacts/`

## Test plan
- [ ] Verify in Cloudflare dashboard that pageviews appear after merge + gh-pages deploy
- [ ] Spot-check 2-3 locales in browser to confirm no console errors from the beacon