### PR TITLE
feat(packaging): MSIX + DMG installers, hybrid CI signing, getting-started page (9 locales)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,14 @@ jobs:
           retention-days: 30
 
   # ─────────────────────────────────────────────────────────────────────────
-  # Windows — PyInstaller → .exe folder → ZIP
+  # Windows — PyInstaller → .exe folder → MSIX (unsigned)
+  #
+  # The MSIX is produced unsigned in CI. Owner signs locally with a
+  # Code Signing certificate via packaging\windows\sign-local.ps1 before
+  # publishing the GitHub Release (hybrid signing model — see docs/release.md).
   # ─────────────────────────────────────────────────────────────────────────
   build-windows:
-    name: Build Windows ZIP
+    name: Build Windows MSIX
     needs: prepare
     runs-on: windows-latest
 
@@ -137,42 +141,25 @@ jobs:
       - name: Install dependencies (with desktop extras)
         run: uv sync --extra desktop
 
-      - name: Build via PyInstaller
-        run: |
-          uv run pyinstaller desktop.spec --noconfirm --clean
-          dir dist\
-
-      - name: Verify .exe
-        run: |
-          if (Test-Path "dist\SpendifAi\SpendifAi.exe") {
-            Write-Host "✅ SpendifAi.exe created"
-          } else {
-            Write-Host "❌ SpendifAi.exe not found"
-            exit 1
-          }
-
-      - name: Create ZIP
+      - name: Build MSIX (PyInstaller + makeappx)
         run: |
           $version = "${{ needs.prepare.outputs.version }}"
-          $zipName = "SpendifAi-${version}-windows.zip"
+          .\packaging\windows\build-msix.ps1 -Version $version
 
-          # Create staging directory with installer + docs
-          New-Item -ItemType Directory -Force "dist\zip_staging" | Out-Null
-          Copy-Item "dist\SpendifAi" "dist\zip_staging\SpendifAi" -Recurse
-          Copy-Item "packaging\windows\install.ps1" "dist\zip_staging\install.ps1"
-          Copy-Item "packaging\windows\uninstall.ps1" "dist\zip_staging\uninstall.ps1"
-          if (Test-Path "README.md") { Copy-Item "README.md" "dist\zip_staging\README.md" }
-          if (Test-Path "VERSION") { Copy-Item "VERSION" "dist\zip_staging\VERSION" }
+      - name: Verify MSIX
+        run: |
+          $msix = Get-ChildItem "build\SpendifAi-*.msix" | Select-Object -First 1
+          if (-not $msix) {
+            Write-Host "❌ MSIX not produced"
+            exit 1
+          }
+          Write-Host "✅ $($msix.Name) ($([math]::Round($msix.Length / 1MB, 1)) MB)"
 
-          Compress-Archive -Path "dist\zip_staging\*" -DestinationPath "dist\$zipName"
-          Write-Host "✅ $zipName created"
-          Get-Item "dist\$zipName" | Format-Table Name, Length
-
-      - name: Upload ZIP artifact
+      - name: Upload MSIX artifact
         uses: actions/upload-artifact@v4
         with:
-          name: windows-zip
-          path: dist/SpendifAi-*-windows.zip
+          name: windows-msix
+          path: build/SpendifAi-*.msix
           retention-days: 30
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -285,7 +272,7 @@ jobs:
       - name: Compute SHA256 checksums
         run: |
           cd packages
-          find . -type f \( -name "*.dmg" -o -name "*.zip" -o -name "*.deb" -o -name "*.rpm" \) | while read f; do
+          find . -type f \( -name "*.dmg" -o -name "*.msix" -o -name "*.deb" -o -name "*.rpm" \) | while read f; do
             sha256sum "$f"
           done | tee ../SHA256SUMS.txt
 
@@ -310,8 +297,8 @@ jobs:
 
           | Platform | File | Install |
           |----------|------|---------|
-          | macOS | SpendifAi-${VERSION}.dmg | Double-click to install |
-          | Windows | SpendifAi-${VERSION}-windows.zip | Extract, run install.ps1 |
+          | macOS | SpendifAi-${VERSION}.dmg | Double-click, drag to Applications |
+          | Windows | SpendifAi-${VERSION}.msix | Double-click to install (requires trusted signature) |
           | Ubuntu/Debian | spendifai_${VERSION}_amd64.deb | sudo apt install ./spendifai_*.deb |
           | Fedora/RHEL | spendifai-${VERSION}-1.noarch.rpm | sudo dnf install ./spendifai-*.rpm |
 
@@ -319,13 +306,17 @@ jobs:
           EOF
           cat SHA256SUMS.txt >> RELEASE_NOTES.md
 
-      - name: Create GitHub Release
+      - name: Create draft GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Release is created as DRAFT so the owner can sign the unsigned
+          # DMG / MSIX locally and replace them via `gh release upload --clobber`
+          # before publishing. See docs/release.md (hybrid signing model).
           TAG="${{ needs.prepare.outputs.tag }}"
-          FILES=$(find packages/ -type f \( -name "*.dmg" -o -name "*.zip" -o -name "*.deb" -o -name "*.rpm" \))
+          FILES=$(find packages/ -type f \( -name "*.dmg" -o -name "*.msix" -o -name "*.deb" -o -name "*.rpm" \))
           gh release create "$TAG" \
+            --draft \
             --title "Spendif.ai $TAG" \
             --notes-file RELEASE_NOTES.md \
             $FILES SHA256SUMS.txt

--- a/CHANGELOG.it.md
+++ b/CHANGELOG.it.md
@@ -22,6 +22,13 @@ Il versioning segue [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Registrazione in Add/Remove Programs di Windows durante l'installazione
 - Workflow CI Linux (`release-linux.yml`): build di .deb/.rpm, smoke test in container, allegati alla GitHub Release
 - Identificatore winget rinominato in `SpendifAi.SpendifAi`
+- Installer MSIX per Windows (`packaging/windows/build-msix.ps1` + `AppxManifest.xml.in`), sostituisce il precedente artefatto ZIP-only per Windows
+- Script di firma locale: `packaging/macos/sign-local.sh` (codesign + notarytool + stapler) e `packaging/windows/sign-local.ps1` (wrapper SignTool)
+- Builder DMG locale (`packaging/macos/build-dmg.sh`) che replica il job CI per riproducibilità offline
+- Modello release CI ibrido: `release.yml` builda tutti e quattro gli installer unsigned e pubblica una GitHub Release in **draft**; l'owner firma DMG e MSIX in locale e li sostituisce via `gh release upload --clobber` prima di rimuovere `--draft`. Documentato in `docs/release_process.it.md` §2bis (EN+IT)
+- Pagina "Primo avvio" su gh-pages, copertura completa 9 lingue (`getting-started.{html,en,de,es,fr,ja,nl,pl,pt}.html`): guida illustrata a 3 step (Download → Installa → Primo avvio) con bottoni di download per DMG/MSIX/.deb/.rpm e placeholder per screenshot (`assets/screenshots/`). Ogni pagina include il beacon Cloudflare Web Analytics e il selettore lingua completo
+- Aggiornata la sezione "Primo avvio" di `installation_{macos,windows}.{md,it.md}` per descrivere il flusso nativo pywebview (splash + download modello + wizard onboarding), sostituendo la sequenza obsoleta Terminale/browser che vale solo per i vecchi script `install.sh`/`install.ps1`
+- Landing page (tutte le 9 lingue: `index.html` IT, `index.{en,de,es,fr,ja,nl,pl,pt}.html`): aggiunto CTA localizzato "Scarica installer" che punta alla pagina getting-started corrispondente alla lingua, sopra le tab esistenti con gli script curl
 
 ### Fixed
 - Auto-invalidazione degli schemi: gli schemi in cache (Flow 1) con parse rate < 10% vengono eliminati automaticamente e ritentati con Flow 2 (riclassificazione LLM)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Windows Add/Remove Programs registration during install
 - Linux CI workflow (`release-linux.yml`): builds .deb/.rpm, smoke-tests in containers, attaches to GitHub Release
 - winget identifier renamed to `SpendifAi.SpendifAi`
+- Windows MSIX installer (`packaging/windows/build-msix.ps1` + `AppxManifest.xml.in`), replaces the previous ZIP-only Windows artefact
+- Local signing scripts: `packaging/macos/sign-local.sh` (codesign + notarytool + stapler) and `packaging/windows/sign-local.ps1` (SignTool wrapper)
+- Local DMG builder (`packaging/macos/build-dmg.sh`) mirroring the CI job for offline reproducibility
+- Hybrid CI release model: `release.yml` builds all four installers unsigned and publishes a **draft** GitHub Release; the owner signs DMG and MSIX locally and replaces them via `gh release upload --clobber` before flipping `--draft=false`. Documented in `docs/release_process.md` §2bis (EN+IT)
+- Getting-started page on gh-pages, full 9-locale coverage (`getting-started.{html,en,de,es,fr,ja,nl,pl,pt}.html`): three-step illustrated install/first-launch guide with download buttons for DMG/MSIX/.deb/.rpm and screenshot placeholders (`assets/screenshots/`). Each page includes the Cloudflare Web Analytics beacon and a full language switcher
+- Updated `installation_{macos,windows}.{md,it.md}` "First Launch" section to describe the native pywebview flow (splash + model download + onboarding wizard), replacing the obsolete Terminal/browser sequence which only applies to the legacy `install.sh`/`install.ps1` scripts
+- Landing pages (all 9 locales: `index.html` IT, `index.{en,de,es,fr,ja,nl,pl,pt}.html`): added localized "Download installer" CTA pointing to the locale-matched getting-started page above the existing curl-script tabs
 
 ### Fixed
 - Schema auto-invalidation: cached schemas (Flow 1) producing < 10% parse rate are automatically deleted and retried with Flow 2 (LLM re-classification)

--- a/assets/screenshots/README.md
+++ b/assets/screenshots/README.md
@@ -1,0 +1,30 @@
+# Screenshots for getting-started page
+
+The gh-pages getting-started page (`getting-started.html` and
+`getting-started.en.html`) references the screenshots listed below.
+
+Drop the PNG/JPG files in this folder using the exact filenames. The HTML
+already contains commented-out `<img>` tags — uncomment them once the
+file exists.
+
+## Expected files
+
+| Filename | Step | Content |
+|---|---|---|
+| `macos-dmg-dragdrop.png` | Install 2 | DMG window mounted, app icon being dragged to the Applications shortcut |
+| `windows-msix-install.png` | Install 2 | Windows App Installer dialog showing Spendif.ai with Install button |
+| `linux-deb-install.png` | Install 2 | Terminal output of `sudo apt install ./spendifai_*.deb` (postinst running, model download progress visible) |
+| `splash-download-progress.png` | First launch 3a | Native window showing splash + "Downloading AI model..." with progress bar mid-way |
+| `onboarding-step-1-language.png` | First launch 3b | Step 1 of the onboarding wizard (language selector + preview of taxonomy/date/amount format) |
+| `app-ready-import-page.png` | First launch 3c | Main app on Import page, sidebar visible, empty state with "Drop your bank CSV/XLSX here" |
+
+## Recommended capture format
+
+- **Aspect ratio**: 16:10 (matches the placeholder card) or 4:3
+- **Resolution**: at least 1280×800, ideally 1920×1200 (Retina-friendly)
+- **Format**: PNG for UI screenshots, JPG only if file size becomes a problem
+- **Anonymisation**: blur/redact any real account names, IBANs, or balances
+  before capturing — even if they're test data, the same image will be
+  reused on the public landing page
+- **Window chrome**: include the native title bar (helps users recognise
+  the OS they're looking at) but crop personal taskbars / dock items

--- a/docs/installation_macos.it.md
+++ b/docs/installation_macos.it.md
@@ -125,9 +125,39 @@ bash install.sh [OPTIONS]
 
 ---
 
-## Primo avvio e inizializzazione del database
+## Primo avvio
 
-Al primo avvio:
+Cosa succede al doppio-click su **Spendif.ai** la prima volta dipende da come
+l'hai installato:
+
+### Installazione nativa (DMG, consigliata)
+
+Se installato dal `.dmg` (`Spendif.ai.app` in `/Applications`), l'app apre una
+**finestra nativa**. Niente Terminale, niente browser.
+
+1. **Splash screen** con barra di progresso.
+2. **Download modello AI** (~2–4 GB in base alla RAM rilevata). Il launcher
+   chiama `core.model_manager.ensure_model_available()` che sceglie il GGUF
+   più grande che entra comodamente nella RAM libera (Qwen2.5-3B,
+   Gemma-3-4B, Qwen2.5-7B o Gemma-3-12B). Il download finisce in
+   `~/.spendifai/models/` e sopravvive a reinstallazioni. **Il primo avvio
+   può richiedere 5–15 minuti** con una connessione casa tipica — è normale.
+3. **`.env` viene scritto** con `LLM_BACKEND=local_llama_cpp`, il path del
+   modello e `SPENDIFAI_DB=sqlite:///~/.spendifai/ledger.db`.
+4. **Streamlit parte dentro la stessa finestra** quando il modello è pronto.
+5. **Wizard di onboarding** (4 step): lingua, titolari, conti, conferma. Il
+   database `~/.spendifai/ledger.db` viene creato al confirm.
+6. **App pronta.** Dai successivi avvii gli step 2–3 sono saltati: splash →
+   wizard (se non ancora completato) o app principale.
+
+> Spazio libero richiesto al primo avvio: ~5 GB (modello + stato venv Python).
+> Non chiudere lo splash finché la barra di progresso non sparisce — chiudere
+> a metà download costringe a ripartire da zero al prossimo avvio.
+
+### Installazione via script (legacy `install.sh`)
+
+Se installato con `bash packaging/macos/install.sh`:
+
 1. Streamlit parte su `http://localhost:8501` (si apre una finestra di Terminale)
 2. Il browser viene aperto automaticamente dopo 3 secondi
 3. SQLAlchemy crea `~/.spendifai/spendifai.db` al primo accesso al database

--- a/docs/installation_macos.md
+++ b/docs/installation_macos.md
@@ -120,9 +120,39 @@ bash install.sh [OPTIONS]
 
 ---
 
-## First Launch and Database Initialisation
+## First Launch
 
-On first launch:
+What happens when you double-click **Spendif.ai** for the first time depends on
+how it was installed:
+
+### Native install (DMG, recommended)
+
+When installed from the `.dmg` (`Spendif.ai.app` in `/Applications`), the app
+opens a **native window**. No Terminal, no browser tab.
+
+1. **Splash screen** appears with a progress bar.
+2. **AI model download** (~2–4 GB depending on detected RAM). The bundled
+   launcher calls `core.model_manager.ensure_model_available()` which picks
+   the largest GGUF that fits comfortably in your free RAM (Qwen2.5-3B,
+   Gemma-3-4B, Qwen2.5-7B, or Gemma-3-12B). The download lives at
+   `~/.spendifai/models/` so it survives reinstalls. **First launch can take
+   5–15 minutes** on a typical home connection — this is normal.
+3. **`.env` is written** to set `LLM_BACKEND=local_llama_cpp`, the model
+   path, and `SPENDIFAI_DB=sqlite:///~/.spendifai/ledger.db`.
+4. **Streamlit boots inside the same window** once the model is ready.
+5. **Onboarding wizard** (4 steps) appears: language, holders, accounts,
+   confirm. The database `~/.spendifai/ledger.db` is created on confirm.
+6. **App is ready.** Subsequent launches skip steps 2–3 and go straight from
+   splash → wizard or main app.
+
+> Free disk space required at first launch: ~5 GB (model + Python venv state).
+> Keep the splash window open until the progress bar disappears — closing
+> mid-download forces a fresh start on next launch.
+
+### Script install (legacy `install.sh`)
+
+If installed via `bash packaging/macos/install.sh`:
+
 1. Streamlit starts on `http://localhost:8501` (a Terminal window opens)
 2. The browser is opened automatically after 3 seconds
 3. SQLAlchemy creates `~/.spendifai/spendifai.db` on the first database access

--- a/docs/installation_windows.it.md
+++ b/docs/installation_windows.it.md
@@ -154,9 +154,35 @@ Viene installata la wheel solo CPU. L'inferenza funziona su qualsiasi hardware m
 
 ---
 
-## Primo avvio e inizializzazione del database
+## Primo avvio
 
-Al primo avvio:
+Cosa succede al primo avvio dipende dall'installer usato:
+
+### Installazione MSIX (consigliata)
+
+Se installato da `Spendif.ai.msix` (Start Menu → Spendif.ai), l'app apre una
+**finestra nativa**. Niente finestra dei comandi, niente browser.
+
+1. **Splash screen** con barra di progresso.
+2. **Download modello AI** (~2–4 GB in base alla VRAM/RAM rilevata). Il
+   launcher chiama `core.model_manager.ensure_model_available()` che sceglie
+   il GGUF più grande che entra in VRAM (o RAM se non c'è GPU): Qwen2.5-3B
+   (2.1 GB), Gemma-3-4B, Qwen2.5-7B o Gemma-3-12B (6.8 GB). Scaricato in
+   `%APPDATA%\Spendif.ai\models\`. **Il primo avvio può richiedere 5–15
+   minuti** con una connessione casa tipica — è normale.
+3. **`.env` viene scritto** con `LLM_BACKEND=local_llama_cpp`, il path del
+   modello e `SPENDIFAI_DB=sqlite:///%APPDATA%/Spendif.ai/ledger.db`.
+4. **Streamlit parte dentro la stessa finestra** quando il modello è pronto.
+5. **Wizard di onboarding** (4 step): lingua, titolari, conti, conferma. Il
+   database `%APPDATA%\Spendif.ai\ledger.db` viene creato al confirm.
+6. **App pronta.** Dai successivi avvii gli step 2–3 sono saltati.
+
+> Spazio libero richiesto al primo avvio: ~5 GB (modello + stato Python).
+> Non chiudere lo splash finché la barra di progresso non sparisce.
+
+### Installazione via script (legacy `install.ps1`)
+
+Se installato via `irm ... | iex` (script PowerShell):
 
 1. Doppio click sul collegamento **Spendif.ai** sul Desktop (oppure trovalo nello Start Menu)
 2. Si apre una finestra dei comandi che mostra l'avvio del server Streamlit

--- a/docs/installation_windows.md
+++ b/docs/installation_windows.md
@@ -177,9 +177,35 @@ OpenAI or Anthropic API key for production use on CPU-only machines.
 
 ---
 
-## First Launch and Database Initialisation
+## First Launch
 
-On first launch:
+What happens at first launch depends on which installer you used:
+
+### MSIX install (recommended)
+
+When installed from `Spendif.ai.msix` (Start Menu → Spendif.ai), the app
+opens a **native window**. No command window, no browser tab.
+
+1. **Splash screen** with a progress bar.
+2. **AI model download** (~2–4 GB depending on detected VRAM/RAM). The
+   bundled launcher calls `core.model_manager.ensure_model_available()` which
+   picks the largest GGUF that fits in VRAM (or RAM if no GPU): Qwen2.5-3B
+   (2.1 GB), Gemma-3-4B, Qwen2.5-7B, or Gemma-3-12B (6.8 GB). Downloaded to
+   `%APPDATA%\Spendif.ai\models\`. **First launch can take 5–15 minutes** on
+   a typical home connection — this is normal.
+3. **`.env` is written** with `LLM_BACKEND=local_llama_cpp`, the model path,
+   and `SPENDIFAI_DB=sqlite:///%APPDATA%/Spendif.ai/ledger.db`.
+4. **Streamlit boots inside the same window** once the model is ready.
+5. **Onboarding wizard** (4 steps): language, holders, accounts, confirm.
+   Database `%APPDATA%\Spendif.ai\ledger.db` is created on confirm.
+6. **App is ready.** Subsequent launches skip steps 2–3.
+
+> Free disk space required at first launch: ~5 GB (model + Python state).
+> Keep the splash window open until the progress bar disappears.
+
+### Script install (legacy `install.ps1`)
+
+If installed via `irm ... | iex` (PowerShell script):
 
 1. Double-click the **Spendif.ai** Desktop shortcut (or find it in Start Menu)
 2. A command window opens showing the Streamlit server starting up

--- a/docs/release_process.it.md
+++ b/docs/release_process.it.md
@@ -59,6 +59,73 @@ generazione dei manifest winget.
 
 ---
 
+## 2bis. Release CI con firma locale ibrida (consigliata)
+
+Il workflow `.github/workflows/release.yml` builda automaticamente i quattro
+installer (DMG, MSIX, .deb, .rpm) ad ogni tag `v*.*.*` e crea una GitHub
+Release in **draft** con gli artefatti unsigned allegati. L'owner firma DMG
+e MSIX **localmente** con i propri certificati e sostituisce i file unsigned
+prima di pubblicare. Le credenziali di firma non finiscono mai su GitHub.
+
+### Procedura
+
+```bash
+# 1. Bump VERSION, aggiorna CHANGELOG, commit, tag, push
+echo "3.1.0" > VERSION
+git add VERSION CHANGELOG.md
+git commit -m "chore(release): bump to 3.1.0"
+git tag v3.1.0
+git push origin main v3.1.0
+```
+
+Al push del tag la CI esegue quattro job paralleli (~15-25 min per il job
+macOS, ~10-15 min per quello Windows) e produce una release **in draft**.
+Poi, sulle macchine dell'owner:
+
+```bash
+# 2a. macOS — firma + notarizzazione del DMG
+gh release download v3.1.0 --pattern '*.dmg' --dir /tmp/release
+export APPLE_DEV_ID="Developer ID Application: Luigi Corsaro (TEAMID)"
+export APPLE_ID="lcorsaro69@gmail.com"
+export APPLE_TEAM_ID="..."
+export APPLE_APP_PASSWORD="app-specific-password"
+bash packaging/macos/sign-local.sh --dmg /tmp/release/SpendifAi-3.1.0.dmg
+gh release upload v3.1.0 /tmp/release/SpendifAi-3.1.0.dmg --clobber
+```
+
+```powershell
+# 2b. Windows — firma dell'MSIX
+gh release download v3.1.0 --pattern '*.msix' --dir C:\release
+$env:MSIX_CERT_PATH = "C:\certs\spendifai.pfx"
+$env:MSIX_CERT_PASSWORD = "secret"
+.\packaging\windows\sign-local.ps1 -Msix C:\release\SpendifAi-3.1.0.msix
+gh release upload v3.1.0 C:\release\SpendifAi-3.1.0.msix --clobber
+```
+
+```bash
+# 3. Ricalcola SHA256SUMS.txt per includere i file firmati
+gh release download v3.1.0 --dir /tmp/release
+cd /tmp/release && sha256sum *.dmg *.msix *.deb *.rpm > SHA256SUMS.txt
+gh release upload v3.1.0 SHA256SUMS.txt --clobber
+
+# 4. Pubblica la draft
+gh release edit v3.1.0 --draft=false
+```
+
+### Perché ibrido
+
+| Aspetto | Firma in CI | Firma locale | Ibrido (questo) |
+|---------|-------------|--------------|-----------------|
+| Build automatica | ✓ | ✗ | ✓ (CI) |
+| Cert fuori da GitHub | ✗ | ✓ | ✓ |
+| Release "1-click" | ✓ | ✗ | ✗ (step manuale firma) |
+| Rischio se token leaks | Malware firmato | Nessuno | Nessuno |
+
+Adatto a fondatori singoli o piccoli team che hanno già i certificati in
+locale e preferiscono non caricarli come Secrets.
+
+---
+
 ## 3. Distribuzione tramite Homebrew
 
 ### Tap Homebrew (approccio attuale)
@@ -315,7 +382,24 @@ Entrambi gli script installano in `~/.local/share/Spendif.ai/` (nessun sudo rich
 
 ---
 
-## 6. CI/CD GitHub Actions (futuro)
+## 6. CI/CD GitHub Actions (implementato)
+
+Il workflow `.github/workflows/release.yml` è attivo e produce tutti e quattro
+gli installer ad ogni tag `v*.*.*`. Vedi **Sezione 2bis** per il flusso di
+firma ibrida che lo avvolge.
+
+Job:
+
+| Job | Runner | Produce | Note |
+|-----|--------|---------|------|
+| `build-macos` | `macos-latest` | `SpendifAi-<ver>.dmg` (unsigned) | PyInstaller + `create-dmg` |
+| `build-windows` | `windows-latest` | `SpendifAi-<ver>.msix` (unsigned) | PyInstaller + `makeappx.exe`. Vedi `packaging/windows/build-msix.ps1`. |
+| `build-deb` | `ubuntu-latest` | `spendifai_<ver>_amd64.deb` | Smoke-test in container `ubuntu:24.04` |
+| `build-rpm` | `ubuntu-latest` | `spendifai-<ver>-1.noarch.rpm` | Smoke-test in container `fedora:41` |
+| `publish` | `ubuntu-latest` | Draft GitHub Release + `SHA256SUMS.txt` | Note estratte da `CHANGELOG.md` |
+
+Proposta originale conservata sotto come riferimento — descrive il percorso
+**non** scelto (firma dentro la CI con secrets):
 
 Una pipeline di rilascio completamente automatizzata via GitHub Actions eliminerebbe la necessità
 di eseguire `release.sh` in locale. Workflow proposto:

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -57,6 +57,74 @@ winget manifest generation.
 
 ---
 
+## 2bis. CI-driven release with hybrid local signing (recommended)
+
+The workflow `.github/workflows/release.yml` automates building the four
+installers (DMG, MSIX, .deb, .rpm) on every `v*.*.*` tag and creates a
+**draft** GitHub Release with the unsigned artefacts attached. The owner
+then signs DMG and MSIX **locally** with their certificates and replaces
+the unsigned files before publishing. This keeps signing credentials off
+GitHub while still automating the build.
+
+### Step-by-step
+
+```bash
+# 1. Bump VERSION, update CHANGELOG, commit, tag, push
+echo "3.1.0" > VERSION
+git add VERSION CHANGELOG.md
+git commit -m "chore(release): bump to 3.1.0"
+git tag v3.1.0
+git push origin main v3.1.0
+```
+
+Once the tag lands, the CI runs four parallel build jobs (~15–25 min for
+the macOS job, ~10–15 min for the Windows job) and produces a **draft**
+release. Then, on the owner's machines:
+
+```bash
+# 2a. macOS — sign + notarise the DMG
+gh release download v3.1.0 --pattern '*.dmg' --dir /tmp/release
+export APPLE_DEV_ID="Developer ID Application: Luigi Corsaro (TEAMID)"
+export APPLE_ID="lcorsaro69@gmail.com"
+export APPLE_TEAM_ID="..."
+export APPLE_APP_PASSWORD="app-specific-password"
+bash packaging/macos/sign-local.sh --dmg /tmp/release/SpendifAi-3.1.0.dmg
+gh release upload v3.1.0 /tmp/release/SpendifAi-3.1.0.dmg --clobber
+```
+
+```powershell
+# 2b. Windows — sign the MSIX
+gh release download v3.1.0 --pattern '*.msix' --dir C:\release
+$env:MSIX_CERT_PATH = "C:\certs\spendifai.pfx"
+$env:MSIX_CERT_PASSWORD = "secret"
+.\packaging\windows\sign-local.ps1 -Msix C:\release\SpendifAi-3.1.0.msix
+gh release upload v3.1.0 C:\release\SpendifAi-3.1.0.msix --clobber
+```
+
+```bash
+# 3. Recompute SHA256SUMS.txt to include the signed files
+gh release download v3.1.0 --dir /tmp/release
+cd /tmp/release && sha256sum *.dmg *.msix *.deb *.rpm > SHA256SUMS.txt
+gh release upload v3.1.0 SHA256SUMS.txt --clobber
+
+# 4. Publish the draft
+gh release edit v3.1.0 --draft=false
+```
+
+### Why hybrid
+
+| Concern | Pure CI signing | Local signing | Hybrid (this one) |
+|---------|-----------------|---------------|-------------------|
+| Build automation | ✓ | ✗ | ✓ (CI) |
+| Certs off GitHub | ✗ | ✓ | ✓ |
+| One-click release | ✓ | ✗ | ✗ (manual sign step) |
+| Risk if token leaks | Signed malware | None | None |
+
+Suitable for solo founders or small teams that already have the certs
+locally and prefer not to upload them as Secrets.
+
+---
+
 ## 3. Homebrew Distribution
 
 ### Homebrew Tap (current approach)
@@ -313,10 +381,24 @@ Both scripts install to `~/.local/share/Spendif.ai/` (no sudo required for the c
 
 ---
 
-## 6. GitHub Actions CI/CD (Future)
+## 6. GitHub Actions CI/CD (implemented)
 
-A fully automated release pipeline via GitHub Actions would eliminate the need
-to run `release.sh` locally. Proposed workflow:
+The workflow `.github/workflows/release.yml` is live and produces all four
+installers on every `v*.*.*` tag. See **Section 2bis** for the hybrid
+signing workflow that wraps it.
+
+Jobs:
+
+| Job | Runner | Produces | Notes |
+|-----|--------|----------|-------|
+| `build-macos` | `macos-latest` | `SpendifAi-<ver>.dmg` (unsigned) | PyInstaller + `create-dmg` |
+| `build-windows` | `windows-latest` | `SpendifAi-<ver>.msix` (unsigned) | PyInstaller + `makeappx.exe`. See `packaging/windows/build-msix.ps1`. |
+| `build-deb` | `ubuntu-latest` | `spendifai_<ver>_amd64.deb` | Smoke-tested in `ubuntu:24.04` container |
+| `build-rpm` | `ubuntu-latest` | `spendifai-<ver>-1.noarch.rpm` | Smoke-tested in `fedora:41` container |
+| `publish` | `ubuntu-latest` | Draft GitHub Release + `SHA256SUMS.txt` | Notes extracted from `CHANGELOG.md` |
+
+Older proposal kept below for reference — describes the path we did **not**
+take (signing inside CI with secrets):
 
 ```yaml
 # .github/workflows/release.yml

--- a/getting-started.de.html
+++ b/getting-started.de.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Installation &amp; erster Start</title>
+  <meta name="description" content="Lade Spendif.ai für macOS, Windows oder Linux herunter. Schritt-für-Schritt-Anleitung zu Installation, erstem Start und initialer Einrichtung." />
+  <meta property="og:title" content="Spendif.ai — Installation &amp; erster Start" />
+  <meta property="og:description" content="Drei Schritte: herunterladen, installieren, erster Start. Alles offline, keine Cloud." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Herunterladen</a>
+        <a href="#install">Installation</a>
+        <a href="#first-launch">Erster Start</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Installation &amp; erster Start</h1>
+    <p class="lead">Drei Schritte, um Spendif.ai auf deinem Rechner zum Laufen zu bringen: herunterladen, installieren, erster Start. Alles offline, kein Konto nötig.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Für dein System herunterladen</h2>
+      <p>Die offiziellen Installer werden als Assets jedes <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a> veröffentlicht. Wähle das passende Format für dein Betriebssystem.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">DMG herunterladen</a>
+          <div class="dl-notes">macOS 12 Monterey oder neuer. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">MSIX herunterladen</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + vertrauenswürdiges Zertifikat in der Pre-Alpha erforderlich.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.deb herunterladen</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.rpm herunterladen</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Suchst du eine bestimmte Version? Siehe <a href="https://github.com/drake69/spendify/releases" target="_blank">alle Releases</a> · Quellcode: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Installieren</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Doppelklick auf die heruntergeladene <code>.dmg</code>-Datei.</p>
+          <p>2. Ziehe <strong>Spendif.ai.app</strong> in den Ordner <strong>Programme</strong>.</p>
+          <p>3. DMG auswerfen (Cmd+E) und die App über das Launchpad starten.</p>
+          <p>Falls "Spendif.ai kann nicht geöffnet werden, da der Entwickler nicht verifiziert werden kann" erscheint (Build noch nicht signiert): Rechtsklick auf die App → <strong>Öffnen</strong> → bestätigen.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(Drag &amp; Drop vom DMG nach Programme)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Doppelklick auf die heruntergeladene <code>.msix</code>-Datei.</p>
+          <p>2. Der in Windows integrierte App-Installer öffnet sich. Klicke <strong>Installieren</strong>.</p>
+          <p>3. Die App erscheint im Startmenü und wird von dort gestartet.</p>
+          <p>Bei "Unbekannter Herausgeber": PowerShell als Administrator öffnen und das Zertifikat einmalig importieren (siehe <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Anleitung</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/windows-msix-install.png</code><div>(Windows App-Installer-Dialog)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Im Terminal:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>Das <code>postinst</code>-Skript installiert <code>uv</code>, erstellt das venv, lädt das Modell herunter und schreibt die <code>.env</code>. Vollständige Anleitung: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">install guide</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/linux-deb-install.png</code><div>(dpkg/dnf Terminal-Ausgabe)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Erster Start</h2>
+      <p>Beim ersten Start richtet Spendif.ai die Umgebung ein — der längste Schritt, der aber nur einmal stattfindet.</p>
+
+      <div class="note">
+        <strong>⏱ Benötigte Zeit:</strong> 5–15 Minuten bei einer typischen Heim-Internetverbindung. Freier Speicherplatz: ~5 GB.<br>
+        Lass das Fenster offen, bis der Fortschrittsbalken verschwindet.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + KI-Modell-Download</h3>
+          <p>Per Doppelklick öffnet sich ein natives Fenster mit <strong>Splashscreen</strong> und Fortschrittsbalken. Spendif.ai erkennt verfügbares RAM/VRAM und lädt das passendste LLM herunter (Qwen 2.5, Gemma 3 — Größen von 2 bis 8 GB).</p>
+          <p>Das Modell liegt unter <code>~/.spendifai/models/</code> (macOS/Linux) oder <code>%APPDATA%\Spendif.ai\models\</code> (Windows) und übersteht Neuinstallationen.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/splash-download-progress.png</code><div>(Splash + Fortschritt Modell-Download)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Onboarding-Assistent — 4 Schritte</h3>
+          <p>Sobald das Modell bereit ist, weicht der Splash dem <strong>Konfigurationsassistenten</strong>:</p>
+          <p>1. <strong>Sprache</strong> — Taxonomie, Datumsformat, Zahlentrennzeichen.<br>
+             2. <strong>Inhaber</strong> — dein Name und die Varianten, die deine Bank verwendet.<br>
+             3. <strong>Konten</strong> — Girokonto, Karten, Bargeld.<br>
+             4. <strong>Bestätigen</strong> — alles wird erst hier geschrieben, keine teilweise Persistenz.</p>
+          <p>Keine Wahl ist endgültig: alles lässt sich später in den <em>Einstellungen</em> ändern.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(Assistent Schritt 1 — Sprachauswahl)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App bereit</h3>
+          <p>Nach der Bestätigung erstellt Spendif.ai die SQLite-Datenbank und führt dich zur <strong>Import</strong>-Seite. Von dort lädst du deine ersten Bank-CSV/XLSX-Dateien.</p>
+          <p>Ab dem nächsten Mal ist der Ablauf: Doppelklick → Splash (1-2 Sekunden) → App. Keine Downloads mehr, kein Assistent mehr.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Screenshot</div><code>assets/screenshots/app-ready-import-page.png</code><div>(App bereit, Import-Seite)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Probleme?</h2>
+      <p>
+        Vollständige Dokumentation:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">Installationsleitfaden</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">Benutzerhandbuch</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS Deep-Dive</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows Deep-Dive</a>.
+      </p>
+      <p>Bugs, Fragen, Anregungen: <a href="https://github.com/drake69/spendify/issues" target="_blank">GitHub Issue eröffnen</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendify" target="_blank">Quellcode auf GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.en.html
+++ b/getting-started.en.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Install &amp; first launch</title>
+  <meta name="description" content="Download Spendif.ai for macOS, Windows or Linux. Step-by-step install, first launch and initial setup guide." />
+  <meta property="og:title" content="Spendif.ai — Install &amp; first launch" />
+  <meta property="og:description" content="Three steps: download, install, first launch. All offline, no cloud." />
+
+  <!-- Cloudflare Web Analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --surface2: #21262d;
+      --border:   #30363d;
+      --blue:     #58a6ff;
+      --green:    #3fb950;
+      --purple:   #bc8cff;
+      --orange:   #e3b341;
+      --red:      #f85149;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --radius:   12px;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; }
+    .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; }
+    .lang-switch a { color: var(--blue); }
+
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn {
+      display: inline-block;
+      background: var(--blue);
+      color: white;
+      padding: 0.6rem 1.1rem;
+      border-radius: 8px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: opacity 0.2s;
+    }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+
+    .step {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+      margin: 2rem 0;
+      align-items: start;
+    }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; }
+    .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) {
+      .step, .step.reverse { grid-template-columns: 1fr; }
+      .step.reverse .step-text, .step.reverse .step-img { order: 0; }
+    }
+    .step-img {
+      background: var(--surface2);
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+      aspect-ratio: 16 / 10;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+      padding: 1rem;
+      overflow: hidden;
+    }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph {
+      display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+    }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+
+    .note {
+      background: var(--surface);
+      border-left: 4px solid var(--orange);
+      padding: 1rem 1.2rem;
+      border-radius: 6px;
+      margin: 1.5rem 0;
+    }
+    .note strong { color: var(--orange); }
+
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Download</a>
+        <a href="#install">Install</a>
+        <a href="#first-launch">First launch</a>
+        <span class="lang-switch">🌐 <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Install &amp; first launch</h1>
+    <p class="lead">Three steps to get Spendif.ai running on your computer: download, install, first launch. All offline, no account required.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Download for your system</h2>
+      <p>Official installers are published as assets on each <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Pick the format for your OS.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Download DMG</a>
+          <div class="dl-notes">macOS 12 Monterey or later. Apple Silicon + Intel.</div>
+        </div>
+
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Download MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + trusted cert needed during pre-alpha.</div>
+        </div>
+
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Download .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Download .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Looking for a specific version? See <a href="https://github.com/drake69/spendify/releases" target="_blank">all releases</a> · Source code: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Install</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Double-click the downloaded <code>.dmg</code>.</p>
+          <p>2. Drag <strong>Spendif.ai.app</strong> into the <strong>Applications</strong> folder.</p>
+          <p>3. Eject the DMG (Cmd+E) and launch the app from Launchpad.</p>
+          <p>If you see "Spendif.ai cannot be opened because the developer cannot be verified" (build not yet signed): right-click the app → <strong>Open</strong> → confirm.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/macos-dmg-dragdrop.png</code>
+            <div>(drag &amp; drop from DMG to Applications)</div>
+          </div>
+          <!-- <img src="assets/screenshots/macos-dmg-dragdrop.png" alt="DMG drag and drop to Applications"> -->
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Double-click the downloaded <code>.msix</code>.</p>
+          <p>2. The built-in App Installer opens. Click <strong>Install</strong>.</p>
+          <p>3. The app appears in the Start Menu — launch from there.</p>
+          <p>If you see "Unknown publisher": open PowerShell as admin and import the certificate once (see the <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">guide</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/windows-msix-install.png</code>
+            <div>(Windows App Installer dialog)</div>
+          </div>
+          <!-- <img src="assets/screenshots/windows-msix-install.png" alt="Windows App Installer"> -->
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>From the terminal:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>The <code>postinst</code> installs <code>uv</code>, creates the venv, downloads the model and writes <code>.env</code>. Full guide: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">installation docs</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/linux-deb-install.png</code>
+            <div>(dpkg/dnf terminal output)</div>
+          </div>
+          <!-- <img src="assets/screenshots/linux-deb-install.png" alt="Linux install output"> -->
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>First launch</h2>
+      <p>On first launch Spendif.ai sets up its environment — it's the longest step, but happens only once.</p>
+
+      <div class="note">
+        <strong>⏱ Time required:</strong> 5–15 minutes on a typical home connection. Free disk space required: ~5 GB.<br>
+        Keep the window open until the progress bar disappears.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + AI model download</h3>
+          <p>Double-clicking opens a native window with a <strong>splash screen</strong> and progress bar. Spendif.ai detects available RAM/VRAM and downloads the most suitable LLM (Qwen 2.5, Gemma 3 — sizes from 2 to 8 GB).</p>
+          <p>The model lives at <code>~/.spendifai/models/</code> (macOS/Linux) or <code>%APPDATA%\Spendif.ai\models\</code> (Windows) and survives reinstalls.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/splash-download-progress.png</code>
+            <div>(splash + model download progress)</div>
+          </div>
+          <!-- <img src="assets/screenshots/splash-download-progress.png" alt="Splash screen with model download progress"> -->
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Onboarding wizard — 4 steps</h3>
+          <p>Once the model is ready, the splash gives way to the <strong>configuration wizard</strong>:</p>
+          <p>1. <strong>Language</strong> — taxonomy, date format, number separators.<br>
+             2. <strong>Holders</strong> — your name and the variants your bank uses.<br>
+             3. <strong>Accounts</strong> — current account, cards, cash.<br>
+             4. <strong>Confirm</strong> — everything is written only here, no partial persistence.</p>
+          <p>No choice is final: you can change everything later from <em>Settings</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/onboarding-step-1-language.png</code>
+            <div>(wizard step 1 — language selection)</div>
+          </div>
+          <!-- <img src="assets/screenshots/onboarding-step-1-language.png" alt="Onboarding step 1 — language"> -->
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App ready</h3>
+          <p>On confirm the wizard creates the SQLite database and lands you on the <strong>Import</strong> page. From here you load your first bank CSV/XLSX files.</p>
+          <p>From then on the flow is: double-click → splash (1-2 seconds) → app. No more downloads, no more wizard.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/app-ready-import-page.png</code>
+            <div>(app ready, Import page)</div>
+          </div>
+          <!-- <img src="assets/screenshots/app-ready-import-page.png" alt="App ready — import page"> -->
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Having trouble?</h2>
+      <p>
+        Full documentation:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">install guide</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">user guide</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS deep-dive</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows deep-dive</a>.
+      </p>
+      <p>Bugs, questions, requests: <a href="https://github.com/drake69/spendify/issues" target="_blank">open a GitHub issue</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendify" target="_blank">Source on GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.es.html
+++ b/getting-started.es.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Instalación y primer inicio</title>
+  <meta name="description" content="Descarga Spendif.ai para macOS, Windows o Linux. Guía paso a paso de instalación, primer inicio y configuración inicial." />
+  <meta property="og:title" content="Spendif.ai — Instalación y primer inicio" />
+  <meta property="og:description" content="Tres pasos: descargar, instalar, primer inicio. Todo offline, sin cuenta." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Descargar</a>
+        <a href="#install">Instalar</a>
+        <a href="#first-launch">Primer inicio</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Instalación y primer inicio</h1>
+    <p class="lead">Tres pasos para tener Spendif.ai funcionando en tu computadora: descargar, instalar, primer inicio. Todo offline, sin cuenta.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Descarga para tu sistema</h2>
+      <p>Los instaladores oficiales se publican como activos de cada <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Elige el formato adecuado para tu SO.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Descargar DMG</a>
+          <div class="dl-notes">macOS 12 Monterey o superior. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Descargar MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + cert de confianza requeridos en la fase pre-alfa.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Descargar .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Descargar .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">¿Buscas una versión específica? Ver <a href="https://github.com/drake69/spendify/releases" target="_blank">todas las releases</a> · Código fuente: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Instalar</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Doble clic en el archivo <code>.dmg</code> descargado.</p>
+          <p>2. Arrastra <strong>Spendif.ai.app</strong> a la carpeta <strong>Aplicaciones</strong>.</p>
+          <p>3. Expulsa el DMG (Cmd+E) y lanza la app desde el Launchpad.</p>
+          <p>Si ves "No se puede abrir Spendif.ai porque no se puede verificar al desarrollador" (build aún no firmada): clic derecho en la app → <strong>Abrir</strong> → confirmar.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(arrastrar &amp; soltar del DMG a Aplicaciones)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Doble clic en el archivo <code>.msix</code> descargado.</p>
+          <p>2. Se abre el Instalador de Apps integrado en Windows. Pulsa <strong>Instalar</strong>.</p>
+          <p>3. La app aparece en el Menú Inicio y se lanza desde allí.</p>
+          <p>Si ves "Editor desconocido": abre PowerShell como admin e importa el certificado una vez (consulta la <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">guía</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/windows-msix-install.png</code><div>(diálogo Instalador de Apps de Windows)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Desde la terminal:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>El <code>postinst</code> instala <code>uv</code>, crea el venv, descarga el modelo y configura <code>.env</code>. Guía completa: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">guía de instalación</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/linux-deb-install.png</code><div>(salida del terminal dpkg/dnf)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Primer inicio</h2>
+      <p>En el primer inicio Spendif.ai prepara el entorno — es el paso más largo, pero ocurre solo una vez.</p>
+
+      <div class="note">
+        <strong>⏱ Tiempo requerido:</strong> 5–15 minutos en una conexión doméstica típica. Espacio libre requerido: ~5 GB.<br>
+        Mantén la ventana abierta hasta que desaparezca la barra de progreso.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + descarga del modelo de IA</h3>
+          <p>Al hacer doble clic se abre una ventana nativa con una <strong>pantalla splash</strong> y barra de progreso. Spendif.ai detecta la RAM/VRAM disponible y descarga el LLM más adecuado (Qwen 2.5, Gemma 3 — tamaños de 2 a 8 GB).</p>
+          <p>El modelo se guarda en <code>~/.spendifai/models/</code> (macOS/Linux) o <code>%APPDATA%\Spendif.ai\models\</code> (Windows) y sobrevive a reinstalaciones.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/splash-download-progress.png</code><div>(splash + progreso descarga modelo)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Asistente de onboarding — 4 pasos</h3>
+          <p>Cuando el modelo está listo, el splash da paso al <strong>asistente de configuración</strong>:</p>
+          <p>1. <strong>Idioma</strong> — taxonomía, formato de fecha, separadores numéricos.<br>
+             2. <strong>Titulares</strong> — tu nombre y las variantes que usa tu banco.<br>
+             3. <strong>Cuentas</strong> — cuenta corriente, tarjetas, efectivo.<br>
+             4. <strong>Confirmar</strong> — todo se escribe solo aquí, sin persistencia parcial.</p>
+          <p>Ninguna elección es definitiva: puedes cambiar todo después desde <em>Ajustes</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(asistente paso 1 — selección idioma)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App lista</h3>
+          <p>Al confirmar el asistente, Spendif.ai crea la base de datos SQLite y te lleva a la página <strong>Importar</strong>. Desde ahí cargas tus primeros CSV/XLSX bancarios.</p>
+          <p>A partir del siguiente inicio el flujo es: doble clic → splash (1-2 segundos) → app. Sin más descargas, sin más asistente.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/app-ready-import-page.png</code><div>(app lista, página Importar)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>¿Tienes problemas?</h2>
+      <p>
+        Documentación completa:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">guía de instalación</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">guía de usuario</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS detallada</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows detallada</a>.
+      </p>
+      <p>Bugs, preguntas, solicitudes: <a href="https://github.com/drake69/spendify/issues" target="_blank">abre una issue en GitHub</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendify" target="_blank">Código fuente en GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.fr.html
+++ b/getting-started.fr.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Installation et premier lancement</title>
+  <meta name="description" content="Téléchargez Spendif.ai pour macOS, Windows ou Linux. Guide pas-à-pas pour l'installation, le premier lancement et la configuration initiale." />
+  <meta property="og:title" content="Spendif.ai — Installation et premier lancement" />
+  <meta property="og:description" content="Trois étapes : télécharger, installer, premier lancement. Tout en local, pas de cloud." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Télécharger</a>
+        <a href="#install">Installer</a>
+        <a href="#first-launch">Premier lancement</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Installation et premier lancement</h1>
+    <p class="lead">Trois étapes pour faire fonctionner Spendif.ai sur votre ordinateur : télécharger, installer, premier lancement. Tout en local, sans compte.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Téléchargez pour votre système</h2>
+      <p>Les installeurs officiels sont publiés en tant qu'assets de chaque <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Choisissez le format adapté à votre OS.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Télécharger DMG</a>
+          <div class="dl-notes">macOS 12 Monterey ou supérieur. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Télécharger MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + certificat de confiance requis pendant la pré-alpha.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Télécharger .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Télécharger .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Vous cherchez une version spécifique ? Voir <a href="https://github.com/drake69/spendify/releases" target="_blank">toutes les releases</a> · Code source : <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Installer</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Double-cliquez sur le fichier <code>.dmg</code> téléchargé.</p>
+          <p>2. Glissez <strong>Spendif.ai.app</strong> dans le dossier <strong>Applications</strong>.</p>
+          <p>3. Éjectez le DMG (Cmd+E) et lancez l'app depuis Launchpad.</p>
+          <p>Si vous voyez "Impossible d'ouvrir Spendif.ai car le développeur ne peut pas être vérifié" (build pas encore signée) : clic droit sur l'app → <strong>Ouvrir</strong> → confirmer.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(glisser-déposer du DMG vers Applications)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Double-cliquez sur le fichier <code>.msix</code> téléchargé.</p>
+          <p>2. L'installeur d'applications intégré à Windows s'ouvre. Cliquez sur <strong>Installer</strong>.</p>
+          <p>3. L'app apparaît dans le menu Démarrer — lancez-la depuis là.</p>
+          <p>Si vous voyez "Éditeur inconnu" : ouvrez PowerShell en admin et importez le certificat une fois (voir le <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">guide</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/windows-msix-install.png</code><div>(boîte de dialogue Windows App Installer)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Depuis le terminal :</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>Le <code>postinst</code> installe <code>uv</code>, crée le venv, télécharge le modèle et configure <code>.env</code>. Guide complet : <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">documentation d'installation</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/linux-deb-install.png</code><div>(sortie terminal dpkg/dnf)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Premier lancement</h2>
+      <p>Au premier lancement, Spendif.ai prépare son environnement — c'est l'étape la plus longue, mais elle n'arrive qu'une fois.</p>
+
+      <div class="note">
+        <strong>⏱ Temps requis :</strong> 5–15 minutes sur une connexion domestique typique. Espace libre requis : ~5 Go.<br>
+        Gardez la fenêtre ouverte jusqu'à ce que la barre de progression disparaisse.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + téléchargement du modèle IA</h3>
+          <p>Double-cliquer ouvre une fenêtre native avec un <strong>écran de démarrage</strong> et une barre de progression. Spendif.ai détecte la RAM/VRAM disponible et télécharge le LLM le plus adapté (Qwen 2.5, Gemma 3 — tailles de 2 à 8 Go).</p>
+          <p>Le modèle est stocké dans <code>~/.spendifai/models/</code> (macOS/Linux) ou <code>%APPDATA%\Spendif.ai\models\</code> (Windows) et survit aux réinstallations.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/splash-download-progress.png</code><div>(splash + progression téléchargement modèle)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Assistant d'onboarding — 4 étapes</h3>
+          <p>Une fois le modèle prêt, le splash laisse place à l'<strong>assistant de configuration</strong> :</p>
+          <p>1. <strong>Langue</strong> — taxonomie, format de date, séparateurs numériques.<br>
+             2. <strong>Titulaires</strong> — votre nom et les variantes utilisées par la banque.<br>
+             3. <strong>Comptes</strong> — compte courant, cartes, espèces.<br>
+             4. <strong>Confirmer</strong> — tout est écrit ici uniquement, pas de persistance partielle.</p>
+          <p>Aucun choix n'est définitif : tout peut être modifié plus tard depuis <em>Paramètres</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(assistant étape 1 — choix de la langue)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App prête</h3>
+          <p>À la confirmation, Spendif.ai crée la base SQLite et vous emmène sur la page <strong>Importer</strong>. Depuis là, vous chargez vos premiers CSV/XLSX bancaires.</p>
+          <p>Aux lancements suivants : double-clic → splash (1-2 secondes) → app. Plus de téléchargements, plus d'assistant.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Capture</div><code>assets/screenshots/app-ready-import-page.png</code><div>(app prête, page Importer)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Des problèmes ?</h2>
+      <p>
+        Documentation complète :
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">guide d'installation</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">guide utilisateur</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS détaillé</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows détaillé</a>.
+      </p>
+      <p>Bugs, questions, demandes : <a href="https://github.com/drake69/spendify/issues" target="_blank">ouvrir une issue sur GitHub</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · Licence MIT · <a href="https://github.com/drake69/spendify" target="_blank">Code source sur GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.html
+++ b/getting-started.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Installazione e primo avvio</title>
+  <meta name="description" content="Scarica Spendif.ai per macOS, Windows o Linux. Guida passo-passo a installazione, primo avvio e configurazione iniziale." />
+  <meta property="og:title" content="Spendif.ai — Installazione e primo avvio" />
+  <meta property="og:description" content="Tre passi: scarica, installa, primo avvio. Tutto sul tuo computer, niente cloud." />
+
+  <!-- Cloudflare Web Analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:       #0d1117;
+      --surface:  #161b22;
+      --surface2: #21262d;
+      --border:   #30363d;
+      --blue:     #58a6ff;
+      --green:    #3fb950;
+      --purple:   #bc8cff;
+      --orange:   #e3b341;
+      --red:      #f85149;
+      --text:     #e6edf3;
+      --muted:    #8b949e;
+      --radius:   12px;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+      line-height: 1.6;
+    }
+
+    a { color: var(--blue); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    /* ── Top nav ─────────────────────────────────────────────────────── */
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; }
+    .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; }
+    .lang-switch a { color: var(--blue); }
+
+    /* ── Hero ─────────────────────────────────────────────────────────── */
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+
+    /* ── Layout ───────────────────────────────────────────────────────── */
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+
+    /* ── Download grid ────────────────────────────────────────────────── */
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 1.5rem;
+      transition: border-color 0.2s, transform 0.2s;
+    }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn {
+      display: inline-block;
+      background: var(--blue);
+      color: white;
+      padding: 0.6rem 1.1rem;
+      border-radius: 8px;
+      font-weight: 600;
+      text-decoration: none;
+      transition: opacity 0.2s;
+    }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-btn.alt { background: var(--surface2); color: var(--text); border: 1px solid var(--border); }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+
+    /* ── Steps with screenshots ───────────────────────────────────────── */
+    .step {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 2rem;
+      margin: 2rem 0;
+      align-items: start;
+    }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; }
+    .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) {
+      .step, .step.reverse { grid-template-columns: 1fr; }
+      .step.reverse .step-text, .step.reverse .step-img { order: 0; }
+    }
+    .step-img {
+      background: var(--surface2);
+      border: 1px dashed var(--border);
+      border-radius: var(--radius);
+      aspect-ratio: 16 / 10;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+      text-align: center;
+      padding: 1rem;
+      overflow: hidden;
+    }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph {
+      display: flex; flex-direction: column; align-items: center; gap: 0.5rem;
+    }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+
+    /* ── Boxes ─────────────────────────────────────────────────────────── */
+    .note {
+      background: var(--surface);
+      border-left: 4px solid var(--orange);
+      padding: 1rem 1.2rem;
+      border-radius: 6px;
+      margin: 1.5rem 0;
+    }
+    .note strong { color: var(--orange); }
+
+    /* ── Footer ────────────────────────────────────────────────────────── */
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Scarica</a>
+        <a href="#install">Installa</a>
+        <a href="#first-launch">Primo avvio</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Installazione e primo avvio</h1>
+    <p class="lead">Tre passi per avere Spendif.ai in funzione sul tuo computer: scarica, installa, primo avvio. Tutto offline, niente account.</p>
+  </section>
+
+  <div class="wrap">
+
+    <!-- ── Step 1 — Download ─────────────────────────────────────────── -->
+    <section id="download">
+      <h2><span class="step-num">1</span>Scarica per il tuo sistema</h2>
+      <p>Gli installer ufficiali sono pubblicati come asset di ogni <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Scegli il formato adatto al tuo OS.</p>
+
+      <div class="dl-grid">
+        <!-- macOS -->
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Scarica DMG</a>
+          <div class="dl-notes">macOS 12 Monterey o superiore. Apple Silicon + Intel.</div>
+        </div>
+
+        <!-- Windows -->
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Scarica MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + cert trusted richiesti per la fase pre-alpha.</div>
+        </div>
+
+        <!-- Debian / Ubuntu -->
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Scarica .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+
+        <!-- Fedora / RHEL -->
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Scarica .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Cerchi una versione specifica? Vedi <a href="https://github.com/drake69/spendify/releases" target="_blank">tutte le release</a> · Codice sorgente: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <!-- ── Step 2 — Install ──────────────────────────────────────────── -->
+    <section id="install">
+      <h2><span class="step-num">2</span>Installa</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Doppio click sul file <code>.dmg</code> scaricato.</p>
+          <p>2. Trascina <strong>Spendif.ai.app</strong> nella cartella <strong>Applicazioni</strong>.</p>
+          <p>3. Espelli il DMG (Cmd+E) e lancia l'app dal Launchpad.</p>
+          <p>Se vedi l'avviso "Impossibile aprire perché lo sviluppatore non può essere verificato" (versione non ancora firmata): tasto destro sull'app → <strong>Apri</strong> → conferma.</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: drag-and-drop DMG screenshot -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/macos-dmg-dragdrop.png</code>
+            <div>(drag &amp; drop dal DMG ad Applicazioni)</div>
+          </div>
+          <!-- <img src="assets/screenshots/macos-dmg-dragdrop.png" alt="DMG drag and drop to Applications"> -->
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Doppio click sul file <code>.msix</code> scaricato.</p>
+          <p>2. Si apre l'installer App Installer integrato in Windows. Premi <strong>Installa</strong>.</p>
+          <p>3. L'app appare nello Start Menu e si lancia da lì.</p>
+          <p>Se vedi "Editore sconosciuto": apri PowerShell come admin e importa una volta il certificato (vedi <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">guida</a>).</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: Windows App Installer dialog -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/windows-msix-install.png</code>
+            <div>(App Installer di Windows)</div>
+          </div>
+          <!-- <img src="assets/screenshots/windows-msix-install.png" alt="Windows App Installer"> -->
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Da terminale:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>Il <code>postinst</code> installa <code>uv</code>, crea il venv, scarica il modello e configura <code>.env</code>. Vedi <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.md" target="_blank">guida completa</a>.</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: Linux terminal install output -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/linux-deb-install.png</code>
+            <div>(output terminale dpkg/dnf)</div>
+          </div>
+          <!-- <img src="assets/screenshots/linux-deb-install.png" alt="Linux install output"> -->
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Step 3 — First launch ─────────────────────────────────────── -->
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Primo avvio</h2>
+      <p>Al primo avvio Spendif.ai prepara l'ambiente — è il passaggio più lungo, ma succede solo la prima volta.</p>
+
+      <div class="note">
+        <strong>⏱ Tempo richiesto:</strong> 5–15 minuti su connessione casa tipica. Spazio libero richiesto: ~5 GB.<br>
+        Tieni la finestra aperta finché la barra di progresso non scompare.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + download modello AI</h3>
+          <p>Al doppio click si apre una finestra nativa con uno <strong>splash screen</strong> e una barra di progresso. Spendif.ai rileva la RAM/VRAM disponibile e scarica il modello LLM più adatto (Qwen 2.5, Gemma 3, dimensioni da 2 a 8 GB).</p>
+          <p>Il modello finisce in <code>~/.spendifai/models/</code> (macOS/Linux) o <code>%APPDATA%\Spendif.ai\models\</code> (Windows) e sopravvive a reinstallazioni.</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: splash screen with progress -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/splash-download-progress.png</code>
+            <div>(splash + barra progresso download modello)</div>
+          </div>
+          <!-- <img src="assets/screenshots/splash-download-progress.png" alt="Splash screen with model download progress"> -->
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Wizard di onboarding — 4 step</h3>
+          <p>Quando il modello è pronto, lo splash lascia spazio al <strong>wizard di configurazione</strong>:</p>
+          <p>1. <strong>Lingua</strong> — tassonomia, formato date e separatori numerici.<br>
+             2. <strong>Titolari</strong> — il tuo nome e le varianti usate dalla banca.<br>
+             3. <strong>Conti</strong> — conto corrente, carte, contanti.<br>
+             4. <strong>Conferma</strong> — tutto viene scritto solo qui, nessuna persistenza parziale.</p>
+          <p>Nessuna scelta è definitiva: puoi cambiare tutto da <em>Impostazioni</em> in seguito.</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: onboarding wizard step 1 -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/onboarding-step-1-language.png</code>
+            <div>(wizard step 1 — selezione lingua)</div>
+          </div>
+          <!-- <img src="assets/screenshots/onboarding-step-1-language.png" alt="Onboarding step 1 — language"> -->
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App pronta</h3>
+          <p>Al confirm del wizard, Spendif.ai crea il database SQLite e ti porta sulla pagina <strong>Import</strong>. Da qui carichi i primi CSV/XLSX della tua banca.</p>
+          <p>Dai successivi avvii il flusso è: doppio click → splash (1-2 secondi) → app. Niente più download, niente più wizard.</p>
+        </div>
+        <div class="step-img">
+          <!-- PLACEHOLDER: main app with import page -->
+          <div class="ph">
+            <div>📷 Screenshot</div>
+            <code>assets/screenshots/app-ready-import-page.png</code>
+            <div>(app pronta, pagina Import)</div>
+          </div>
+          <!-- <img src="assets/screenshots/app-ready-import-page.png" alt="App ready — import page"> -->
+        </div>
+      </div>
+    </section>
+
+    <!-- ── Help ──────────────────────────────────────────────────────── -->
+    <section id="help">
+      <h2>Hai problemi?</h2>
+      <p>
+        Documentazione completa:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.md" target="_blank">guida installazione</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.md" target="_blank">guida utente</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.it.md" target="_blank">macOS dettagliata</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.it.md" target="_blank">Windows dettagliata</a>.
+      </p>
+      <p>Bug, domande, richieste: <a href="https://github.com/drake69/spendify/issues" target="_blank">apri una issue su GitHub</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendify" target="_blank">Source on GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.ja.html
+++ b/getting-started.ja.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — インストールと初回起動</title>
+  <meta name="description" content="macOS、Windows、Linux 向けに Spendif.ai をダウンロード。インストール、初回起動、初期設定までのステップガイド。" />
+  <meta property="og:title" content="Spendif.ai — インストールと初回起動" />
+  <meta property="og:description" content="ダウンロード、インストール、初回起動の 3 ステップ。すべてオフライン、クラウド不要。" />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic", "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">ダウンロード</a>
+        <a href="#install">インストール</a>
+        <a href="#first-launch">初回起動</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>インストールと初回起動</h1>
+    <p class="lead">Spendif.ai をお使いのコンピューターで動かすための 3 ステップ: ダウンロード、インストール、初回起動。すべてオフライン、アカウント不要です。</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>お使いの OS 用にダウンロード</h2>
+      <p>公式インストーラーは各 <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a> のアセットとして公開されています。OS に合ったフォーマットを選んでください。</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">DMG をダウンロード</a>
+          <div class="dl-notes">macOS 12 Monterey 以降。Apple Silicon + Intel 対応。</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">MSIX をダウンロード</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11。プレアルファ期間中はサイドロード + 信頼された証明書が必要です。</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.deb をダウンロード</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+。</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.rpm をダウンロード</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+。</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">特定のバージョンをお探しですか? <a href="https://github.com/drake69/spendify/releases" target="_blank">すべてのリリース</a>を参照 · ソースコード: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>。</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>インストール</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. ダウンロードした <code>.dmg</code> ファイルをダブルクリックします。</p>
+          <p>2. <strong>Spendif.ai.app</strong> を <strong>アプリケーション</strong> フォルダにドラッグします。</p>
+          <p>3. DMG を取り出し (Cmd+E)、Launchpad からアプリを起動します。</p>
+          <p>「開発元を確認できないため、Spendif.ai を開けません」と表示された場合 (まだ署名されていないビルド): アプリを右クリック → <strong>開く</strong> → 確認。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(DMG からアプリケーションへドラッグ &amp; ドロップ)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. ダウンロードした <code>.msix</code> ファイルをダブルクリックします。</p>
+          <p>2. Windows 内蔵のアプリ インストーラーが開きます。<strong>インストール</strong> をクリックします。</p>
+          <p>3. アプリがスタートメニューに表示されます — そこから起動します。</p>
+          <p>「不明な発行元」と表示された場合: 管理者として PowerShell を開き、証明書を一度インポートしてください (<a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">ガイド</a>参照)。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/windows-msix-install.png</code><div>(Windows アプリ インストーラーのダイアログ)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>ターミナルから:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p><code>postinst</code> が <code>uv</code> をインストールし、venv を作成し、モデルをダウンロードして <code>.env</code> を構成します。完全なガイド: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">インストールドキュメント</a>。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/linux-deb-install.png</code><div>(dpkg/dnf のターミナル出力)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>初回起動</h2>
+      <p>初回起動時、Spendif.ai は環境をセットアップします — 一番時間がかかるステップですが、一度だけです。</p>
+
+      <div class="note">
+        <strong>⏱ 所要時間:</strong> 一般的な家庭用回線で 5〜15 分。必要な空き容量: 約 5 GB。<br>
+        プログレスバーが消えるまでウィンドウを開いたままにしてください。
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. スプラッシュ + AI モデルのダウンロード</h3>
+          <p>ダブルクリックで、<strong>スプラッシュ画面</strong>とプログレスバーを備えたネイティブウィンドウが開きます。Spendif.ai は利用可能な RAM/VRAM を検出し、最も適した LLM をダウンロードします (Qwen 2.5、Gemma 3 — 2〜8 GB)。</p>
+          <p>モデルは <code>~/.spendifai/models/</code> (macOS/Linux) または <code>%APPDATA%\Spendif.ai\models\</code> (Windows) に保存され、再インストールしても残ります。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/splash-download-progress.png</code><div>(スプラッシュ + モデルダウンロード進捗)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. オンボーディング ウィザード — 4 ステップ</h3>
+          <p>モデルの準備ができると、スプラッシュは <strong>設定ウィザード</strong> に切り替わります:</p>
+          <p>1. <strong>言語</strong> — 分類体系、日付形式、数値区切り。<br>
+             2. <strong>名義人</strong> — あなたの名前と銀行が使うバリエーション。<br>
+             3. <strong>口座</strong> — 当座預金、カード、現金。<br>
+             4. <strong>確認</strong> — すべてここでのみ書き込まれ、部分的な永続化はありません。</p>
+          <p>どの選択も最終的ではありません: 後から <em>設定</em> で変更できます。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(ウィザード ステップ 1 — 言語選択)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. アプリ準備完了</h3>
+          <p>ウィザードの確認時に、Spendif.ai は SQLite データベースを作成し、<strong>インポート</strong> ページに移動します。そこから最初の銀行 CSV/XLSX ファイルを読み込みます。</p>
+          <p>次回以降の起動フローは: ダブルクリック → スプラッシュ (1〜2 秒) → アプリ。ダウンロードもウィザードもありません。</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 スクリーンショット</div><code>assets/screenshots/app-ready-import-page.png</code><div>(アプリ準備完了、インポート ページ)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>困りごとがありますか?</h2>
+      <p>
+        完全なドキュメント:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">インストールガイド</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">ユーザーガイド</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS 詳細</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows 詳細</a>。
+      </p>
+      <p>バグ、質問、要望: <a href="https://github.com/drake69/spendify/issues" target="_blank">GitHub Issue を開く</a>。</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendify" target="_blank">GitHub のソースコード</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.nl.html
+++ b/getting-started.nl.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Installatie &amp; eerste start</title>
+  <meta name="description" content="Download Spendif.ai voor macOS, Windows of Linux. Stapsgewijze gids voor installatie, eerste start en initiële configuratie." />
+  <meta property="og:title" content="Spendif.ai — Installatie &amp; eerste start" />
+  <meta property="og:description" content="Drie stappen: downloaden, installeren, eerste start. Alles offline, geen account." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Downloaden</a>
+        <a href="#install">Installeren</a>
+        <a href="#first-launch">Eerste start</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.pl.html">PL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Installatie &amp; eerste start</h1>
+    <p class="lead">Drie stappen om Spendif.ai op je computer te laten draaien: downloaden, installeren, eerste start. Alles offline, geen account nodig.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Download voor jouw systeem</h2>
+      <p>De officiële installers worden gepubliceerd als assets van elke <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Kies het juiste formaat voor je OS.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">DMG downloaden</a>
+          <div class="dl-notes">macOS 12 Monterey of nieuwer. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">MSIX downloaden</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + vertrouwd certificaat vereist in de pre-alpha-fase.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.deb downloaden</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">.rpm downloaden</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Op zoek naar een specifieke versie? Bekijk <a href="https://github.com/drake69/spendify/releases" target="_blank">alle releases</a> · Broncode: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Installeren</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Dubbelklik op het gedownloade <code>.dmg</code>-bestand.</p>
+          <p>2. Sleep <strong>Spendif.ai.app</strong> naar de map <strong>Programma's</strong>.</p>
+          <p>3. Eject de DMG (Cmd+E) en start de app vanuit Launchpad.</p>
+          <p>Als je "Kan Spendif.ai niet openen omdat de ontwikkelaar niet kan worden geverifieerd" ziet (build nog niet ondertekend): rechtermuisklik op de app → <strong>Open</strong> → bevestigen.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(slepen &amp; neerzetten van DMG naar Programma's)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Dubbelklik op het gedownloade <code>.msix</code>-bestand.</p>
+          <p>2. De ingebouwde App Installer van Windows opent. Klik op <strong>Installeren</strong>.</p>
+          <p>3. De app verschijnt in het Startmenu — start hem daar vandaan.</p>
+          <p>Als je "Onbekende uitgever" ziet: open PowerShell als beheerder en importeer het certificaat eenmalig (zie de <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">handleiding</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/windows-msix-install.png</code><div>(Windows App Installer dialoog)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Vanuit de terminal:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>De <code>postinst</code> installeert <code>uv</code>, maakt het venv aan, downloadt het model en schrijft <code>.env</code>. Volledige handleiding: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">install guide</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/linux-deb-install.png</code><div>(dpkg/dnf terminaloutput)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Eerste start</h2>
+      <p>Bij de eerste start zet Spendif.ai zijn omgeving op — dat is de langste stap, maar gebeurt slechts één keer.</p>
+
+      <div class="note">
+        <strong>⏱ Benodigde tijd:</strong> 5–15 minuten bij een typische thuisverbinding. Benodigde vrije ruimte: ~5 GB.<br>
+        Houd het venster open tot de voortgangsbalk verdwijnt.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + AI-model download</h3>
+          <p>Dubbelklikken opent een native venster met een <strong>splashscreen</strong> en voortgangsbalk. Spendif.ai detecteert beschikbaar RAM/VRAM en downloadt het meest geschikte LLM (Qwen 2.5, Gemma 3 — formaten van 2 tot 8 GB).</p>
+          <p>Het model staat in <code>~/.spendifai/models/</code> (macOS/Linux) of <code>%APPDATA%\Spendif.ai\models\</code> (Windows) en blijft staan bij herinstallaties.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/splash-download-progress.png</code><div>(splash + voortgang modeldownload)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Onboarding-wizard — 4 stappen</h3>
+          <p>Zodra het model klaar is, maakt het splash plaats voor de <strong>configuratiewizard</strong>:</p>
+          <p>1. <strong>Taal</strong> — taxonomie, datumnotatie, numerieke scheidingstekens.<br>
+             2. <strong>Houders</strong> — je naam en de varianten die je bank gebruikt.<br>
+             3. <strong>Rekeningen</strong> — betaalrekening, kaarten, contant geld.<br>
+             4. <strong>Bevestigen</strong> — alles wordt alleen hier geschreven, geen gedeeltelijke persistentie.</p>
+          <p>Geen enkele keuze is definitief: je kunt alles later wijzigen via <em>Instellingen</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(wizard stap 1 — taalkeuze)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App klaar</h3>
+          <p>Bij bevestiging maakt Spendif.ai de SQLite-database aan en brengt je naar de <strong>Import</strong>-pagina. Vanaf daar laad je je eerste bank-CSV/XLSX-bestanden.</p>
+          <p>Bij volgende keren is de flow: dubbelklik → splash (1-2 seconden) → app. Geen downloads meer, geen wizard meer.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Schermafbeelding</div><code>assets/screenshots/app-ready-import-page.png</code><div>(app klaar, Import-pagina)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Problemen?</h2>
+      <p>
+        Volledige documentatie:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">installatiehandleiding</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">gebruikershandleiding</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS detail</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows detail</a>.
+      </p>
+      <p>Bugs, vragen, verzoeken: <a href="https://github.com/drake69/spendify/issues" target="_blank">open een issue op GitHub</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · MIT-licentie · <a href="https://github.com/drake69/spendify" target="_blank">Broncode op GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.pl.html
+++ b/getting-started.pl.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Instalacja i pierwsze uruchomienie</title>
+  <meta name="description" content="Pobierz Spendif.ai dla macOS, Windows lub Linux. Przewodnik krok po kroku po instalacji, pierwszym uruchomieniu i wstępnej konfiguracji." />
+  <meta property="og:title" content="Spendif.ai — Instalacja i pierwsze uruchomienie" />
+  <meta property="og:description" content="Trzy kroki: pobierz, zainstaluj, pierwsze uruchomienie. Wszystko offline, bez chmury." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Pobierz</a>
+        <a href="#install">Instaluj</a>
+        <a href="#first-launch">Pierwsze uruchomienie</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pt.html">PT</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Instalacja i pierwsze uruchomienie</h1>
+    <p class="lead">Trzy kroki, aby uruchomić Spendif.ai na komputerze: pobierz, zainstaluj, pierwsze uruchomienie. Wszystko offline, bez konta.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Pobierz dla swojego systemu</h2>
+      <p>Oficjalne instalatory są publikowane jako zasoby każdego <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Wybierz format odpowiedni dla Twojego systemu.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Pobierz DMG</a>
+          <div class="dl-notes">macOS 12 Monterey lub nowszy. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Pobierz MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. W fazie pre-alfa wymagany sideload + zaufany certyfikat.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Pobierz .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Pobierz .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Szukasz konkretnej wersji? Zobacz <a href="https://github.com/drake69/spendify/releases" target="_blank">wszystkie wydania</a> · Kod źródłowy: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Instaluj</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Kliknij dwukrotnie pobrany plik <code>.dmg</code>.</p>
+          <p>2. Przeciągnij <strong>Spendif.ai.app</strong> do folderu <strong>Programy</strong>.</p>
+          <p>3. Wysuń DMG (Cmd+E) i uruchom aplikację z Launchpada.</p>
+          <p>Jeśli widzisz "Nie można otworzyć Spendif.ai, ponieważ nie można zweryfikować dewelopera" (kompilacja jeszcze niepodpisana): kliknij prawym przyciskiem na aplikację → <strong>Otwórz</strong> → potwierdź.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(przeciąganie z DMG do Programów)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Kliknij dwukrotnie pobrany plik <code>.msix</code>.</p>
+          <p>2. Otworzy się wbudowany Instalator Aplikacji Windows. Kliknij <strong>Zainstaluj</strong>.</p>
+          <p>3. Aplikacja pojawi się w Menu Start — uruchom ją stamtąd.</p>
+          <p>Jeśli widzisz "Nieznany wydawca": otwórz PowerShell jako administrator i zaimportuj certyfikat jednorazowo (zobacz <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">przewodnik</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/windows-msix-install.png</code><div>(okno dialogowe Instalatora Aplikacji Windows)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>Z terminala:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p><code>postinst</code> instaluje <code>uv</code>, tworzy venv, pobiera model i konfiguruje <code>.env</code>. Pełny przewodnik: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">dokumentacja instalacji</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/linux-deb-install.png</code><div>(wyjście terminala dpkg/dnf)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Pierwsze uruchomienie</h2>
+      <p>Przy pierwszym uruchomieniu Spendif.ai konfiguruje środowisko — to najdłuższy krok, ale wykonywany tylko raz.</p>
+
+      <div class="note">
+        <strong>⏱ Wymagany czas:</strong> 5–15 minut na typowym domowym łączu. Wymagane wolne miejsce: ~5 GB.<br>
+        Trzymaj okno otwarte, dopóki pasek postępu nie zniknie.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + pobieranie modelu AI</h3>
+          <p>Podwójne kliknięcie otwiera natywne okno z <strong>ekranem powitalnym</strong> i paskiem postępu. Spendif.ai wykrywa dostępny RAM/VRAM i pobiera najbardziej odpowiedni LLM (Qwen 2.5, Gemma 3 — rozmiary od 2 do 8 GB).</p>
+          <p>Model trafia do <code>~/.spendifai/models/</code> (macOS/Linux) lub <code>%APPDATA%\Spendif.ai\models\</code> (Windows) i przetrwa reinstalacje.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/splash-download-progress.png</code><div>(splash + postęp pobierania modelu)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Kreator wprowadzający — 4 kroki</h3>
+          <p>Gdy model jest gotowy, splash ustępuje miejsca <strong>kreatorowi konfiguracji</strong>:</p>
+          <p>1. <strong>Język</strong> — taksonomia, format daty, separatory liczbowe.<br>
+             2. <strong>Właściciele</strong> — Twoje imię i warianty używane przez bank.<br>
+             3. <strong>Konta</strong> — konto bieżące, karty, gotówka.<br>
+             4. <strong>Potwierdź</strong> — wszystko jest zapisywane tylko tutaj, brak częściowej trwałości.</p>
+          <p>Żaden wybór nie jest ostateczny: możesz zmienić wszystko później w <em>Ustawieniach</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(kreator krok 1 — wybór języka)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. Aplikacja gotowa</h3>
+          <p>Po potwierdzeniu Spendif.ai tworzy bazę SQLite i przenosi Cię do strony <strong>Import</strong>. Stamtąd ładujesz pierwsze pliki CSV/XLSX z banku.</p>
+          <p>Przy kolejnych uruchomieniach przebieg to: podwójne kliknięcie → splash (1-2 sekundy) → aplikacja. Bez pobierania, bez kreatora.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Zrzut ekranu</div><code>assets/screenshots/app-ready-import-page.png</code><div>(aplikacja gotowa, strona Import)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Masz problem?</h2>
+      <p>
+        Pełna dokumentacja:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">przewodnik instalacji</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">przewodnik użytkownika</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS szczegółowo</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows szczegółowo</a>.
+      </p>
+      <p>Błędy, pytania, prośby: <a href="https://github.com/drake69/spendify/issues" target="_blank">otwórz issue na GitHubie</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · Licencja MIT · <a href="https://github.com/drake69/spendify" target="_blank">Kod źródłowy na GitHubie</a></p>
+  </footer>
+</body>
+</html>

--- a/getting-started.pt.html
+++ b/getting-started.pt.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Spendif.ai — Instalação e primeira execução</title>
+  <meta name="description" content="Baixe o Spendif.ai para macOS, Windows ou Linux. Guia passo a passo para instalação, primeira execução e configuração inicial." />
+  <meta property="og:title" content="Spendif.ai — Instalação e primeira execução" />
+  <meta property="og:description" content="Três passos: baixar, instalar, primeira execução. Tudo offline, sem nuvem." />
+
+  <!-- Cloudflare Web Analytics — privacy-friendly, cookie-less analytics -->
+  <script defer src="https://static.cloudflareinsights.com/beacon.min.js" data-cf-beacon='{"token": "cf66fd7e52d248d9afaadeeedb0ea166"}'></script>
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root { --bg:#0d1117; --surface:#161b22; --surface2:#21262d; --border:#30363d; --blue:#58a6ff; --green:#3fb950; --purple:#bc8cff; --orange:#e3b341; --red:#f85149; --text:#e6edf3; --muted:#8b949e; --radius:12px; }
+    html { scroll-behavior: smooth; }
+    body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif; line-height: 1.6; }
+    a { color: var(--blue); text-decoration: none; } a:hover { text-decoration: underline; }
+    .nav { position: sticky; top: 0; background: rgba(13,17,23,0.92); backdrop-filter: blur(12px); border-bottom: 1px solid var(--border); z-index: 100; }
+    .nav-inner { max-width: 1100px; margin: 0 auto; padding: 1rem 1.5rem; display: flex; justify-content: space-between; align-items: center; }
+    .nav-brand { font-weight: 700; font-size: 1.15rem; } .nav-brand a { color: var(--text); }
+    .nav-links { display: flex; gap: 1.5rem; align-items: center; }
+    .nav-links a { color: var(--muted); font-size: 0.95rem; }
+    .lang-switch { color: var(--muted); font-size: 0.9rem; } .lang-switch a { color: var(--blue); }
+    .hero { padding: 4rem 1.5rem 2rem; text-align: center; }
+    .hero h1 { font-size: 2.4rem; line-height: 1.2; margin-bottom: 0.8rem; }
+    .hero .lead { font-size: 1.15rem; color: var(--muted); max-width: 640px; margin: 0 auto; }
+    .wrap { max-width: 1100px; margin: 0 auto; padding: 0 1.5rem 4rem; }
+    section { margin-top: 3.5rem; }
+    h2 { font-size: 1.6rem; margin-bottom: 1rem; }
+    h3 { font-size: 1.2rem; margin: 1.5rem 0 0.8rem; color: var(--text); }
+    p { color: var(--muted); margin-bottom: 0.8rem; }
+    .step-num { display: inline-block; width: 2.2rem; height: 2.2rem; border-radius: 50%; background: var(--blue); color: white; text-align: center; line-height: 2.2rem; font-weight: 700; margin-right: 0.8rem; vertical-align: middle; }
+    .dl-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; margin-top: 1.5rem; }
+    .dl-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 1.5rem; transition: border-color 0.2s, transform 0.2s; }
+    .dl-card:hover { border-color: var(--blue); transform: translateY(-2px); }
+    .dl-card h3 { margin: 0 0 0.5rem; color: var(--text); }
+    .dl-card .os-icon { font-size: 2rem; margin-bottom: 0.5rem; }
+    .dl-card .ext { color: var(--muted); font-size: 0.85rem; font-family: monospace; margin-bottom: 1rem; }
+    .dl-btn { display: inline-block; background: var(--blue); color: white; padding: 0.6rem 1.1rem; border-radius: 8px; font-weight: 600; text-decoration: none; transition: opacity 0.2s; }
+    .dl-btn:hover { opacity: 0.9; text-decoration: none; }
+    .dl-notes { color: var(--muted); font-size: 0.85rem; margin-top: 0.8rem; }
+    .step { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin: 2rem 0; align-items: start; }
+    .step.reverse { grid-template-columns: 1fr 1fr; }
+    .step.reverse .step-text { order: 2; } .step.reverse .step-img { order: 1; }
+    @media (max-width: 720px) { .step, .step.reverse { grid-template-columns: 1fr; } .step.reverse .step-text, .step.reverse .step-img { order: 0; } }
+    .step-img { background: var(--surface2); border: 1px dashed var(--border); border-radius: var(--radius); aspect-ratio: 16 / 10; display: flex; align-items: center; justify-content: center; color: var(--muted); font-size: 0.9rem; text-align: center; padding: 1rem; overflow: hidden; }
+    .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
+    .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
+    .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+    .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
+    .note strong { color: var(--orange); }
+    footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
+    footer a { color: var(--blue); }
+  </style>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <div class="nav-brand"><a href="/">Spendif.ai</a></div>
+      <div class="nav-links">
+        <a href="#download">Baixar</a>
+        <a href="#install">Instalar</a>
+        <a href="#first-launch">Primeira execução</a>
+        <span class="lang-switch">🌐 <a href="getting-started.en.html">EN</a> · <a href="getting-started.html">IT</a> · <a href="getting-started.de.html">DE</a> · <a href="getting-started.es.html">ES</a> · <a href="getting-started.fr.html">FR</a> · <a href="getting-started.ja.html">JA</a> · <a href="getting-started.nl.html">NL</a> · <a href="getting-started.pl.html">PL</a></span>
+      </div>
+    </div>
+  </nav>
+
+  <section class="hero">
+    <h1>Instalação e primeira execução</h1>
+    <p class="lead">Três passos para deixar o Spendif.ai rodando no seu computador: baixar, instalar, primeira execução. Tudo offline, sem conta.</p>
+  </section>
+
+  <div class="wrap">
+
+    <section id="download">
+      <h2><span class="step-num">1</span>Baixe para o seu sistema</h2>
+      <p>Os instaladores oficiais são publicados como assets de cada <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Escolha o formato adequado para o seu SO.</p>
+
+      <div class="dl-grid">
+        <div class="dl-card">
+          <div class="os-icon">🍎</div>
+          <h3>macOS</h3>
+          <div class="ext">SpendifAi-*.dmg</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Baixar DMG</a>
+          <div class="dl-notes">macOS 12 Monterey ou superior. Apple Silicon + Intel.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🪟</div>
+          <h3>Windows</h3>
+          <div class="ext">SpendifAi-*.msix</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Baixar MSIX</a>
+          <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + certificado confiável necessários na fase pre-alpha.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🐧</div>
+          <h3>Debian / Ubuntu</h3>
+          <div class="ext">spendifai_*_amd64.deb</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Baixar .deb</a>
+          <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
+        </div>
+        <div class="dl-card">
+          <div class="os-icon">🎩</div>
+          <h3>Fedora / RHEL</h3>
+          <div class="ext">spendifai-*.rpm</div>
+          <a class="dl-btn" href="https://github.com/drake69/spendify/releases/latest" target="_blank">Baixar .rpm</a>
+          <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
+        </div>
+      </div>
+
+      <p class="dl-notes" style="margin-top:1.5rem">Procurando uma versão específica? Veja <a href="https://github.com/drake69/spendify/releases" target="_blank">todas as releases</a> · Código-fonte: <a href="https://github.com/drake69/spendify" target="_blank">drake69/spendify</a>.</p>
+    </section>
+
+    <section id="install">
+      <h2><span class="step-num">2</span>Instalar</h2>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>macOS — DMG</h3>
+          <p>1. Dê duplo clique no arquivo <code>.dmg</code> baixado.</p>
+          <p>2. Arraste <strong>Spendif.ai.app</strong> para a pasta <strong>Aplicativos</strong>.</p>
+          <p>3. Ejete o DMG (Cmd+E) e inicie o app pelo Launchpad.</p>
+          <p>Se você vir "Não é possível abrir o Spendif.ai porque o desenvolvedor não pode ser verificado" (build ainda não assinada): clique com o botão direito no app → <strong>Abrir</strong> → confirmar.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/macos-dmg-dragdrop.png</code><div>(arrastar e soltar do DMG para Aplicativos)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>Windows — MSIX</h3>
+          <p>1. Dê duplo clique no arquivo <code>.msix</code> baixado.</p>
+          <p>2. O Instalador de Aplicativos integrado do Windows abre. Clique em <strong>Instalar</strong>.</p>
+          <p>3. O app aparece no Menu Iniciar — abra a partir dali.</p>
+          <p>Se você vir "Editor desconhecido": abra o PowerShell como administrador e importe o certificado uma vez (veja o <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">guia</a>).</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/windows-msix-install.png</code><div>(diálogo do Instalador de Aplicativos do Windows)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>Linux — .deb / .rpm</h3>
+          <p>No terminal:</p>
+          <p><code>sudo apt install ./spendifai_*.deb</code> &nbsp;(Debian/Ubuntu)</p>
+          <p><code>sudo dnf install ./spendifai-*.rpm</code> &nbsp;(Fedora/RHEL)</p>
+          <p>O <code>postinst</code> instala o <code>uv</code>, cria o venv, baixa o modelo e configura o <code>.env</code>. Guia completo: <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">documentação de instalação</a>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/linux-deb-install.png</code><div>(saída do terminal dpkg/dnf)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="first-launch">
+      <h2><span class="step-num">3</span>Primeira execução</h2>
+      <p>Na primeira execução, o Spendif.ai prepara o ambiente — é o passo mais longo, mas acontece apenas uma vez.</p>
+
+      <div class="note">
+        <strong>⏱ Tempo necessário:</strong> 5–15 minutos numa conexão doméstica típica. Espaço livre necessário: ~5 GB.<br>
+        Mantenha a janela aberta até a barra de progresso desaparecer.
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3a. Splash + download do modelo de IA</h3>
+          <p>Ao dar duplo clique, abre-se uma janela nativa com uma <strong>tela de abertura</strong> e barra de progresso. O Spendif.ai detecta a RAM/VRAM disponível e baixa o LLM mais adequado (Qwen 2.5, Gemma 3 — tamanhos de 2 a 8 GB).</p>
+          <p>O modelo fica em <code>~/.spendifai/models/</code> (macOS/Linux) ou <code>%APPDATA%\Spendif.ai\models\</code> (Windows) e sobrevive a reinstalações.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/splash-download-progress.png</code><div>(splash + progresso do download do modelo)</div></div>
+        </div>
+      </div>
+
+      <div class="step reverse">
+        <div class="step-text">
+          <h3>3b. Assistente de onboarding — 4 passos</h3>
+          <p>Quando o modelo estiver pronto, a splash dá lugar ao <strong>assistente de configuração</strong>:</p>
+          <p>1. <strong>Idioma</strong> — taxonomia, formato de data, separadores numéricos.<br>
+             2. <strong>Titulares</strong> — seu nome e as variantes usadas pelo banco.<br>
+             3. <strong>Contas</strong> — conta corrente, cartões, dinheiro.<br>
+             4. <strong>Confirmar</strong> — tudo é gravado apenas aqui, sem persistência parcial.</p>
+          <p>Nenhuma escolha é definitiva: você pode alterar tudo depois em <em>Configurações</em>.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/onboarding-step-1-language.png</code><div>(assistente passo 1 — seleção de idioma)</div></div>
+        </div>
+      </div>
+
+      <div class="step">
+        <div class="step-text">
+          <h3>3c. App pronto</h3>
+          <p>Ao confirmar, o Spendif.ai cria o banco de dados SQLite e leva você para a página <strong>Importar</strong>. A partir daí, você carrega os primeiros arquivos CSV/XLSX do seu banco.</p>
+          <p>Nas execuções seguintes o fluxo é: duplo clique → splash (1-2 segundos) → app. Sem mais downloads, sem mais assistente.</p>
+        </div>
+        <div class="step-img">
+          <div class="ph"><div>📷 Captura</div><code>assets/screenshots/app-ready-import-page.png</code><div>(app pronto, página Importar)</div></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="help">
+      <h2>Com problemas?</h2>
+      <p>
+        Documentação completa:
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installazione.en.md" target="_blank">guia de instalação</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/guida_utente.en.md" target="_blank">guia do usuário</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_macos.md" target="_blank">macOS detalhado</a> ·
+        <a href="https://github.com/drake69/spendify/blob/main/docs/installation_windows.md" target="_blank">Windows detalhado</a>.
+      </p>
+      <p>Bugs, dúvidas, pedidos: <a href="https://github.com/drake69/spendify/issues" target="_blank">abra uma issue no GitHub</a>.</p>
+    </section>
+
+  </div>
+
+  <footer>
+    <p>© 2026 Luigi Corsaro · Spendif.ai · Licença MIT · <a href="https://github.com/drake69/spendify" target="_blank">Código-fonte no GitHub</a></p>
+  </footer>
+</body>
+</html>

--- a/index.de.html
+++ b/index.de.html
@@ -985,6 +985,13 @@
     <h2>Ein Befehl, App bereit</h2>
     <p class="section-sub">Native Desktop-App mit integrierter lokaler KI. Kein Docker, kein dauerhaft offenes Terminal.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.de.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Installer herunterladen (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Schritt-für-Schritt-Anleitung mit Screenshots → <a href="getting-started.de.html">Installation &amp; erster Start</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— oder, über das Terminal: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.en.html
+++ b/index.en.html
@@ -984,6 +984,13 @@
     <h2>One command, app ready</h2>
     <p class="section-sub">Native desktop app with local AI included. No Docker, no Terminal kept open.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.en.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Download installer (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Step-by-step guide with screenshots → <a href="getting-started.en.html">install &amp; first launch</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— or, from the terminal: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.es.html
+++ b/index.es.html
@@ -984,6 +984,13 @@
     <h2>Un comando, aplicación lista</h2>
     <p class="section-sub">App de escritorio nativa con IA local incluida. Sin Docker, sin Terminal siempre abierto.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.es.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Descargar instalador (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Guía paso a paso con capturas → <a href="getting-started.es.html">instalación y primer inicio</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— o, desde la terminal: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.fr.html
+++ b/index.fr.html
@@ -984,6 +984,13 @@
     <h2>Une commande, application prête</h2>
     <p class="section-sub">Application de bureau native avec IA locale incluse. Pas de Docker, pas de Terminal toujours ouvert.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.fr.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Télécharger l'installeur (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Guide pas-à-pas avec captures d'écran → <a href="getting-started.fr.html">installation et premier lancement</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— ou, depuis le terminal : —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.html
+++ b/index.html
@@ -984,6 +984,13 @@
     <h2>Un comando, l'app è pronta</h2>
     <p class="section-sub">App desktop nativa con AI locale inclusa. Niente Docker, niente Terminal sempre aperto.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Scarica l'installer (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Guida passo-passo con screenshot → <a href="getting-started.html">installazione e primo avvio</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— oppure, da terminale: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.ja.html
+++ b/index.ja.html
@@ -982,6 +982,13 @@
     <h2>1コマンドで、アプリの準備完了</h2>
     <p class="section-sub">ローカルAI同梱のネイティブデスクトップアプリです。Dockerは不要、ターミナルを開いたままにする必要もありません。</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.ja.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 インストーラーをダウンロード (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">スクリーンショット付きステップガイド → <a href="getting-started.ja.html">インストールと初回起動</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— または、ターミナルから: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.nl.html
+++ b/index.nl.html
@@ -984,6 +984,13 @@
     <h2>Eén commando, app klaar voor gebruik</h2>
     <p class="section-sub">Native desktop-app met lokale AI inbegrepen. Geen Docker, geen Terminal die openblijft.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.nl.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Installer downloaden (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Stapsgewijze gids met schermafbeeldingen → <a href="getting-started.nl.html">installatie &amp; eerste start</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— of, vanuit de terminal: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.pl.html
+++ b/index.pl.html
@@ -984,6 +984,13 @@
     <h2>Jedno polecenie, aplikacja gotowa</h2>
     <p class="section-sub">Natywna aplikacja desktopowa z lokalnym AI w komplecie. Bez Dockera, bez utrzymywania otwartego terminala.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.pl.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Pobierz instalator (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Przewodnik krok po kroku ze zrzutami → <a href="getting-started.pl.html">instalacja i pierwsze uruchomienie</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— lub z terminala: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/index.pt.html
+++ b/index.pt.html
@@ -984,6 +984,13 @@
     <h2>Um comando, app pronto</h2>
     <p class="section-sub">App desktop nativa com IA local incluída. Sem Docker, sem Terminal sempre aberto.</p>
 
+    <p style="text-align:center;margin:1.5rem 0 2.5rem;">
+      <a href="getting-started.pt.html" style="display:inline-block;background:var(--blue);color:#fff;padding:0.75rem 1.5rem;border-radius:8px;font-weight:600;text-decoration:none;">📥 Baixar instalador (DMG · MSIX · .deb · .rpm)</a><br>
+      <span style="color:var(--muted);font-size:0.9rem;">Guia passo a passo com capturas → <a href="getting-started.pt.html">instalação e primeira execução</a></span>
+    </p>
+
+    <p style="text-align:center;color:var(--muted);margin-bottom:1.5rem;">— ou, pelo terminal: —</p>
+
     <div class="os-tabs">
       <button class="os-tab active" onclick="switchOS('mac')">🍎 macOS</button>
       <button class="os-tab" onclick="switchOS('deb')">🐧 Debian / Ubuntu</button>

--- a/packaging/macos/build-dmg.sh
+++ b/packaging/macos/build-dmg.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Spendif.ai — macOS DMG builder (local + CI parity)
+#
+#  Produces: build/SpendifAi-<version>.dmg (unsigned)
+#
+#  USAGE:
+#    cd sw_artifacts
+#    bash packaging/macos/build-dmg.sh [--version X.Y.Z] [--skip-pyinstaller]
+#
+#  PREREQUISITES:
+#    macOS, Xcode CLT (xcode-select --install)
+#    uv installed
+#    create-dmg (optional, prettier layout)  →  brew install create-dmg
+#    Without create-dmg the script falls back to hdiutil (functional, plain).
+#
+#  DESIGN:
+#    - Mirrors the CI job in .github/workflows/release.yml so a local build
+#      reproduces the same artefact byte-for-byte (modulo timestamps).
+#    - Output is always unsigned. Run packaging/macos/sign-local.sh after
+#      this script to codesign + notarize + staple before distribution.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+VERSION=""
+SKIP_PYINSTALLER=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)           VERSION="$2"; shift 2 ;;
+    --skip-pyinstaller)  SKIP_PYINSTALLER=true; shift ;;
+    -h|--help)
+      sed -n '2,20p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+if [[ -z "$VERSION" ]]; then
+  if [[ -f "${REPO_ROOT}/VERSION" ]]; then
+    VERSION="$(tr -d '[:space:]' < "${REPO_ROOT}/VERSION")"
+  else
+    VERSION="0.0.0"
+  fi
+fi
+
+cd "${REPO_ROOT}"
+
+APP_BUNDLE="dist/SpendifAi.app"
+DMG_NAME="SpendifAi-${VERSION}.dmg"
+BUILD_DIR="build"
+DMG_PATH="${BUILD_DIR}/${DMG_NAME}"
+ICNS_PATH="packaging/macos/spendifai.icns"
+
+echo "▸ Spendif.ai DMG builder — version ${VERSION}"
+
+mkdir -p "${BUILD_DIR}"
+rm -f "${DMG_PATH}"
+
+# ── 1. PyInstaller ──────────────────────────────────────────────────────────
+if [[ "${SKIP_PYINSTALLER}" == "false" ]]; then
+  echo "▸ Building .app via PyInstaller..."
+  uv run --extra desktop pyinstaller desktop.spec --noconfirm --clean
+fi
+
+if [[ ! -d "${APP_BUNDLE}" ]]; then
+  echo "✖ ${APP_BUNDLE} not found. Run without --skip-pyinstaller." >&2
+  exit 1
+fi
+echo "✔ ${APP_BUNDLE} ready"
+
+# ── 2. Icon (optional regenerate) ───────────────────────────────────────────
+if [[ ! -f "${ICNS_PATH}" ]]; then
+  echo "▸ Generating app icon..."
+  uv run python packaging/macos/create_icon.py || echo "⚠ icon generation skipped"
+fi
+
+# ── 3. DMG ──────────────────────────────────────────────────────────────────
+if command -v create-dmg &>/dev/null; then
+  echo "▸ Building DMG via create-dmg..."
+  ICON_ARGS=()
+  [[ -f "${ICNS_PATH}" ]] && ICON_ARGS=(--volicon "${ICNS_PATH}")
+
+  # create-dmg exits 2 on icon-setting glitches even when DMG is fine
+  set +e
+  create-dmg \
+    --volname "Spendif.ai" \
+    "${ICON_ARGS[@]}" \
+    --window-pos 200 120 \
+    --window-size 600 400 \
+    --icon-size 100 \
+    --icon "SpendifAi.app" 175 190 \
+    --hide-extension "SpendifAi.app" \
+    --app-drop-link 425 190 \
+    "${DMG_PATH}" \
+    "${APP_BUNDLE}"
+  rc=$?
+  set -e
+  if [[ ${rc} -ne 0 && ${rc} -ne 2 ]]; then
+    echo "✖ create-dmg failed (exit ${rc})" >&2
+    exit ${rc}
+  fi
+  [[ ${rc} -eq 2 ]] && echo "⚠ create-dmg icon warning (non-fatal)"
+else
+  echo "▸ create-dmg not found — falling back to hdiutil"
+  STAGE="$(mktemp -d)"
+  cp -R "${APP_BUNDLE}" "${STAGE}/"
+  ln -s /Applications "${STAGE}/Applications"
+  hdiutil create \
+    -volname "Spendif.ai" \
+    -srcfolder "${STAGE}" \
+    -ov \
+    -format UDZO \
+    "${DMG_PATH}"
+  rm -rf "${STAGE}"
+fi
+
+# ── 4. Verify ───────────────────────────────────────────────────────────────
+if [[ ! -f "${DMG_PATH}" ]]; then
+  echo "✖ DMG not produced" >&2
+  exit 1
+fi
+
+SIZE="$(du -h "${DMG_PATH}" | cut -f1)"
+echo ""
+echo "✔ DMG ready: ${DMG_PATH} (${SIZE})"
+echo ""
+echo "Next steps:"
+echo "  • Inspect:  open ${DMG_PATH}"
+echo "  • Sign:     bash packaging/macos/sign-local.sh --dmg ${DMG_PATH}"

--- a/packaging/macos/sign-local.sh
+++ b/packaging/macos/sign-local.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Spendif.ai — macOS local signing + notarization
+#
+#  Signs SpendifAi.app + DMG with a Developer ID Application certificate,
+#  submits to Apple notarization, and staples the ticket.
+#
+#  USAGE:
+#    cd sw_artifacts
+#    bash packaging/macos/sign-local.sh [--dmg PATH] [--app PATH] [--skip-notarize]
+#
+#  REQUIRED ENV VARS (or 1Password / Keychain integration):
+#    APPLE_DEV_ID         e.g. "Developer ID Application: Luigi Corsaro (TEAMID)"
+#    APPLE_ID             e.g. "lcorsaro69@gmail.com"
+#    APPLE_TEAM_ID        10-char team id from Apple Developer portal
+#    APPLE_APP_PASSWORD   app-specific password (appleid.apple.com → Security)
+#
+#  ALTERNATIVE: use a notarytool keychain profile (one-time setup)
+#    xcrun notarytool store-credentials spendifai-notary \
+#        --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_PASSWORD"
+#    then export NOTARY_PROFILE=spendifai-notary
+#
+#  DESIGN:
+#    - codesign --deep --options runtime → hardened runtime is mandatory for notarization
+#    - --entitlements packaging/macos/entitlements.plist → only if present (LLM might need
+#      JIT / allow-unsigned-executable-memory). Skipped if file missing.
+#    - notarytool submit --wait → blocks until Apple verdict (~5-15 min)
+#    - stapler staple → embeds the ticket so Gatekeeper accepts offline too
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+APP_PATH=""
+DMG_PATH=""
+SKIP_NOTARIZE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app)            APP_PATH="$2"; shift 2 ;;
+    --dmg)            DMG_PATH="$2"; shift 2 ;;
+    --skip-notarize)  SKIP_NOTARIZE=true; shift ;;
+    -h|--help)
+      sed -n '2,30p' "${BASH_SOURCE[0]}"; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+cd "${REPO_ROOT}"
+
+# Auto-detect if not provided
+[[ -z "${APP_PATH}" && -d "dist/SpendifAi.app" ]] && APP_PATH="dist/SpendifAi.app"
+if [[ -z "${DMG_PATH}" ]]; then
+  CANDIDATE="$(ls -t build/SpendifAi-*.dmg 2>/dev/null | head -1 || true)"
+  [[ -n "${CANDIDATE}" ]] && DMG_PATH="${CANDIDATE}"
+fi
+
+[[ -z "${APPLE_DEV_ID:-}" ]] && { echo "✖ APPLE_DEV_ID not set" >&2; exit 1; }
+
+ENTITLEMENTS="packaging/macos/entitlements.plist"
+ENT_ARGS=()
+[[ -f "${ENTITLEMENTS}" ]] && ENT_ARGS=(--entitlements "${ENTITLEMENTS}")
+
+# ── 1. Sign .app (if provided) ──────────────────────────────────────────────
+if [[ -n "${APP_PATH}" ]]; then
+  echo "▸ Codesigning ${APP_PATH}..."
+  # Sign nested frameworks/dylibs first, then the bundle
+  codesign --force --deep --options runtime --timestamp \
+    "${ENT_ARGS[@]}" \
+    --sign "${APPLE_DEV_ID}" \
+    "${APP_PATH}"
+
+  echo "▸ Verifying signature..."
+  codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+  spctl --assess --type execute --verbose "${APP_PATH}" || \
+    echo "⚠ spctl not yet accepting — will be ok after notarization"
+  echo "✔ ${APP_PATH} signed"
+fi
+
+# ── 2. Sign DMG (if provided) ───────────────────────────────────────────────
+if [[ -n "${DMG_PATH}" ]]; then
+  echo "▸ Codesigning ${DMG_PATH}..."
+  codesign --force --timestamp --sign "${APPLE_DEV_ID}" "${DMG_PATH}"
+  echo "✔ ${DMG_PATH} signed"
+fi
+
+# ── 3. Notarize ─────────────────────────────────────────────────────────────
+if [[ "${SKIP_NOTARIZE}" == "true" ]]; then
+  echo "ℹ Skipping notarization (--skip-notarize)"
+  exit 0
+fi
+
+[[ -z "${DMG_PATH}" ]] && { echo "ℹ No DMG to notarize; done."; exit 0; }
+
+NOTARY_ARGS=()
+if [[ -n "${NOTARY_PROFILE:-}" ]]; then
+  NOTARY_ARGS=(--keychain-profile "${NOTARY_PROFILE}")
+else
+  [[ -z "${APPLE_ID:-}" || -z "${APPLE_TEAM_ID:-}" || -z "${APPLE_APP_PASSWORD:-}" ]] && {
+    echo "✖ Set APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD or NOTARY_PROFILE" >&2
+    exit 1
+  }
+  NOTARY_ARGS=(
+    --apple-id "${APPLE_ID}"
+    --team-id "${APPLE_TEAM_ID}"
+    --password "${APPLE_APP_PASSWORD}"
+  )
+fi
+
+echo "▸ Submitting ${DMG_PATH} to Apple notarization (5-15 min)..."
+xcrun notarytool submit "${DMG_PATH}" "${NOTARY_ARGS[@]}" --wait
+
+echo "▸ Stapling notarization ticket..."
+xcrun stapler staple "${DMG_PATH}"
+xcrun stapler validate "${DMG_PATH}"
+
+echo ""
+echo "✔ ${DMG_PATH} signed + notarized + stapled"
+echo ""
+echo "Verify offline acceptance:"
+echo "  spctl -a -t open --context context:primary-signature ${DMG_PATH}"

--- a/packaging/windows/AppxManifest.xml.in
+++ b/packaging/windows/AppxManifest.xml.in
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Spendif.ai — MSIX AppxManifest template.
+
+  Tokens substituted by packaging/windows/build-msix.ps1:
+    @VERSION@               e.g. 3.0.0.0 (4-part version)
+    @PUBLISHER@             X.500 DN, must match cert subject exactly
+                            e.g. "CN=Luigi Corsaro, O=Spendif.ai, C=IT"
+    @PUBLISHER_DISPLAY@     Friendly name shown to user
+    @ARCH@                  x64 | arm64 | neutral
+
+  Capabilities are kept MINIMAL:
+    - runFullTrust: required because PyInstaller produces a desktop EXE
+      that needs full Win32 access (file system, native dlls, llama.cpp GPU).
+    - No internetClient: Spendif.ai runs locally; downloads happen on
+      first launch from the desktop launcher, not from the packaged app.
+      Add later if the in-app updater is implemented.
+-->
+<Package
+    xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+    xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+    xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+    IgnorableNamespaces="uap rescap">
+
+  <Identity
+      Name="SpendifAi"
+      Publisher="@PUBLISHER@"
+      Version="@VERSION@"
+      ProcessorArchitecture="@ARCH@" />
+
+  <Properties>
+    <DisplayName>Spendif.ai</DisplayName>
+    <PublisherDisplayName>@PUBLISHER_DISPLAY@</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+    <Description>Personal finance manager with local AI categorisation. Runs fully offline.</Description>
+  </Properties>
+
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.22631.0" />
+  </Dependencies>
+
+  <Resources>
+    <Resource Language="en-us" />
+    <Resource Language="it-it" />
+  </Resources>
+
+  <Applications>
+    <Application Id="SpendifAi" Executable="SpendifAi\SpendifAi.exe" EntryPoint="Windows.FullTrustApplication">
+      <uap:VisualElements
+          DisplayName="Spendif.ai"
+          Description="Personal finance manager with local AI"
+          BackgroundColor="transparent"
+          Square150x150Logo="Assets\Square150x150Logo.png"
+          Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/packaging/windows/build-msix.ps1
+++ b/packaging/windows/build-msix.ps1
@@ -1,0 +1,169 @@
+<#
+.SYNOPSIS
+    Spendif.ai — Windows MSIX builder (local + CI parity)
+
+.DESCRIPTION
+    Produces build\SpendifAi-<version>.msix (unsigned).
+    Mirrors the CI job in .github/workflows/release.yml.
+
+.PARAMETER Version
+    4-part version (e.g. 3.0.0.0). If omitted, reads VERSION file and
+    pads to 4 parts.
+
+.PARAMETER Publisher
+    X.500 DN that MUST match the signing certificate Subject exactly.
+    Default: "CN=SpendifAi Dev, O=Spendif.ai, C=IT" (placeholder for
+    self-signed cert). Override for production:
+      -Publisher "CN=Luigi Corsaro, O=Spendif.ai, C=IT"
+
+.PARAMETER PublisherDisplay
+    Friendly publisher name (shown in Add/Remove Programs).
+
+.PARAMETER Architecture
+    x64 (default) | arm64 | neutral
+
+.PARAMETER SkipPyInstaller
+    Reuse existing dist\SpendifAi\ instead of rebuilding.
+
+.EXAMPLE
+    cd sw_artifacts
+    .\packaging\windows\build-msix.ps1
+    .\packaging\windows\build-msix.ps1 -Version 3.1.0.0 -Publisher "CN=Luigi Corsaro, O=Spendif.ai, C=IT"
+
+.NOTES
+    Requires Windows SDK (for makeappx.exe). Install via:
+      winget install Microsoft.WindowsSDK.10.0.22621
+    Output is unsigned. Sign with packaging\windows\sign-local.ps1 before
+    distribution — MSIX cannot be installed in normal mode without a
+    trusted signature.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "",
+    [string]$Publisher = "CN=SpendifAi Dev, O=Spendif.ai, C=IT",
+    [string]$PublisherDisplay = "Spendif.ai",
+    [ValidateSet("x64", "arm64", "neutral")]
+    [string]$Architecture = "x64",
+    [switch]$SkipPyInstaller
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Set-Location $RepoRoot
+
+# ── 1. Resolve version (must be 4 parts) ─────────────────────────────────────
+if (-not $Version) {
+    if (Test-Path "VERSION") {
+        $Version = (Get-Content "VERSION" -Raw).Trim()
+    } else {
+        $Version = "0.0.0"
+    }
+}
+$parts = $Version.Split('.')
+while ($parts.Count -lt 4) { $parts += "0" }
+$Version4 = ($parts[0..3] -join '.')
+Write-Host "▸ Spendif.ai MSIX builder — version $Version4 ($Architecture)"
+
+# ── 2. PyInstaller ───────────────────────────────────────────────────────────
+$AppRoot = "dist\SpendifAi"
+$AppExe = "$AppRoot\SpendifAi.exe"
+
+if (-not $SkipPyInstaller) {
+    Write-Host "▸ Building .exe via PyInstaller..."
+    & uv run --extra desktop pyinstaller desktop.spec --noconfirm --clean
+    if ($LASTEXITCODE -ne 0) { throw "PyInstaller failed" }
+}
+
+if (-not (Test-Path $AppExe)) {
+    throw "$AppExe not found. Run without -SkipPyInstaller."
+}
+Write-Host "✔ $AppExe ready"
+
+# ── 3. Stage MSIX layout ─────────────────────────────────────────────────────
+$Stage = "build\msix-stage"
+if (Test-Path $Stage) { Remove-Item $Stage -Recurse -Force }
+New-Item -ItemType Directory -Force -Path $Stage | Out-Null
+New-Item -ItemType Directory -Force -Path "$Stage\SpendifAi" | Out-Null
+New-Item -ItemType Directory -Force -Path "$Stage\Assets" | Out-Null
+
+Write-Host "▸ Staging payload..."
+Copy-Item -Path "$AppRoot\*" -Destination "$Stage\SpendifAi\" -Recurse -Force
+
+# ── 4. Assets (logos) ────────────────────────────────────────────────────────
+# MSIX requires specific PNG assets. If a project-provided ICO exists,
+# we render it to the required sizes via System.Drawing; otherwise we
+# generate flat-colour placeholders so the package is still valid.
+$Ico = "packaging\windows\spendifai.ico"
+$Sizes = @{
+    "StoreLogo.png"        = 50
+    "Square44x44Logo.png"  = 44
+    "Square150x150Logo.png" = 150
+    "Wide310x150Logo.png"  = @(310, 150)
+}
+
+Add-Type -AssemblyName System.Drawing
+foreach ($name in $Sizes.Keys) {
+    $dims = $Sizes[$name]
+    if ($dims -is [array]) { $w = $dims[0]; $h = $dims[1] } else { $w = $dims; $h = $dims }
+    $out = "$Stage\Assets\$name"
+    $bmp = New-Object System.Drawing.Bitmap $w, $h
+    $g = [System.Drawing.Graphics]::FromImage($bmp)
+    $g.Clear([System.Drawing.Color]::FromArgb(0, 184, 148))  # brand teal
+    if (Test-Path $Ico) {
+        try {
+            $icon = New-Object System.Drawing.Icon($Ico, $w, $h)
+            $g.DrawIcon($icon, 0, 0)
+            $icon.Dispose()
+        } catch { }
+    }
+    $bmp.Save($out, [System.Drawing.Imaging.ImageFormat]::Png)
+    $g.Dispose(); $bmp.Dispose()
+}
+Write-Host "✔ Assets generated"
+
+# ── 5. Render AppxManifest.xml from template ─────────────────────────────────
+$Template = "packaging\windows\AppxManifest.xml.in"
+$Manifest = "$Stage\AppxManifest.xml"
+if (-not (Test-Path $Template)) { throw "$Template not found" }
+
+(Get-Content $Template -Raw) `
+    -replace '@VERSION@',           $Version4 `
+    -replace '@PUBLISHER@',         $Publisher `
+    -replace '@PUBLISHER_DISPLAY@', $PublisherDisplay `
+    -replace '@ARCH@',              $Architecture |
+    Set-Content -Path $Manifest -Encoding UTF8
+
+Write-Host "✔ Manifest rendered"
+
+# ── 6. Locate makeappx.exe ───────────────────────────────────────────────────
+$MakeAppx = $null
+$Candidates = @(
+    "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\makeappx.exe",
+    "${env:ProgramFiles}\Windows Kits\10\bin\*\x64\makeappx.exe"
+)
+foreach ($pattern in $Candidates) {
+    $found = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue |
+             Sort-Object -Property FullName -Descending |
+             Select-Object -First 1
+    if ($found) { $MakeAppx = $found.FullName; break }
+}
+if (-not $MakeAppx) {
+    throw "makeappx.exe not found. Install Windows SDK: winget install Microsoft.WindowsSDK.10.0.22621"
+}
+Write-Host "▸ Using makeappx: $MakeAppx"
+
+# ── 7. Pack ──────────────────────────────────────────────────────────────────
+$MsixName = "SpendifAi-$Version.msix"
+$MsixPath = "build\$MsixName"
+if (Test-Path $MsixPath) { Remove-Item $MsixPath -Force }
+
+& "$MakeAppx" pack /d $Stage /p $MsixPath /o
+if ($LASTEXITCODE -ne 0) { throw "makeappx pack failed (exit $LASTEXITCODE)" }
+
+$size = "{0:N1} MB" -f ((Get-Item $MsixPath).Length / 1MB)
+Write-Host ""
+Write-Host "✔ MSIX ready: $MsixPath ($size)"
+Write-Host ""
+Write-Host "Next steps:"
+Write-Host "  • Sign:    .\packaging\windows\sign-local.ps1 -Msix $MsixPath"
+Write-Host "  • Install: Add-AppxPackage $MsixPath  (requires trusted signature)"

--- a/packaging/windows/sign-local.ps1
+++ b/packaging/windows/sign-local.ps1
@@ -1,0 +1,115 @@
+<#
+.SYNOPSIS
+    Spendif.ai — Windows MSIX local signing.
+
+.DESCRIPTION
+    Wraps SignTool.exe to sign an MSIX with a Code Signing certificate.
+    The certificate Subject MUST match the <Identity Publisher="..."> in
+    the MSIX manifest, otherwise SignTool fails with 0x8007000B.
+
+.PARAMETER Msix
+    Path to the MSIX file. If omitted, picks the newest in build\.
+
+.PARAMETER CertPath
+    Path to .pfx file. Defaults to env:MSIX_CERT_PATH.
+
+.PARAMETER CertPassword
+    Password for the .pfx. Defaults to env:MSIX_CERT_PASSWORD.
+
+.PARAMETER TimestampUrl
+    RFC 3161 timestamp server (default: DigiCert).
+
+.EXAMPLE
+    $env:MSIX_CERT_PATH = "C:\path\to\spendifai.pfx"
+    $env:MSIX_CERT_PASSWORD = "secret"
+    .\packaging\windows\sign-local.ps1
+
+.NOTES
+    SELF-SIGNED CERT (for testing / sideload):
+      $cert = New-SelfSignedCertificate -Type CodeSigningCert `
+          -Subject "CN=SpendifAi Dev, O=Spendif.ai, C=IT" `
+          -KeyUsage DigitalSignature -FriendlyName "Spendif.ai Dev" `
+          -CertStoreLocation Cert:\CurrentUser\My `
+          -TextExtension @("2.5.29.37={text}1.3.6.1.5.5.7.3.3","2.5.29.19={text}")
+      $pwd = ConvertTo-SecureString -String "secret" -Force -AsPlainText
+      Export-PfxCertificate -Cert $cert -FilePath spendifai.pfx -Password $pwd
+      # Install for trust:
+      Import-Certificate -FilePath spendifai.cer -CertStoreLocation Cert:\LocalMachine\TrustedPeople
+
+    PRODUCTION CERT: buy from Sectigo / DigiCert (OV ~$200/yr, EV ~$400/yr).
+    EV certs get zero SmartScreen warning immediately; OV builds reputation.
+#>
+[CmdletBinding()]
+param(
+    [string]$Msix = "",
+    [string]$CertPath = $env:MSIX_CERT_PATH,
+    [string]$CertPassword = $env:MSIX_CERT_PASSWORD,
+    [string]$TimestampUrl = "http://timestamp.digicert.com"
+)
+
+$ErrorActionPreference = "Stop"
+$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Set-Location $RepoRoot
+
+# ── 1. Resolve MSIX ──────────────────────────────────────────────────────────
+if (-not $Msix) {
+    $Msix = (Get-ChildItem "build\SpendifAi-*.msix" -ErrorAction SilentlyContinue |
+             Sort-Object LastWriteTime -Descending | Select-Object -First 1).FullName
+}
+if (-not $Msix -or -not (Test-Path $Msix)) {
+    throw "MSIX not found. Run packaging\windows\build-msix.ps1 first or pass -Msix."
+}
+
+# ── 2. Validate cert ─────────────────────────────────────────────────────────
+if (-not $CertPath) {
+    throw "CertPath not set. Pass -CertPath or set env:MSIX_CERT_PATH."
+}
+if (-not (Test-Path $CertPath)) {
+    throw "Certificate not found: $CertPath"
+}
+if (-not $CertPassword) {
+    throw "CertPassword not set. Pass -CertPassword or set env:MSIX_CERT_PASSWORD."
+}
+
+# ── 3. Locate SignTool.exe ───────────────────────────────────────────────────
+$SignTool = $null
+$Candidates = @(
+    "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe",
+    "${env:ProgramFiles}\Windows Kits\10\bin\*\x64\signtool.exe"
+)
+foreach ($pattern in $Candidates) {
+    $found = Get-ChildItem -Path $pattern -ErrorAction SilentlyContinue |
+             Sort-Object -Property FullName -Descending |
+             Select-Object -First 1
+    if ($found) { $SignTool = $found.FullName; break }
+}
+if (-not $SignTool) {
+    throw "signtool.exe not found. Install Windows SDK."
+}
+
+# ── 4. Sign ──────────────────────────────────────────────────────────────────
+Write-Host "▸ Signing $Msix"
+Write-Host "  Cert: $CertPath"
+Write-Host "  Timestamp: $TimestampUrl"
+
+& "$SignTool" sign `
+    /fd SHA256 `
+    /a `
+    /f $CertPath `
+    /p $CertPassword `
+    /tr $TimestampUrl `
+    /td SHA256 `
+    $Msix
+
+if ($LASTEXITCODE -ne 0) { throw "SignTool failed (exit $LASTEXITCODE)" }
+
+# ── 5. Verify ────────────────────────────────────────────────────────────────
+Write-Host "▸ Verifying..."
+& "$SignTool" verify /pa /v $Msix
+if ($LASTEXITCODE -ne 0) { throw "Signature verification failed" }
+
+Write-Host ""
+Write-Host "✔ $Msix signed and verified"
+Write-Host ""
+Write-Host "Install (requires cert trusted on target machine):"
+Write-Host "  Add-AppxPackage $Msix"


### PR DESCRIPTION
## Summary

- **MSIX + DMG installers** alongside existing `.deb`/`.rpm`. CI builds all four unsigned on tag `v*.*.*` and publishes a **draft** GitHub Release; owner signs DMG and MSIX locally with their own certs and replaces the unsigned files via `gh release upload --clobber` before publishing. Signing credentials never reach GitHub Secrets.
- **Local + CI parity scripts** for every step: `packaging/macos/{build-dmg,sign-local}.sh`, `packaging/windows/{build-msix.ps1,sign-local.ps1,AppxManifest.xml.in}`.
- **First-launch flow documented properly** — `installation_{macos,windows}.{md,it.md}` now describe the native pywebview splash + model download + onboarding wizard, instead of the obsolete Terminal/browser sequence that only applies to the legacy `install.sh`/`install.ps1` scripts.
- **Getting-started gh-pages page in 9 locales** (it/en/de/es/fr/ja/nl/pl/pt) with three-step illustrated install/first-launch guide, download buttons per OS, screenshot placeholders under `assets/screenshots/`, full language switcher, and the Cloudflare Web Analytics beacon on every page.
- **Landing CTAs** (`index.{html,en,de,es,fr,ja,nl,pl,pt}.html`): localised "Download installer" button above the existing curl-script tabs, linking to the matching getting-started page.

Backlog item: AI-49 (`sestante/backlog.json`, status `doing`).

## Test plan

### Build & CI
- [ ] CI (`ci.yml`) green on this PR — tests, architecture, security
- [ ] After merge, tag a trial release (e.g. `v3.0.1`) and verify `release.yml` produces all four artefacts as a draft release:
  - [ ] `SpendifAi-3.0.1.dmg` (unsigned, mounts, contains `SpendifAi.app` + `/Applications` symlink)
  - [ ] `SpendifAi-3.0.1.msix` (unsigned, ~500 MB)
  - [ ] `spendifai_3.0.1_amd64.deb` (smoke-tested in `ubuntu:24.04` container by the workflow)
  - [ ] `spendifai-3.0.1-1.noarch.rpm` (smoke-tested in `fedora:41` container by the workflow)
  - [ ] `SHA256SUMS.txt` present, Release marked as **draft**

### Local hybrid signing dry-run (post-merge, once cert is available)
- [ ] `bash packaging/macos/build-dmg.sh --version 3.0.1` produces a working DMG locally
- [ ] `bash packaging/macos/sign-local.sh --dmg build/SpendifAi-3.0.1.dmg` succeeds with valid Apple Developer ID cert (codesign + notarytool + stapler)
- [ ] On Windows: `.\packaging\windows\build-msix.ps1 -Version 3.0.1.0` produces a valid MSIX
- [ ] `.\packaging\windows\sign-local.ps1` signs it with a valid `.pfx` cert
- [ ] After local signing, `gh release upload v3.0.1 --clobber` replaces unsigned artefacts in the draft, then `gh release edit v3.0.1 --draft=false` publishes

### Docs
- [ ] `getting-started.html` and 8 translations open correctly in the browser (no broken layout, language switcher works on each)
- [ ] Each `index.*.html` shows the new "Download installer" CTA above the curl tabs
- [ ] `docs/release_process.{md,it.md}` §2bis (hybrid signing) reads end-to-end