### PR TITLE
fix(sanitizer): handle non-string inputs from pandas 2.x string-dtype + NaN

### DIFF
--- a/core/classifier.py
+++ b/core/classifier.py
@@ -383,9 +383,12 @@ def classify_document(
     sample = df_raw.loc[sorted(_top_idx)].copy()
 
     if sanitize:
-        for col in sample.select_dtypes(include="object").columns:
+        for col in sample.select_dtypes(include=["object", "string"]).columns:
+            # pandas 2.x quirk: `astype(str)` on a `string`-dtype Series with
+            # NaN leaves the NaN as float, breaking the regex-based sanitizer
+            # downstream. `fillna("")` first makes the conversion total.
             sample[col] = sanitize_dataframe_descriptions(
-                sample[col].astype(str).tolist(), sanitize_config
+                sample[col].fillna("").astype(str).tolist(), sanitize_config
             )
 
     sample_json = sample.to_json(orient="records", force_ascii=False)

--- a/core/sanitizer.py
+++ b/core/sanitizer.py
@@ -86,6 +86,13 @@ def redact_pii(text: str, config: SanitizationConfig | None = None) -> str:
       Bank codes     → <TX_CODE>
       Fiscal code    → <FISCAL_ID>
     """
+    # Defensive guard: pandas `string`-dtype columns leak NaN through
+    # `astype(str).tolist()`, so callers may pass floats. Coerce to str
+    # and treat NaN / None as empty.
+    if text is None or (isinstance(text, float) and text != text):
+        return ""
+    if not isinstance(text, str):
+        text = str(text)
     if not text:
         return text
 

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -274,3 +274,53 @@ class TestSanitizeDataframeDescriptions:
         descs = [f"desc {i}" for i in range(10)]
         results = sanitize_dataframe_descriptions(descs, None)
         assert results == descs  # no PII, all unchanged
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Defensive type coercion (regression: pandas 2.x string-dtype + NaN)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestNonStringInputs:
+    """Regression for the crash where `sample[col].astype(str).tolist()` on a
+    pandas `string`-dtype Series with NaN leaked float NaNs into the sanitizer,
+    which then exploded on the first `re.sub` call with
+    `TypeError: expected string or bytes-like object, got 'float'`.
+    """
+
+    def test_redact_pii_handles_nan(self):
+        assert redact_pii(float("nan")) == ""
+
+    def test_redact_pii_handles_none(self):
+        assert redact_pii(None) == ""
+
+    def test_redact_pii_coerces_non_string(self):
+        assert redact_pii(1.5) == "1.5"
+        assert redact_pii(42) == "42"
+
+    def test_sanitize_dataframe_descriptions_mixed_types(self):
+        descs = ["bonifico IT60X0542811101000000123456", float("nan"), None, 1.5, "ok"]
+        results = sanitize_dataframe_descriptions(descs, SanitizationConfig())
+        assert len(results) == 5
+        assert "<ACCOUNT_ID>" in results[0]
+        assert results[1] == ""
+        assert results[2] == ""
+        assert results[3] == "1.5"
+        assert results[4] == "ok"
+
+    def test_sanitize_pandas_string_dtype_series_with_nan(self):
+        # Reproduce the upstream pandas quirk: `string` dtype + NaN +
+        # `.astype(str).tolist()` yields a list with a float NaN in it.
+        import pandas as pd
+
+        series = pd.Series(["bonifico IT60X0542811101000000123456", None, "ok"], dtype="string")
+        as_list = series.astype(str).tolist()
+        assert any(not isinstance(x, str) for x in as_list), (
+            "If this assertion ever fails, pandas fixed the underlying quirk and "
+            "the defensive guard in redact_pii is no longer load-bearing — but it "
+            "still costs nothing to keep."
+        )
+        results = sanitize_dataframe_descriptions(as_list, SanitizationConfig())
+        assert len(results) == 3
+        assert "<ACCOUNT_ID>" in results[0]
+        assert results[1] == ""
+        assert results[2] == "ok"


### PR DESCRIPTION
## Summary

Hotfix for a crash in the upload pipeline reproducible on real bank CSV files containing a `string`-dtype column with NaN values:

\`\`\`
TypeError: expected string or bytes-like object, got 'float'
File "core/sanitizer.py", line 112, in redact_pii
    text = combined.sub(fake, text)
\`\`\`

## Root cause

pandas 2.x \`astype(str).tolist()\` on a \`string\`-dtype Series with NaN does **not** convert the NaN to the string \`"nan"\` — it leaks through as a float. The downstream regex-based sanitizer then explodes on the first \`re.sub\` call.

\`\`\`python
>>> pd.Series(['a', np.nan, 'b'], dtype='string').astype(str).tolist()
['a', nan, 'b']   # nan is float, not str
\`\`\`

## Fix — defense in depth, two points

- \`core/classifier.py\` — switch to \`fillna("").astype(str).tolist()\` and broaden \`select_dtypes\` to also include the \`string\` extension dtype (pandas 2.x default for inferred string columns)
- \`core/sanitizer.py\` — defensive guard in \`redact_pii\`: return \`""\` for None / NaN and coerce other non-string inputs to str. Protects future callers from the same trap

## Regression tests

\`TestNonStringInputs\` (5 new tests in \`tests/test_sanitizer.py\`), including one that reproduces the exact pandas string-dtype + NaN quirk end-to-end and verifies the fix.

\`\`\`
tests/test_sanitizer.py::TestNonStringInputs::test_redact_pii_handles_nan PASSED
tests/test_sanitizer.py::TestNonStringInputs::test_redact_pii_handles_none PASSED
tests/test_sanitizer.py::TestNonStringInputs::test_redact_pii_coerces_non_string PASSED
tests/test_sanitizer.py::TestNonStringInputs::test_sanitize_dataframe_descriptions_mixed_types PASSED
tests/test_sanitizer.py::TestNonStringInputs::test_sanitize_pandas_string_dtype_series_with_nan PASSED
\`\`\`

Full suite: 40/40 passed locally.

## Why hotfix-first

Discovered while testing the desktop app — blocks any real-world CSV import with a string-dtype + NaN column. Promoting ahead of the in-progress README restructure PR (#TBD) so that branch can rebase onto a clean main with the fix in place.