### PR TITLE
docs(readme): refocus README on devs, add architecture/design_decisions, honest privacy claims

### DIFF
--- a/CHANGELOG.it.md
+++ b/CHANGELOG.it.md
@@ -29,11 +29,17 @@ Il versioning segue [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Pagina "Primo avvio" su gh-pages, copertura completa 9 lingue (`getting-started.{html,en,de,es,fr,ja,nl,pl,pt}.html`): guida illustrata a 3 step (Download → Installa → Primo avvio) con bottoni di download per DMG/MSIX/.deb/.rpm e placeholder per screenshot (`assets/screenshots/`). Ogni pagina include il beacon Cloudflare Web Analytics e il selettore lingua completo
 - Aggiornata la sezione "Primo avvio" di `installation_{macos,windows}.{md,it.md}` per descrivere il flusso nativo pywebview (splash + download modello + wizard onboarding), sostituendo la sequenza obsoleta Terminale/browser che vale solo per i vecchi script `install.sh`/`install.ps1`
 - Landing page (tutte le 9 lingue: `index.html` IT, `index.{en,de,es,fr,ja,nl,pl,pt}.html`): aggiunto CTA localizzato "Scarica installer" che punta alla pagina getting-started corrispondente alla lingua, sopra le tab esistenti con gli script curl
+- README riorganizzato per audience tecnica/sviluppatori (era misto end-user + dev): ridotto da 663 → ~180 righe, banner che dirige gli utenti finali alla getting-started su gh-pages, sei bullet "Cosa è implementato" con path file + RF-codes + beta tag onesti, sezione develop-locally con chiarimento Ollama vs llama.cpp, link reciproci IT·EN nella tabella documentazione
+- Nuovi `docs/architecture.{md,it.md}` con diagramma a layer e dettagli Flow 1 vs Flow 2 prima inseriti nel README
+- Nuovi `docs/design_decisions.{md,it.md}` con il razionale Decimal/SHA-256/invert_sign/RF-03/RF-04 prima nel README, con flag espliciti `(beta)` su RF-03 e RF-04
+- Nuova sezione "Cosa ottieni" su tutti i 9 `getting-started.*.html` con sei bullet user-value (tradotti in tutte le lingue) — framing complementare a "Cosa è implementato" del README
+- Sezione README "Cosa lascia la macchina" resa esplicita e onesta: esempio concreto before/after di redazione PII e ammissione che **importi** e **date** delle transazioni viaggiano comunque verso i backend LLM remoti nell'implementazione attuale (item di backlog AI-55 copre le modalità di redazione). Bullet privacy su tutti i 9 getting-started gh-pages riscritto con lo stesso tono onesto
 
 ### Fixed
 - Auto-invalidazione degli schemi: gli schemi in cache (Flow 1) con parse rate < 10% vengono eliminati automaticamente e ritentati con Flow 2 (riclassificazione LLM)
 - Pulizia schemi orfani: la migration di avvio rimuove le righe `document_schema` senza `header_sha256`, prevenendo voci stale irraggiungibili
 - Header SHA256 sempre popolato sullo schema prima del persist, evitando la creazione di schemi orfani
+- Crash del sanitizer su colonne pandas 2.x `string`-dtype con NaN: `astype(str).tolist()` lasciava trapelare float NaN nel sanitizer regex, sollevando `TypeError: expected string or bytes-like object, got 'float'` su import CSV bancari reali. Fix in `core/classifier.py` (`fillna("").astype(str)`) più guard difensivo in `core/sanitizer.py` (`redact_pii` coerce gli input non-string a `""`). 5 test di regressione in `tests/test_sanitizer.py::TestNonStringInputs` (#108)
 
 ## [0.1.0] - 2026-04-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,17 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Getting-started page on gh-pages, full 9-locale coverage (`getting-started.{html,en,de,es,fr,ja,nl,pl,pt}.html`): three-step illustrated install/first-launch guide with download buttons for DMG/MSIX/.deb/.rpm and screenshot placeholders (`assets/screenshots/`). Each page includes the Cloudflare Web Analytics beacon and a full language switcher
 - Updated `installation_{macos,windows}.{md,it.md}` "First Launch" section to describe the native pywebview flow (splash + model download + onboarding wizard), replacing the obsolete Terminal/browser sequence which only applies to the legacy `install.sh`/`install.ps1` scripts
 - Landing pages (all 9 locales: `index.html` IT, `index.{en,de,es,fr,ja,nl,pl,pt}.html`): added localized "Download installer" CTA pointing to the locale-matched getting-started page above the existing curl-script tabs
+- README restructured for technical/developer audience (was a mix of end-user + dev content): trimmed from 663 → ~180 lines, banner directing end users to the gh-pages getting-started, six "What's implemented" bullets with file paths + RF-codes + honest beta tags, develop-locally section with Ollama vs llama.cpp clarification, reciprocal IT·EN documentation links
+- New `docs/architecture.{md,it.md}` capturing the layer diagram and Flow 1 vs Flow 2 details previously inlined in the README
+- New `docs/design_decisions.{md,it.md}` capturing the Decimal/SHA-256/invert_sign/RF-03/RF-04 rationale previously inlined in the README, with explicit `(beta)` status flags on RF-03 and RF-04
+- New "What you get" section on all 9 `getting-started.*.html` pages with six user-value bullets (translated into all locales) — duplicate-free framing complementing the README's "What's implemented"
+- README "What leaves the machine" section made explicit and honest: shows a concrete before/after PII redaction example and acknowledges that transaction **amounts** and **dates** still travel to remote LLM backends in the current implementation (backlog AI-55 covers redaction modes). Privacy bullet on all 9 gh-pages getting-started rewritten in the same honest tone
 
 ### Fixed
 - Schema auto-invalidation: cached schemas (Flow 1) producing < 10% parse rate are automatically deleted and retried with Flow 2 (LLM re-classification)
 - Orphan schema purge: startup migration removes `document_schema` rows without `header_sha256`, preventing unreachable stale entries
 - Header SHA256 always populated on schema before persist, preventing orphan schemas from being created
+- Sanitizer crash on pandas 2.x `string`-dtype columns with NaN: `astype(str).tolist()` was leaking float NaNs into the regex-based sanitizer, raising `TypeError: expected string or bytes-like object, got 'float'` on real bank CSV imports. Fix in `core/classifier.py` (`fillna("").astype(str)`) plus defensive guard in `core/sanitizer.py` (`redact_pii` coerces non-string inputs to `""`). 5 regression tests in `tests/test_sanitizer.py::TestNonStringInputs` (#108)
 
 ## [0.1.0] - 2026-04-06
 

--- a/README.it.md
+++ b/README.it.md
@@ -6,573 +6,180 @@
 [![License: PolyForm NC](https://img.shields.io/badge/license-PolyForm%20Noncommercial-orange)](LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Streamlit](https://img.shields.io/badge/UI-Streamlit-ff4b4b?logo=streamlit&logoColor=white)](https://streamlit.io)
-[![Issues](https://img.shields.io/github/issues/drake69/spendifai)](https://github.com/drake69/spendify/issues)
-[![Last commit](https://img.shields.io/github/last-commit/drake69/spendifai)](https://github.com/drake69/spendify/commits/main)
+[![Issues](https://img.shields.io/github/issues/drake69/spendify)](https://github.com/drake69/spendify/issues)
+[![Last commit](https://img.shields.io/github/last-commit/drake69/spendify)](https://github.com/drake69/spendify/commits/main)
 [![Supporta su Patreon](https://img.shields.io/badge/Patreon-offrimi%20un%20caffè%20☕-F96854?logo=patreon&logoColor=white)](https://patreon.com/drake69)
 
 > 🇬🇧 [Read in English](README.md)
 
-Registro finanziario personale unificato con pipeline ibrida deterministica + LLM.
-
-Aggrega movimenti eterogenei (conti correnti, carte di credito, carte di debito, conti deposito, prepagate) in un unico ledger cronologico, eliminando il double-counting da addebiti carta periodici e da giroconti interni. Il processing avviene in modalità **offline-first**; i backend LLM remoti sono supportati come opt-in con sanitizzazione PII obbligatoria.
+Registro finanziario personale unificato con pipeline ibrida deterministica + LLM. Aggrega export bancari eterogenei (conti correnti, carte di credito/debito/prepagate, conti deposito) in un unico ledger cronologico, eliminando il double-counting da addebiti carta periodici e giroconti interni. Offline-first; backend LLM remoti opt-in con sanitizzazione PII obbligatoria.
 
 ---
 
-## Indice
-
-- [Caratteristiche principali](#caratteristiche-principali)
-- [Architettura](#architettura)
-- [Struttura del progetto](#struttura-del-progetto)
-- [Installazione](#installazione)
-- [Configurazione](#configurazione)
-- [Avvio](#avvio)
-- [Tassonomia](#tassonomia)
-- [Motore delle regole](#motore-delle-regole)
-- [Giroconti](#giroconti)
-- [Test](#test)
-- [Decisioni di design](#decisioni-di-design)
+> 👋 **Utente finale — vuoi installare Spendif.ai?**
+> Vai alla [pagina Primo avvio](https://drake69.github.io/spendify/getting-started.html) per la guida illustrata di installazione + primo avvio. Questo README è per sviluppatori e contributor.
 
 ---
 
-## Caratteristiche principali
+## Cos'è (tecnicamente)
 
-| Funzionalità | Dettaglio |
-|---|---|
-| **Classificazione automatica** | Rileva tipo di documento (conto corrente, carta, prepagata, deposito) senza configurazione preventiva |
-| **Normalizzazione deterministica** | Encoding detection, delimiter detection, header detection, importi in `Decimal` (mai `float`) |
-| **Correzione segno carta** | Flag `invert_sign` in `DocumentSchema`: quando un file carta salva le spese come valori positivi, vengono negati automaticamente |
-| **Idempotenza SHA-256** | Re-importare lo stesso file produce esattamente lo stesso insieme di righe |
-| **Riconciliazione carta–c/c (RF-03)** | Algoritmo a 3 fasi che elimina il double-counting da addebiti aggregati mensili |
-| **Rilevamento giroconti (RF-04)** | Matching simbolico importo+finestra temporale; esclusione o neutralizzazione configurabile |
-| **Categorizzazione a cascata (RF-05)** | Regole utente → regex statiche → LLM strutturato → fallback "Altro" |
-| **Motore regole con applicazione retroattiva** | Le regole deterministiche vengono applicate a tutte le transazioni esistenti al momento del salvataggio, non solo alle future importazioni |
-| **Sottocategoria come fonte di verità** | La sottocategoria è la chiave primaria: se LLM o regola assegna una sottocategoria presente in tassonomia, la categoria genitore viene risolta automaticamente |
-| **Wizard di onboarding guidato** | Wizard in 4 step al primo avvio: selezione lingua (rilevata dal browser), nomi titolari, conti bancari, conferma. Scrittura atomica: il DB viene popolato solo al clic su "Inizia!". Saltato automaticamente se esiste già una tassonomia (installazioni esistenti). |
-| **Tassonomia multi-lingua** | Template built-in in 5 lingue (🇮🇹 🇬🇧 🇫🇷 🇩🇪 🇪🇸). Salvati nella tabella `taxonomy_default` del DB (nessun file YAML richiesto). Lingua scelta all'onboarding; reimpostabile da Impostazioni in qualsiasi momento. |
-| **Tassonomia a 2 livelli nel DB** | 15 categorie di spesa + 7 di entrata; gestita dalla pagina Tassonomia (DB-backed, nessun restart richiesto) |
-| **Backend LLM multi-provider** | Ollama (locale, default), OpenAI, Claude — interfaccia astratta comune, nessun LangChain |
-| **Config LLM nell'UI** | Backend, modello e chiavi API configurabili dalla pagina Impostazioni senza toccare `.env` |
-| **PII sanitization (RF-10)** | IBAN, PAN, CF, nomi del titolare redatti prima di qualsiasi chiamata remota |
-| **Circuit breaker** | Fallback automatico su Ollama locale; quarantena (`to_review=True`) se tutti i backend falliscono |
-| **Contesti di vita** | Dimensione ortogonale configurabile dall'utente (es. Quotidianità / Lavoro / Vacanza) assegnabile a ogni transazione; suggerimenti automatici basati su similarità Jaccard con transazioni precedenti |
-| **Re-run LLM su fallimenti** | Pulsante nella pagina Review che rielabora solo le transazioni in cui l'LLM aveva fallito (`description == raw_description`) |
-| **Rilevamento giroconti cross-account** | Pulsante nella pagina Review che riesegue `detect_internal_transfers` globalmente su tutte le transazioni, intercettando le coppie non trovate in fase di import |
-| **Permutazioni nome titolare** | Tutte le permutazioni dei token del nome del titolare vengono verificate per il rilevamento giroconti, evitando i falsi negativi quando l'ordine varia tra i file |
-| **Service layer + CI coupling gate** | Tutte le pagine UI importano solo da `services.*`, mai da `core.*` o `db.*` direttamente. `tools/coupling_check.py --strict` applica il vincolo in CI; le violazioni bloccano la PR. |
-| **Persistenza SQLAlchemy** | 11 tabelle ORM; CRUD idempotente; migrazioni automatiche all'avvio |
-| **Progresso import cross-session** | Stato del job di importazione salvato nel DB; tutte le sessioni browser vedono il progresso in tempo reale |
-| **Export report** | HTML standalone (Plotly), CSV, XLSX |
-| **UI Streamlit 9 pagine** | Import → Ledger → Modifiche massive → Analytics → Review → Regole → Tassonomia → Impostazioni → Check List |
-| **Check List mensile** | Tabella pivot mese × conto con conteggio transazioni; evidenzia i mesi mancanti a colpo d'occhio |
+- **Python 3.13 · Streamlit · SQLAlchemy · Pydantic · Pandas**
+- **Pipeline ibrida**: normalizer deterministico + classifier LLM + categorizer a cascata
+- **LLM multi-backend** con circuit breaker: llama.cpp (default per desktop), Ollama, OpenAI, Claude — uso diretto dell'SDK, niente LangChain
+- **Launcher desktop nativo**: pywebview + PyInstaller → DMG / MSIX / .deb / .rpm
+- **UI Streamlit a 14 pagine**, i18n IT+EN completo (760+ chiavi di traduzione)
 
----
+## Cosa è implementato
+
+- **Pipeline ibrida (deterministica + LLM)** — `core/normalizer.py` parsa qualunque export bancario tabellare; `core/classifier.py` deduce `DocumentSchema` via LLM; `core/categorizer.py` esegue una cascata a 4 step (regole utente → regex → LLM → fallback)
+- **LLM multi-backend con circuit breaker** — factory in `core/llm_backends.py`: llama.cpp, Ollama, OpenAI, Claude. Fallback automatico + quarantena su fallimento
+- **PII sanitization (RF-10)** — redazione di IBAN / PAN / codice fiscale / nomi titolari in `core/sanitizer.py`, obbligatoria prima di qualsiasi call remota (`assert_sanitized()` è una precondizione, non best-effort)
+- **Tassonomia multilingua** — 2 livelli in DB, 5 lingue (it/en/fr/de/es), configurabile dall'UI Streamlit
+- **Riconciliazione carta-conto (RF-03, beta)** — algoritmo a 3 fasi in `core/normalizer.py`: appaia gli addebiti carta con le spese sottostanti per eliminare il double-counting *(edge cases ancora in raffinamento)*
+- **Rilevazione giroconti interni (RF-04, beta)** — matching su importo simbolico + finestra di ±7 giorni, con permutazioni dei nomi titolare per intercettare export tipo "Cognome Nome" *(edge cases ancora in raffinamento)*
+
+## 👩‍💻 Sviluppo locale
+
+```bash
+git clone https://github.com/drake69/spendify.git
+cd spendify
+uv sync --extra desktop
+
+# LLM locale (scelta dello sviluppatore — l'installer desktop gestisce
+# questo automaticamente):
+#   → se hai già Ollama attivo:   ollama pull gemma3:12b
+#   → altrimenti: `uv sync` installa llama-cpp-python e il launcher
+#     scarica automaticamente un modello GGUF al primo avvio
+
+./start.sh                    # oppure: streamlit run app.py
+```
+
+Prerequisiti: **Python 3.13+**, **[uv](https://github.com/astral-sh/uv)**, e in alternativa Ollama o nulla (llama.cpp è bundle). Setup completo → [CONTRIBUTING.md](CONTRIBUTING.md).
+
+### Eseguire come app desktop nativa da sorgente
+
+```bash
+uv run python -m desktop.launcher
+```
+
+Apre una finestra pywebview, scarica un modello AI al primo avvio, e avvia Streamlit dentro la stessa finestra. Identico all'esperienza DMG/MSIX confezionata.
+
+## Eseguire i test
+
+```bash
+uv run pytest -v                                  # suite completa (no mock LLM)
+uv run pytest --cov=. --cov-report=term-missing   # con coverage (target ≥ 90%)
+uv run pytest -k "architecture"                   # gate separazione layer
+uv run pytest -k "security"                       # forbidden pattern + SQL injection
+```
+
+I test architetturali e di sicurezza sono gate CI obbligatori e devono restare verdi su `main`.
 
 ## Architettura
 
 ```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                            app.py  (Streamlit)                           │
-│  [onboarding gate] → sidebar → upload │ ledger │ bulk-edit │ analytics  │
-│                               review │ rules │ taxonomy │ settings       │
-└──────────────────────────┬───────────────────────────────────────────────┘
-                           │ services.*  (facade layer)
-               core/orchestrator.py
-               ProcessingConfig  ·  process_file()
-                           │
-        ┌──────────────────┼───────────────────┐
-        │                  │                   │
- Flow 1 (template)    Flow 2 (schema-on-read)
- DocumentSchema        classifier.py → LLM  → DocumentSchema
- già noto              (campione sanitizzato)    invert_sign detection
-        │
- normalizer.py          sanitizer.py      llm_backends.py
- ├─ encoding detect     ├─ IBAN/PAN/CF    ├─ OllamaBackend
- ├─ parse_amount()      ├─ owner names    ├─ OpenAIBackend
- ├─ SHA-256 tx_id       └─ assert_sani.. └─ ClaudeBackend
- ├─ invert_sign                              BackendFactory
- ├─ RF-03 reconcile                          call_with_fallback()
- └─ RF-04 transfers
-        │
- categorizer.py  ←── TaxonomyConfig (caricato dal DB)
- Step 0: regole utente  (risoluzione sottocategoria → categoria)
- Step 1: regex statiche
- Step 2: stub ML
- Step 3: LLM structured output  (enum sottocategorie vincolato)
- Step 4: fallback "Altro"
-        │
-    db/repository.py   (SQLAlchemy, idempotente)
-    └─ Transaction · ImportBatch · DocumentSchemaModel
-       ReconciliationLink · InternalTransferLink · CategoryRule
-       UserSettings · ImportJob · Account
-       TaxonomyCategory · TaxonomySubcategory · TaxonomyDefault
-        │
-    reports/generator.py
-    └─ HTML (Jinja2+Plotly) · CSV · XLSX
+ui/  →  services/  →  core/  →  db/  →  SQLite
+                ↑       ↑
+       async_runner  llm_backends · sanitizer · normalizer · classifier · categorizer
 ```
 
-### Flow 1 vs Flow 2
+L'UI può importare solo da `services/`; `core/` non può importare `db/`; `db/` non importa mai verso l'alto. Il coupling gate (`tools/coupling_check.py --strict`) blocca le PR che violano la regola.
 
-| | Flow 1 | Flow 2 |
-|---|---|---|
-| **Attivazione** | `DocumentSchema` già in DB per quel fingerprint colonne | Prima importazione di un nuovo formato |
-| **Schema** | Recuperato da DB, applicato direttamente | LLM inferisce lo schema da un campione anonimizzato |
-| **Promozione** | — | Il template Flow 2 approvato viene salvato e diventa Flow 1 |
-| **Auto-invalidazione** | Se il parse rate < 10%, lo schema viene eliminato e Flow 2 viene ritentato automaticamente | — |
-| **Costo LLM** | Zero (solo categorizzazione) | Una chiamata per classificazione + una per categorizzazione batch |
+Diagramma completo e Flow 1 vs Flow 2 → [docs/architecture.it.md](docs/architecture.it.md).
 
----
-
-## Struttura del progetto
+## Struttura del repository
 
 ```
-spendifai/
-├── app.py                  # Entry point Streamlit — onboarding gate + 9 pagine
-├── .env.example            # Template variabili d'ambiente
-├── pyproject.toml          # Dipendenze (uv / pip)
-│
-├── core/
-│   ├── models.py           # Enum: DocumentType, TransactionType, GirocontoMode …
-│   ├── schemas.py          # DocumentSchema (Pydantic) + invert_sign + llm_json_schema()
-│   ├── llm_backends.py     # LLMBackend ABC · Ollama · OpenAI · Claude · BackendFactory
-│   ├── sanitizer.py        # PII redaction (RF-10)
-│   ├── normalizer.py       # Encoding, parse_amount (Decimal), SHA-256, RF-03, RF-04
-│   ├── classifier.py       # Flow 2: inferenza DocumentSchema via LLM
-│   ├── categorizer.py      # Cascata 4-step + TaxonomyConfig (find_category_for_subcategory)
-│   └── orchestrator.py     # Pipeline principale: ProcessingConfig · process_file()
-│
-├── db/
-│   ├── models.py           # ORM SQLAlchemy (11 tabelle) + migrazioni automatiche
-│   ├── repository.py       # CRUD idempotente · persist_import_result() · CRUD tassonomia
-│   │                       #   bulk_set_giroconto_by_description()
-│   │                       #   get_transactions_by_rule_pattern()
-│   │                       #   seed_user_taxonomy_from_default()
-│   └── taxonomy_defaults.py  # Template tassonomia built-in (5 lingue: it/en/fr/de/es)
-│                              #   TAXONOMY_DEFAULTS · SUPPORTED_LANGUAGES
-│
-├── services/               # Facade layer — la UI importa solo da qui, mai da core.* o db.*
-│   ├── settings_service.py # SettingsService: CRUD impostazioni + tassonomia + conti + onboarding
-│   └── import_service.py   # ImportService: analisi file, pipeline, cache schema + re-export tipi
-│
-├── reports/
-│   ├── generator.py        # HTML (Jinja2+Plotly) · CSV · XLSX
-│   └── template_report.html.j2
-│
-├── ui/
-│   ├── onboarding_page.py  # Wizard primo avvio (4 step: lingua → titolari → conti → conferma)
-│   ├── sidebar.py          # Pulsanti navigazione (9 pagine) + modalità giroconto
-│   ├── upload_page.py      # Import multi-file + progress bar cross-session
-│   ├── registry_page.py    # Ledger filtrabile + selezione al click + bulk giroconto
-│   ├── analysis_page.py    # 7 grafici Plotly: barre mensili, saldo cumulativo,
-│   │                       #   pie+treemap spese, drill-down categoria, pie+treemap entrate,
-│   │                       #   top-10 descrizioni, stacked per conto + export HTML
-│   ├── review_page.py      # Correzione categoria + toggle giroconto + salvataggio regola
-│   ├── bulk_edit_page.py   # Operazioni massive: categoria/contesto/giroconto + eliminazione da filtro
-│   ├── rules_page.py       # CRUD completo regole + "Esegui tutte le regole" bulk re-categorizzazione
-│   ├── taxonomy_page.py    # CRUD DB-backed per categorie e sottocategorie
-│   ├── settings_page.py    # Locale, lingua, config LLM, expander reset tassonomia
-│   └── checklist_page.py   # Pivot mese × conto: checklist presenza transazioni
-│
-├── tools/
-│   ├── coupling_check.py   # Validatore accoppiamento architetturale (UI → services.* only)
-│   │                       #   --strict: applica baseline, usato in CI
-│   └── coupling_baseline.json  # Soglie max violazioni per file (attualmente tutte zero)
-│
-├── prompts/
-│   ├── classifier.json     # Prompt Flow 2 (hint invert_sign per file carta)
-│   └── categorizer.json    # Prompt categorizzazione transazioni
-│
-├── tests/
-│   ├── test_normalizer.py          # Test deterministici (parse_amount, SHA-256 …)
-│   ├── test_backends.py            # Factory backend, validazione, mock Ollama
-│   ├── test_categorizer.py         # Regole statiche, cascata, risoluzione tassonomia
-│   ├── test_repository_rules.py    # Upsert regole, pattern matching, toggle giroconto, bulk ops
-│   └── test_taxonomy_onboarding.py # Template multi-lingua + servizi onboarding (27 test)
-│
-└── support/
-    ├── formatting.py       # format_amount_display, format_date_display, format_raw_amount_display
-    └── logging.py
+sw_artifacts/
+├── app.py                  # Entry point Streamlit (onboarding gate + 14 pagine)
+├── core/                   # Pipeline: orchestrator, normalizer, classifier, categorizer, sanitizer, llm_backends
+├── services/               # Facade layer per l'UI; async runner; settings; import
+├── ui/                     # Pagine Streamlit + i18n + widgets
+├── db/                     # SQLAlchemy ORM, repository pattern, schema con auto-hash migrations
+├── api/                    # Endpoint REST FastAPI (opzionale)
+├── desktop/                # Launcher nativo (pywebview) + splash
+├── packaging/              # Build script: macos/, windows/, linux/, homebrew/, winget/
+├── docker/                 # Containerizzazione
+├── prompts/                # Template prompt LLM (JSON versionato)
+├── reports/                # Export HTML + CSV + XLSX
+├── tests/                  # Suite pytest (target coverage ≥ 90%)
+├── benchmark/              # Suite benchmark LLM (multi-provider)
+└── docs/                   # Documentazione utente e sviluppatore
 ```
 
----
+Dettagli → [docs/developer_guide.md](docs/developer_guide.md).
 
-## Installazione
+## 📚 Documentazione
 
-### ⚡ Installazione rapida (Docker — niente git clone)
-
-L'unico prerequisito è **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** installato e avviato.
-
-**Mac / Linux:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/drake69/spendifai/main/installer/install.sh | bash
-```
-
-**Windows (PowerShell):**
-```powershell
-irm https://raw.githubusercontent.com/drake69/spendifai/main/installer/install.ps1 | iex
-```
-
-Lo script scarica l'immagine pre-compilata da GitHub Container Registry, avvia il container e apre il browser su **http://localhost:8501** automaticamente.
-
-> **AI locale opzionale:** l'installer chiede se aggiungere Ollama + `gemma3:12b` (scaricato automaticamente, ~8 GB). Compatibile con Apple Silicon (arm64) e amd64.
-
-> **Aggiornamento all'ultima versione:**
-> ```bash
-> docker compose --project-directory ~/spendifai pull && docker compose --project-directory ~/spendifai up -d
-> ```
-
-> **Disinstallazione:** `curl -fsSL https://raw.githubusercontent.com/drake69/spendifai/main/installer/uninstall.sh | bash`
-
----
-
-### 🖥️ App desktop nativa (no Docker, no Terminal)
-
-Installer one-click che scaricano il modello AI automaticamente e lanciano una finestra nativa:
-
-| Piattaforma | Comando |
-|-------------|---------|
-| **macOS** | `bash packaging/macos/install.sh` oppure `brew install --cask spendifai` |
-| **Windows** | `winget install SpendifAi.SpendifAi` oppure esegui `install.ps1` |
-| **Ubuntu/Debian** | `sudo apt install ./spendifai_*.deb` (build: `bash packaging/linux/build-deb.sh`) |
-| **Fedora/RHEL** | `sudo dnf install ./spendifai-*.rpm` (build: `bash packaging/linux/build-rpm.sh`) |
-
-> L'installer rileva l'hardware, scarica il modello LLM migliore per la RAM disponibile (1–7 GB) e configura llama.cpp — **zero intervento utente**. L'app gira in una finestra nativa (pywebview), senza Terminal né browser.
-
----
-
-### Installazione developer (nativa, consigliata su Mac)
-
-> Setup completo, convenzioni di codice, sistema di priorità e flusso PR → **[CONTRIBUTING.md](CONTRIBUTING.md)**
-
-### Prerequisiti
-
-- **Python 3.13+**
-- **[uv](https://github.com/astral-sh/uv)** (gestore pacchetti consigliato)
-- **[Ollama](https://ollama.com)** per il backend LLM locale (default)
-
-### 1. Clona il repository
-
-```bash
-git clone https://github.com/drake69/spendify.git
-cd spendifai
-```
-
-### 2. Installa le dipendenze
-
-```bash
-uv sync
-```
-
-### 3. Configura le variabili d'ambiente
-
-```bash
-cp .env.example .env
-# Nessuna modifica necessaria per un'installazione locale standard — percorsi già impostati
-```
-
-### 4. Scarica il modello LLM locale (opzionale)
-
-```bash
-ollama pull gemma3:12b   # ~8 GB — salta se hai intenzione di usare OpenAI/Anthropic
-```
-
-> Mantieni Ollama in esecuzione (`ollama serve`) durante l'uso dell'app. Backend LLM, modello e API key si configurano dalla pagina **⚙️ Impostazioni** — non nel `.env`.
-
----
-
-## Configurazione
-
-Il file `.env` contiene solo parametri infrastrutturali. Tutto il resto — backend LLM, chiavi API, modello, nomi titolari per PII redaction, formato data, lingua — è configurabile dalla pagina **⚙️ Impostazioni** e persiste nel DB:
-
-```dotenv
-# URI database — lascia invariato per uso locale; sovrascritto da docker-compose per Docker
-SPENDIFAI_DB=sqlite:///ledger.db
-```
-
-> **Nient'altro appartiene al `.env`.** Backend LLM, URL Ollama, nome modello, chiavi API OpenAI/Anthropic e nomi titolari sono tutti salvati nella tabella `user_settings` e modificabili live dall'UI senza riavviare l'app.
-
-### Modalità giroconto
-
-Configurabile dalla sidebar dell'app:
-
-| Modalità | Comportamento |
+| Argomento | Lingue |
 |---|---|
-| `neutral` | I giroconti restano nel ledger come `internal_out` / `internal_in` (default) |
-| `exclude` | I giroconti vengono rimossi dal registro (saldo netto non influenzato) |
+| Installazione e primo avvio | [EN](docs/installazione.en.md) · [IT](docs/installazione.md) |
+| Guida utente (ogni pagina) | [EN](docs/guida_utente.en.md) · [IT](docs/guida_utente.md) |
+| Reference guide (pipeline, tassonomia, RF-03/04) | [EN](docs/reference_guide.en.md) · [IT](docs/reference_guide.md) |
+| Architettura | [EN](docs/architecture.md) · [IT](docs/architecture.it.md) |
+| Design decisions | [EN](docs/design_decisions.md) · [IT](docs/design_decisions.it.md) |
+| Configurazione | [EN](docs/configurazione.en.md) · [IT](docs/configurazione.md) |
+| Developer guide | [EN](docs/developer_guide.en.md) · [IT](docs/developer_guide.md) |
+| Guida alla categorizzazione | [EN](docs/guida_classificazione.en.md) · [IT](docs/guida_classificazione.md) |
+| Schema database | [EN](docs/database.en.md) · [IT](docs/database.md) |
+| Deployment | [EN](docs/deployment.en.md) · [IT](docs/deployment.md) |
+| Processo di rilascio | [EN](docs/release_process.md) · [IT](docs/release_process.it.md) |
+| Contribuire | [EN](CONTRIBUTING.en.md) · [IT](CONTRIBUTING.md) |
+| Politica di sicurezza | [EN](SECURITY.md) · [IT](SECURITY.it.md) |
+| Changelog | [EN](CHANGELOG.md) · [IT](CHANGELOG.it.md) |
 
-### Privacy e backend remoti
+## Contribuire
+
+Segnalazioni di bug, idee di feature e PR sono benvenute. Vedi [CONTRIBUTING.md](CONTRIBUTING.md) per workflow, policy di branching, framework delle priorità e gate CI.
+
+## Licenza
+
+**PolyForm Noncommercial 1.0.0** — vedi [LICENSE](LICENSE). Uso personale libero; l'uso commerciale richiede una licenza separata.
+
+---
+
+### Cosa lascia la macchina — onestà
+
+Tutti i dati finanziari sono memorizzati localmente in `~/.spendifai/ledger.db`.
+
+**Backend LLM locale (default — llama.cpp, Ollama)**: nulla lascia la macchina.
+
+**Backend LLM remoto (opt-in — OpenAI, Claude)**: il payload contiene
+descrizioni sanitizzate **insieme a** **importi**, **date** e **metadati
+delle colonne**.
+
+#### Esempio di redazione — categorizer (`core/categorizer.py:303`)
+
+Riga grezza della transazione dal CSV:
 
 ```
-[LOCAL — default]  Ollama locale: nessun dato esce dal processo.
-                   Nessuna sanitizzazione richiesta.
-
-[REMOTE — opt-in]  OpenAI / Claude: PII sanitization OBBLIGATORIA.
-                   IBAN → <ACCOUNT_ID>  |  PAN → <CARD_ID>
-                   CF   → <FISCAL_ID>  |  owner → <OWNER>
-                   Chiamata bloccata se assert_sanitized() fallisce.
+date:        2026-03-15
+description: "BONIFICO da MARIO ROSSI IT60X0542811101000000123456 CAU 12345 STIPENDIO MENSILE"
+amount:      1500.00
 ```
 
----
+Cosa l'LLM remoto riceve effettivamente:
 
-## Avvio
-
-```bash
-# Con uv
-uv run streamlit run app.py
-
-# Oppure
-streamlit run app.py
+```json
+{
+  "amount": "1500.00",
+  "description": "BONIFICO da Carlo Brambilla <ACCOUNT_ID> <TX_CODE> STIPENDIO MENSILE"
+}
 ```
 
-Al **primo avvio** appare automaticamente il wizard di onboarding (4 step: lingua, nomi titolari, conti, conferma). Le installazioni esistenti con dati già nella tassonomia vengono rilevate automaticamente e saltano il wizard.
-
-L'app si apre su `http://localhost:8501` con 9 pagine:
-
-| Pagina | Descrizione |
-|---|---|
-| **📥 Import** | Carica uno o più file (CSV / XLSX). Progresso live visibile da tutte le sessioni browser. Riepilogo: transazioni, riconciliazioni, transfer link, flow usato (1/2). |
-| **📋 Ledger** | Tabella filtrabile per data, tipo, descrizione, categoria, contesto, flag revisione. Click su una riga per selezionarla istantaneamente. Colonne Entrata/Uscita separate e allineate a destra. Filtro contesto + pannello assegnazione con suggerimenti Jaccard. Toggle giroconto con bulk-apply. Download CSV/XLSX. |
-| **✏️ Modifiche massive** | Operazioni in blocco su transazione di riferimento: toggle giroconto, assegnazione contesto (con similarità Jaccard), correzione categoria + salvataggio regola. Eliminazione massiva tramite filtri combinati (data, conto, tipo, descrizione, categoria) con anteprima e conferma `ELIMINA` obbligatoria. |
-| **📊 Analytics** | 7 grafici Plotly interattivi: barre mensili entrate/uscite, saldo cumulativo, pie+treemap spese per categoria, drill-down interattivo categoria→sottocategoria con trend mensile, pie+treemap entrate, top-10 descrizioni, stacked per conto. Export HTML. |
-| **🔍 Review** | Transazioni con `to_review=True`. Toggle giroconto (con bulk-apply). Correzione categoria/sottocategoria + salvataggio opzionale come regola permanente applicata immediatamente. Pulsante "Re-run LLM" per transazioni non pulite. Pulsante "Riesegui giroconti cross-account". |
-| **📏 Regole** | CRUD completo regole di categorizzazione. Modifica/elimina regole + ricalcolo bulk delle transazioni già categorizzate. Pulsante "▶️ Esegui tutte le regole" applica tutte le regole a ogni transazione del ledger in un colpo. |
-| **🗂️ Tassonomia** | CRUD DB-backed per categorie e sottocategorie (spese e entrate). Le modifiche hanno effetto immediato senza restart. |
-| **⚙️ Impostazioni** | Formato data, separatori importo, lingua descrizioni, contesti di vita, lista conti bancari, backend LLM (modello + chiavi API). Tutto persistito nel DB. |
-| **✅ Check List** | Tabella pivot mese × conto. Mese corrente in cima, ordine decrescente. Celle: numero tx o **—** se assenti. Colorazione per volume. Filtri: selezione conti, ultimi N mesi, nascondi mesi vuoti. Export CSV. |
-
----
-
-## Tassonomia
-
-La tassonomia è memorizzata nel database (tabelle `taxonomy_category` / `taxonomy_subcategory`) e gestita dalla pagina **🗂️ Tassonomia**.
-
-### Template multi-lingua built-in
-
-La tabella `taxonomy_default` contiene template immutabili in 5 lingue — Italiano, Inglese, Francese, Tedesco, Spagnolo. Vengono popolati da `db/taxonomy_defaults.py` al primo avvio (nessun file YAML). Durante l'onboarding l'utente seleziona la lingua e il template viene copiato nella tassonomia utente.
-
-Per reimpostare la tassonomia su una lingua diversa in qualsiasi momento: **⚙️ Impostazioni → 🔄 Reset tassonomia**.
-
-### Tassonomia di default (Italiano)
-
-**Categorie di spesa (15):** Casa · Alimentari · Ristorazione · Trasporti · Salute · Istruzione · Abbigliamento · Comunicazioni · Svago e tempo libero · Animali domestici · Finanza e assicurazioni · Cura personale · Tasse e tributi · Regali e donazioni · Altro
-
-**Categorie di entrata (7):** Lavoro dipendente · Lavoro autonomo · Rendite finanziarie · Rendite immobiliari · Trasferimenti e rimborsi · Prestazioni sociali · Altro entrate
-
-**La sottocategoria è la fonte di verità:** se LLM o una regola assegnano una sottocategoria presente in tassonomia, la categoria genitore corretta viene risolta automaticamente — i due livelli sono sempre consistenti nel DB.
-
----
-
-## Motore delle regole
-
-Le regole di categorizzazione sono memorizzate nella tabella `category_rule` e applicate in più punti del ciclo di vita.
-
-### Tipi di matching
-
-| Tipo | Comportamento |
-|---|---|
-| `contains` | Il pattern appare ovunque nella descrizione (case-insensitive) |
-| `exact` | La descrizione corrisponde esattamente al pattern (case-insensitive) |
-| `regex` | Regex Python completa confrontata con la descrizione |
-
-`get_transactions_by_rule_pattern` ricerca **tutte** le transazioni indipendentemente da come erano state categorizzate (LLM, regola o correzione manuale). Salvare una nuova regola corregge correttamente anche le transazioni già categorizzate dall'LLM.
-
-### Priorità
-
-Quando più regole corrispondono alla stessa transazione vince quella con il valore di `priority` più alto. La priorità di default è 10; è possibile assegnare qualsiasi intero.
-
-### Semantica upsert
-
-Creare una regola con la stessa coppia `(pattern, match_type)` di una regola esistente la **aggiorna** sul posto (categoria, sottocategoria, priorità) anziché creare un duplicato.
-
-### Applicazione retroattiva
-
-Salvare una regola dalle pagine **Ledger** o **Review** la applica immediatamente a tutte le transazioni esistenti che corrispondono al pattern, non solo alle future importazioni. Il messaggio di conferma indica quante transazioni sono state aggiornate. Lo stesso comportamento è disponibile dalla pagina **Regole** tramite l'opzione di ricalcolo bulk su singola regola.
-
-Inoltre, il pulsante **▶️ Esegui tutte le regole** nella pagina **Regole** applica tutte le regole a ogni transazione del ledger in un colpo solo (non limitato a `to_review=True`). Utile dopo aver creato più regole contemporaneamente o dopo aver importato dati storici.
-
----
-
-## Giroconti
-
-Un *giroconto* è un movimento interno tra conti di propria titolarità (es. bonifico da conto corrente a conto deposito, ricarica di una prepagata). Includere entrambi i lati nel saldo causerebbe double-counting.
-
-### Tipi di transazione
-
-| `tx_type` | Significato |
-|---|---|
-| `internal_out` | Lato uscente del giroconto (importo negativo) |
-| `internal_in` | Lato entrante del giroconto (importo positivo) |
-
-Entrambi i tipi sono esclusi dal saldo netto, dalle entrate e dalle uscite.
-
-### Rilevamento automatico (RF-04)
-
-La pipeline tenta di abbinare i giroconti automaticamente durante l'importazione con tre passaggi:
-
-1. **Regex keyword** — la descrizione corrisponde a un pattern configurato (es. "Giroconto", "Bonifico tra i miei conti") → alta confidenza
-2. **Matching importo + data** — stesso importo assoluto entro ±3 giorni, su `account_label` diversi → confidenza media/alta
-3. **Permutazioni nome titolare** — la descrizione contiene qualsiasi permutazione dei token del nome del titolare → alta confidenza (intercetta sia "Corsaro Luigi Gerotti Elena" che "Luigi Corsaro Elena Gerotti")
-
-### Riesecuzione cross-account
-
-Quando le due transazioni di un giroconto appartengono a file importati in momenti diversi, il primo import non può trovare la coppia. Usa il pulsante **"🔁 Riesegui rilevamento giroconti"** nella pagina **🔍 Review** per rieseguire il rilevamento globalmente su tutte le transazioni non-giroconto.
-
-### Toggle manuale
-
-Dalle pagine **Ledger** o **Review** è possibile contrassegnare manualmente qualsiasi transazione come giroconto (o ripristinarla):
-
-- **Toggle singolo** — cambia il `tx_type` della transazione selezionata (`expense` ↔ `internal_out`, `income` ↔ `internal_in`).
-- **Bulk apply** — se altre transazioni condividono la stessa descrizione, una checkbox (default: abilitata) consente di applicare la stessa modifica a tutte con un solo click. Il numero di transazioni coinvolte è visibile prima di confermare.
-
-`bulk_set_giroconto_by_description` in `db/repository.py` implementa l'operazione bulk: aggiorna tutte le transazioni con la descrizione indicata eccetto quella già modificata, e restituisce il numero di righe cambiate.
-
----
-
-## Contesti di vita
-
-I contesti di vita sono una dimensione di classificazione ortogonale alla tassonomia delle categorie. Mentre la categoria risponde *cosa è stato acquistato*, il contesto risponde *per quale area della vita*.
-
-### Design
-
-| Aspetto | Dettaglio |
-|---|---|
-| **Storage** | Colonna `context VARCHAR(64)` nullable sulla tabella `Transaction` |
-| **Ortogonalità** | Indipendente da categoria/sottocategoria — qualsiasi combinazione è valida |
-| **Configurabile** | Aggiunta, rinomina e rimozione contesti dalla pagina **⚙️ Impostazioni** (salvati come JSON in `user_settings`) |
-| **Contesti default** | Quotidianità · Lavoro · Vacanza |
-
-### Assegnazione
-
-Dalla pagina **📋 Ledger**, seleziona una transazione e apri il pannello espandibile "🌍 Assegna contesto":
-
-1. Scegli un contesto dal menu a discesa (o cancella quello esistente)
-2. Attiva opzionalmente **"Applica anche a transazioni simili"** — la similarità Jaccard a livello di token (soglia 0.35) trova transazioni con descrizione semanticamente vicina e pre-assegna lo stesso contesto
-3. Clicca **Applica**
-
-### Filtro
-
-La barra filtri del registro include un selettore contesto: *tutti*, i singoli valori configurati, o *— nessuno —* (transazioni senza contesto assegnato).
-
----
-
-## Test
-
-```bash
-# Tutti i test (nessun mock LLM richiesto)
-uv run python -m pytest tests/ -v
-
-# Con coverage
-uv run python -m pytest tests/ --cov=core --cov=db --cov-report=term-missing
-```
-
-### File di test
-
-| File | Copertura |
-|---|---|
-| `test_normalizer.py` | `parse_amount`, dedup SHA-256, encoding detection |
-| `test_backends.py` | Factory backend, validazione, mock Ollama |
-| `test_categorizer.py` | Regole statiche, cascata 4-step, risoluzione tassonomia |
-| `test_repository_rules.py` | Upsert regole, `get_transactions_by_rule_pattern` (tutti i tipi + regressione LLM-sourced), `apply_rules_to_review_transactions`, `toggle_transaction_giroconto`, `bulk_set_giroconto_by_description` |
-| `test_taxonomy_onboarding.py` | Struttura `TAXONOMY_DEFAULTS` (5 lingue), migrazione `taxonomy_default` (seeding + idempotenza), metodi onboarding di `SettingsService`, auto-skip per utenti esistenti |
-
-Tutti i test usano un database SQLite in-memory — nessun I/O su file, nessun servizio esterno richiesto.
-
----
-
-## Decisioni di design
-
-### `Decimal` — mai `float`
-
-Tutti gli importi sono `decimal.Decimal`. I float IEEE 754 introducono errori di arrotondamento che falsano saldi e riconciliazioni.
-
-### Idempotenza SHA-256
-
-Ogni transazione ha un `id` di 24 caratteri (SHA-256 troncato) calcolato deterministicamente da `(source_file, date, amount, description)`. Re-importare lo stesso file non genera duplicati.
-
-### Correzione segno carta (`invert_sign`)
-
-I file movimenti italiani per carte di credito/debito esportano spesso gli acquisti come valori positivi. Il flag `DocumentSchema.invert_sign`, impostato dall'LLM durante la classificazione Flow 2, istruisce il normalizzatore a negare tutti gli importi — le spese diventano negative e i rimborsi positivi con un'unica operazione simmetrica.
-
-#### Algoritmo di rilevamento in due passi
-
-Il classificatore decide il valore di `invert_sign` con un algoritmo in due passi. **Lo Step 0 ha la priorità massima: se si attiva, lo Step 1 viene saltato completamente.** Lo Step 1 è consultato solo quando lo Step 0 non riesce a dare una risposta definitiva.
-
-**Step 0 — Sinonimi del nome colonna (priorità massima)**
-
-Il nome della colonna importo viene confrontato con tre gruppi di sinonimi:
-
-| Gruppo | Esempi di nomi | Decisione |
-|---|---|---|
-| **Sinonimi di uscita** | Uscita, Uscite, Addebito, Addebiti, Pagamento, Spesa, Dare, Importo addebitato | `invert_sign = true` (spese salvate come positivi → negarle) |
-| **Sinonimi di entrata** | Entrata, Entrate, Accredito, Accrediti, Avere, Credito, Importo accreditato | `invert_sign = false` (entrate già positive → nessuna modifica) |
-| **Nomi neutri** | Importo, Amount, Valore, Totale | Nessuna decisione — si procede allo Step 1 |
-
-Il matching è case-insensitive e parziale (es. "Addebiti carta" corrisponde a "Addebito"). La regola dei sinonimi di uscita si applica solo ai doc_type carta; conti correnti e depositi mantengono sempre `invert_sign = false` indipendentemente dal nome della colonna.
-
-**Step 1 — Analisi della distribuzione dei segni (solo nomi neutri)**
-
-Quando lo Step 0 trova un nome neutro e non può classificare per nome, il classificatore conta i valori positivi e negativi nel campione e calcola `positive_ratio` e `negative_ratio`:
-
-- File carta, maggioranza positivi (> 60 %): le spese sono salvate come positivi (convenzione AMEX / tipici export italiani) → `invert_sign = true`
-- File carta, maggioranza negativi (> 60 %): le spese hanno già il segno corretto → `invert_sign = false`
-- Split circa 50/50: si analizzano le descrizioni (nomi di esercenti con importi positivi → `invert_sign = true`; "bonifico ricevuto" con importo positivo → `invert_sign = false`)
-- Conto corrente / deposito: sempre `invert_sign = false`, indipendentemente dalla distribuzione
-
-#### Campi diagnostici
-
-Ogni `DocumentSchema` prodotto dal Flow 2 include quattro campi diagnostici per audit e debug:
-
-| Campo | Tipo | Contenuto |
-|---|---|---|
-| `positive_ratio` | `float \| null` | Frazione di valori > 0 nella colonna importo nel campione |
-| `negative_ratio` | `float \| null` | Frazione di valori < 0 nella colonna importo nel campione |
-| `semantic_evidence` | `list[str]` | 2–4 frasi brevi dell'LLM che spiegano la decisione |
-| `normalization_case_id` | `str \| null` | C1 = conto corrente signed_single · C2 = carta invertita · C3 = carta già negativa · C4 = colonne Dare/Avere · C5 = ambiguo |
-
-Questi campi sono persistiti nella tabella DB `document_schema` e visibili nel riepilogo dello schema Flow 2 nell'UI.
-
-### Sottocategoria come chiave primaria
-
-Il categorizzatore tratta la sottocategoria come autoritativa. `TaxonomyConfig.find_category_for_subcategory()` risolve la categoria genitore da qualsiasi nome di sottocategoria valido. LLM e regole possono specificare il livello più granulare e la gerarchia è sempre consistente nel DB.
-
-### Tassonomia nel DB
-
-La tassonomia a 2 livelli (categorie + sottocategorie) risiede in due tabelle DB (`taxonomy_category`, `taxonomy_subcategory`). Al primo avvio il wizard di onboarding copia il template della lingua scelta dalla tabella immutabile `taxonomy_default` nella tassonomia utente. Nessun file YAML. Le modifiche successive sono gestite interamente dall'UI — nessun restart richiesto.
-
-### PII sanitization come precondizione
-
-`assert_sanitized()` è chiamata in `call_with_fallback()` prima di qualsiasi richiesta a backend remoto. Se il testo contiene pattern IBAN/PAN/CF rilevabili, la chiamata viene rifiutata — non degradata silenziosamente.
-
-### Circuit breaker e quarantena
-
-`call_with_fallback(primary, ...)` prova il backend primario, poi Ollama locale come fallback. Se entrambi falliscono, la transazione riceve `to_review=True` e viene messa in coda senza bloccare il resto del batch.
-
-### Nessun LangChain
-
-I backend LLM usano direttamente `openai` SDK, `anthropic` SDK e `requests` (per Ollama). Nessuna dipendenza da framework di orchestrazione LLM.
-
-### RF-03: algoritmo a 3 fasi
-
-La riconciliazione carta–conto corrente usa: (1) finestra temporale ±45 giorni, (2) sliding window contigua (gap ≤ 5 giorni, O(n²)), (3) subset sum al boundary (k=10 tx, ~10⁶ operazioni).
-
----
-
-## Dipendenze principali
-
-| Pacchetto | Versione | Scopo |
-|---|---|---|
-| `streamlit` | ≥ 1.35 | UI |
-| `pandas` | ≥ 2.2 | Elaborazione dati |
-| `sqlalchemy` | ≥ 2.0 | ORM / persistenza |
-| `pydantic` | ≥ 2.0 | Validazione schemi |
-| `openai` | ≥ 1.30 | Backend OpenAI |
-| `anthropic` | ≥ 0.28 | Backend Claude |
-| `requests` | ≥ 2.31 | Backend Ollama |
-| `chardet` | ≥ 5.0 | Encoding detection |
-| `plotly` | ≥ 5.20 | Grafici |
-| `jinja2` | ≥ 3.1 | Template report HTML |
-| `pyyaml` | ≥ 6.0 | Parsing seed taxonomy.yaml |
-| `pytest` | ≥ 8.0 | Test |
-
----
-
-*Tutti i dati sono salvati localmente nel database SQLite (`ledger.db`). Nessuna informazione finanziaria viene trasmessa a servizi esterni salvo esplicita configurazione del backend remoto e sanitizzazione PII obbligatoria.*
+Cosa è cambiato:
+- `MARIO ROSSI` (nome titolare configurato) → `Carlo Brambilla` (nome finto dal pool italiano, ripristinato dopo la risposta LLM)
+- `IT60X...` (IBAN) → `<ACCOUNT_ID>`
+- `CAU 12345` (codice transazione bancaria) → `<TX_CODE>`
+- `amount` e metadati di data: **inviati in chiaro**
+
+Il prompt del categorizer dice al modello di "basare la decisione su
+descrizione, importo e contesto" (`prompts/categorizer.json`). Se
+l'importo influisca davvero sull'accuracy in pratica non è stato
+misurato contro una baseline senza importi — il default conservativo
+lo lascia nel payload finché non sarà misurato.
+
+#### Roadmap
+
+Le modalità di redazione di importi e date per i backend remoti
+(`none` / `buckets` / `strip`) sono in roadmap — item di backlog **AI-55**.

--- a/README.md
+++ b/README.md
@@ -6,658 +6,179 @@
 [![License: PolyForm NC](https://img.shields.io/badge/license-PolyForm%20Noncommercial-orange)](LICENSE)
 [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 [![Streamlit](https://img.shields.io/badge/UI-Streamlit-ff4b4b?logo=streamlit&logoColor=white)](https://streamlit.io)
-[![Issues](https://img.shields.io/github/issues/drake69/spendifai)](https://github.com/drake69/spendify/issues)
-[![Last commit](https://img.shields.io/github/last-commit/drake69/spendifai)](https://github.com/drake69/spendify/commits/main)
+[![Issues](https://img.shields.io/github/issues/drake69/spendify)](https://github.com/drake69/spendify/issues)
+[![Last commit](https://img.shields.io/github/last-commit/drake69/spendify)](https://github.com/drake69/spendify/commits/main)
 [![Support on Patreon](https://img.shields.io/badge/Patreon-buy%20me%20a%20coffee%20☕-F96854?logo=patreon&logoColor=white)](https://patreon.com/drake69)
 
 > 🇮🇹 [Leggi in italiano](README.it.md)
 
-Unified personal finance ledger with a hybrid deterministic + LLM pipeline.
-
-Aggregates heterogeneous movements files (current accounts, credit cards, debit cards, savings accounts, prepaid cards) into a single chronological ledger, eliminating double-counting from periodic card settlements and internal transfers. Processing runs **offline-first**; remote LLM backends are supported as opt-in with mandatory PII sanitization.
+Unified personal finance ledger with a hybrid deterministic + LLM pipeline. Aggregates heterogeneous bank exports (current accounts, credit/debit/prepaid cards, savings accounts) into a single chronological ledger, eliminating double-counting from periodic card settlements and internal transfers. Offline-first; remote LLM backends opt-in with mandatory PII sanitization.
 
 ---
 
-## Table of Contents
-
-- [Features](#features)
-- [Architecture](#architecture)
-- [Project structure](#project-structure)
-- [Installation](#installation)
-- [Configuration](#configuration)
-- [Running the app](#running-the-app)
-- [Taxonomy](#taxonomy)
-- [Rule engine](#rule-engine)
-- [Giroconto (internal transfers)](#giroconto-internal-transfers)
-- [Tests](#tests)
-- [Design decisions](#design-decisions)
+> 👋 **End users — looking to install Spendif.ai?**
+> Go to the [Getting Started page](https://drake69.github.io/spendify/getting-started.en.html) for the illustrated install + first-launch guide. This README is for developers and contributors.
 
 ---
 
-## Features
+## What it is (technical)
 
-| Feature | Detail |
-|---|---|
-| **Automatic classification** | Detects document type (current account, credit/debit card, prepaid, savings) with no prior configuration |
-| **Deterministic normalization** | Encoding detection, delimiter detection, header detection, amounts as `Decimal` (never `float`) |
-| **Card sign correction** | `invert_sign` flag in `DocumentSchema`: when a card file stores expenses as positive values, they are negated automatically |
-| **SHA-256 idempotency** | Re-importing the same file always produces exactly the same set of rows |
-| **Card–account reconciliation (RF-03)** | 3-phase algorithm that eliminates double-counting from monthly aggregate settlements |
-| **Internal transfer detection (RF-04)** | Symbolic amount + time-window matching; configurable exclusion or neutralization |
-| **Cascade categorization (RF-05)** | User rules → static regex → structured LLM → fallback "Other" |
-| **Rule engine with bulk apply** | Deterministic rules apply to all existing transactions on save, not just future imports |
-| **Subcategory-authoritative matching** | Subcategory is the primary key: if an LLM or rule assigns a subcategory present in the taxonomy, the parent category is resolved automatically |
-| **Guided onboarding wizard** | 4-step first-run wizard: language selection (browser-detected), owner names, bank accounts, confirmation. Atomic write: DB populated only on final "Start!". Skipped automatically if taxonomy already exists (existing installations). |
-| **Multi-language taxonomy** | Built-in default taxonomy in 5 languages (🇮🇹 🇬🇧 🇫🇷 🇩🇪 🇪🇸). Seeded from `taxonomy_default` DB table (no YAML file). Language chosen at onboarding; can be reset from Settings at any time. |
-| **2-level taxonomy in DB** | 15 expense + 7 income categories; managed via the Taxonomy UI page (DB-backed, no file restart required) |
-| **Multi-provider LLM backend** | llama.cpp (local GGUF), Ollama (local, default), OpenAI, Claude, vLLM, OpenAI-compatible — shared abstract interface, no LangChain |
-| **LLM config in UI** | Backend, model and API keys are configurable from the Settings page without editing `.env`. Context window auto-detected from GGUF header / Ollama API / static lookup — no manual input required. |
-| **PII sanitization (RF-10)** | IBAN, PAN, fiscal codes, owner names redacted before any remote call |
-| **Circuit breaker** | Automatic fallback to local Ollama; quarantine (`to_review=True`) if all backends fail |
-| **Life contexts** | User-configurable orthogonal dimension (e.g. Everyday / Work / Vacation) assignable to any transaction; Jaccard-based similarity suggestions pre-fill context from past transactions |
-| **LLM re-run on failures** | Review page button re-runs description cleaning + categorization only on transactions where the LLM previously failed (`description == raw_description`) |
-| **Cross-account giroconto re-detection** | Review page button re-runs `detect_internal_transfers` globally on all transactions to catch pairs missed because the counterpart file was imported later |
-| **Owner-name permutation matching** | All token permutations of account-holder names are checked for giroconto detection, preventing missed matches when the name order varies across bank files |
-| **Service layer + CI coupling gate** | All UI pages import only from `services.*`, never from `core.*` or `db.*` directly. `tools/coupling_check.py --strict` enforces this in CI; violations fail the PR. |
-| **SQLAlchemy persistence** | 11 ORM tables; idempotent CRUD; automatic migrations on startup |
-| **Cross-session import progress** | Import job state stored in DB; all browser sessions see live progress |
-| **Report export** | Standalone HTML (Plotly), CSV, XLSX |
-| **14-page Streamlit UI** | Import → Import History → Ledger → Bulk Edit → Analytics → Report → Budget → Budget vs Actual → Review → Rules → Taxonomy → Settings → Checklist → Chat |
-| **Full i18n (EN + IT)** | 760+ translation keys, all UI pages internationalized; JSON-based with `t(key)` and Italian fallback |
-| **Monthly coverage checklist** | Pivot table (month × account) showing transaction counts; highlights missing months at a glance |
-| **Adaptive support chatbot** | Three modes auto-selected from user LLM settings: RAG Cloud (Claude/OpenAI), RAG Local (Ollama/vLLM), or deterministic FAQ match (TF-IDF, no LLM). Multi-language knowledge base (IT/EN/DE/ES/FR/PT). |
+- **Python 3.13 · Streamlit · SQLAlchemy · Pydantic · Pandas**
+- **Hybrid pipeline**: deterministic normalizer + LLM classifier + categorizer cascade
+- **Multi-backend LLM** with circuit breaker: llama.cpp (default for desktop), Ollama, OpenAI, Claude — direct SDK use, no LangChain
+- **Native desktop launcher**: pywebview + PyInstaller → DMG / MSIX / .deb / .rpm
+- **14-page Streamlit UI**, full IT+EN i18n (760+ translation keys)
 
----
+## What's implemented
+
+- **Hybrid pipeline (deterministic + LLM)** — `core/normalizer.py` parses any tabular bank export; `core/classifier.py` infers `DocumentSchema` via LLM; `core/categorizer.py` runs a 4-step cascade (user rules → regex → LLM → fallback)
+- **Multi-backend LLM with circuit breaker** — `core/llm_backends.py` factory: llama.cpp, Ollama, OpenAI, Claude. Automatic fallback + quarantine on failure
+- **PII sanitization (RF-10)** — IBAN / PAN / fiscal code / owner-name redaction in `core/sanitizer.py`, mandatory before any remote call (`assert_sanitized()` is a precondition, not best-effort)
+- **Multi-language taxonomy** — 2-level in DB, 5 languages (it/en/fr/de/es), configurable from the Streamlit UI
+- **Card-account reconciliation (RF-03, beta)** — 3-phase algorithm in `core/normalizer.py`: pairs credit-card settlements with the underlying expenses to eliminate double-counting *(edge cases still being refined)*
+- **Internal transfer detection (RF-04, beta)** — symbolic-amount + ±7-day window matching, with owner-name permutations to catch "Cognome Nome" exports *(edge cases still being refined)*
+
+## 👩‍💻 Develop locally
+
+```bash
+git clone https://github.com/drake69/spendify.git
+cd spendify
+uv sync --extra desktop
+
+# Local LLM (developer choice — the desktop installer handles this automatically):
+#   → if you already have Ollama running:   ollama pull gemma3:12b
+#   → otherwise: `uv sync` installs llama-cpp-python and the launcher
+#     auto-downloads a GGUF model on first run
+
+./start.sh                    # or: streamlit run app.py
+```
+
+Prerequisites: **Python 3.13+**, **[uv](https://github.com/astral-sh/uv)**, and either Ollama or nothing (llama.cpp is bundled). Full setup → [CONTRIBUTING.en.md](CONTRIBUTING.en.md).
+
+### Run as a native desktop app from source
+
+```bash
+uv run python -m desktop.launcher
+```
+
+Opens a pywebview window, downloads an AI model on first run, and starts Streamlit inside the same window. Identical to the bundled DMG/MSIX experience.
+
+## Run tests
+
+```bash
+uv run pytest -v                                  # full suite (no LLM mocks)
+uv run pytest --cov=. --cov-report=term-missing   # with coverage (target ≥ 90%)
+uv run pytest -k "architecture"                   # layer separation gate
+uv run pytest -k "security"                       # forbidden patterns + SQL injection
+```
+
+Architectural and security tests are mandatory CI gates and must stay green on `main`.
 
 ## Architecture
 
 ```
-┌──────────────────────────────────────────────────────────────────────────┐
-│                            app.py  (Streamlit)                           │
-│  [onboarding gate] → sidebar → upload │ ledger │ bulk-edit │ analytics  │
-│                               review │ rules │ taxonomy │ settings │ chat │
-└──────────────────────────┬───────────────────────────────────────────────┘
-                           │ services.*  (facade layer)
-               core/orchestrator.py
-               ProcessingConfig  ·  process_file()
-                           │
-        ┌──────────────────┼───────────────────┐
-        │                  │                   │
- Flow 1 (template)    Flow 2 (schema-on-read)
- DocumentSchema        classifier.py → LLM  → DocumentSchema
- already in DB         (sanitized sample)      invert_sign detection
-        │
- normalizer.py          sanitizer.py      llm_backends.py
- ├─ encoding detect     ├─ IBAN/PAN/CF    ├─ OllamaBackend
- ├─ parse_amount()      ├─ owner names    ├─ OpenAIBackend
- ├─ SHA-256 tx_id       └─ assert_sani.. └─ ClaudeBackend
- ├─ invert_sign                              BackendFactory
- ├─ RF-03 reconcile                          call_with_fallback()
- └─ RF-04 transfers
-        │
- categorizer.py  ←── TaxonomyConfig (loaded from DB)
- Step 0: user rules  (subcategory → category resolution)
- Step 1: static regex
- Step 2: ML stub
- Step 3: LLM structured output  (subcategory constrained enum)
- Step 4: fallback "Other"
-        │
-    db/repository.py   (SQLAlchemy, idempotent)
-    └─ Transaction · ImportBatch · DocumentSchemaModel
-       ReconciliationLink · InternalTransferLink · CategoryRule
-       UserSettings · ImportJob · Account
-       TaxonomyCategory · TaxonomySubcategory · TaxonomyDefault
-        │
-    reports/generator.py
-    └─ HTML (Jinja2+Plotly) · CSV · XLSX
-
- chat_bot/engine.py  ←── adaptive support chatbot
- ├─ RAG Cloud (Claude/OpenAI API)
- ├─ RAG Local (Ollama/vLLM)
- └─ FAQ Match (TF-IDF classifier, no LLM)
-     knowledge/<lang>/faq.json · docs/
+ui/  →  services/  →  core/  →  db/  →  SQLite
+                ↑       ↑
+       async_runner  llm_backends · sanitizer · normalizer · classifier · categorizer
 ```
 
-### Flow 1 vs Flow 2
+UI may import only `services/`; `core/` may not import `db/`; `db/` may not import upward. The coupling gate (`tools/coupling_check.py --strict`) blocks PRs that violate this.
 
-| | Flow 1 | Flow 2 |
-|---|---|---|
-| **Trigger** | `DocumentSchema` already in DB for that column fingerprint | First import of a new format |
-| **Schema** | Retrieved from DB and applied directly | LLM infers the schema from an anonymized sample |
-| **Promotion** | — | Approved Flow 2 template is saved and becomes Flow 1 |
-| **Auto-invalidation** | If parse rate < 10%, schema is deleted and Flow 2 retry is triggered automatically | — |
-| **LLM cost** | Zero (categorization only) | One call for classification + one for batch categorization |
+Full diagram and Flow 1 vs Flow 2 → [docs/architecture.md](docs/architecture.md).
 
----
-
-## Project structure
+## Repository layout
 
 ```
-spendifai/
-├── app.py                  # Streamlit entry point — onboarding gate + 14 pages
-├── .env.example            # Environment variable template
-├── pyproject.toml          # Dependencies (uv / pip)
-│
-├── core/
-│   ├── models.py           # Enums: DocumentType, TransactionType, GirocontoMode …
-│   ├── schemas.py          # DocumentSchema (Pydantic) + invert_sign + llm_json_schema()
-│   ├── llm_backends.py     # LLMBackend ABC · Ollama · OpenAI · Claude · BackendFactory
-│   ├── sanitizer.py        # PII redaction (RF-10)
-│   ├── normalizer.py       # Encoding, parse_amount (Decimal), SHA-256, RF-03, RF-04
-│   ├── classifier.py       # Flow 2: DocumentSchema inference via LLM
-│   ├── categorizer.py      # 4-step cascade + TaxonomyConfig (find_category_for_subcategory)
-│   └── orchestrator.py     # Main pipeline: ProcessingConfig · process_file()
-│
-├── db/
-│   ├── models.py           # SQLAlchemy ORM (11 tables) + automatic migrations
-│   ├── repository.py       # Idempotent CRUD · persist_import_result() · taxonomy CRUD
-│   │                       #   bulk_set_giroconto_by_description()
-│   │                       #   get_transactions_by_rule_pattern()
-│   │                       #   seed_user_taxonomy_from_default()
-│   └── taxonomy_defaults.py  # Built-in taxonomy templates (5 languages: it/en/fr/de/es)
-│                              #   TAXONOMY_DEFAULTS · SUPPORTED_LANGUAGES
-│
-├── services/               # Facade layer — UI imports only from here, never from core.* or db.*
-│   ├── settings_service.py # SettingsService: CRUD settings + taxonomy + accounts + onboarding
-│   └── import_service.py   # ImportService: file analysis, pipeline, schema cache + type re-exports
-│
-├── reports/
-│   ├── generator.py        # HTML (Jinja2+Plotly) · CSV · XLSX
-│   └── template_report.html.j2
-│
-├── ui/
-│   ├── onboarding_page.py  # First-run wizard (4 steps: language → owners → accounts → confirm)
-│   ├── sidebar.py          # Navigation buttons (9 pages) + giroconto mode
-│   ├── upload_page.py      # Multi-file import + cross-session progress bar
-│   ├── registry_page.py    # Filterable ledger + row-click selection + giroconto bulk-apply
-│   ├── analysis_page.py    # 7 Plotly charts: monthly bars, cumulative balance,
-│   │                       #   expense pie+treemap, category drill-down, income pie+treemap,
-│   │                       #   top-10 descriptions, stacked by account + HTML export
-│   ├── review_page.py      # Category correction + giroconto toggle + optional rule saving
-│   ├── bulk_edit_page.py   # Bulk operations: category/context/giroconto + mass deletion by filter
-│   ├── rules_page.py       # Full CRUD for CategoryRule + "Run all rules" bulk re-categorization
-│   ├── taxonomy_page.py    # DB-backed CRUD for categories and subcategories
-│   ├── settings_page.py    # Locale, language, LLM config, taxonomy reset expander
-│   ├── checklist_page.py   # Month × account pivot: transaction presence checklist
-│   └── chat_page.py        # Adaptive support chatbot (FAQ + RAG)
-│
-├── tools/
-│   ├── coupling_check.py   # Architectural coupling validator (UI → services.* only)
-│   │                       #   --strict: enforces baseline, used in CI
-│   └── coupling_baseline.json  # Per-file max violation thresholds (currently all zero)
-│
-├── chat_bot/
-│   ├── engine.py           # ChatBotEngine: auto-selects RAG cloud/local or FAQ match
-│   ├── rag.py              # RAG engine: TF-IDF retrieval + LLM generation
-│   ├── faq_classifier.py   # Deterministic TF-IDF FAQ matcher (no LLM needed)
-│   ├── faq_store.py        # Loads FAQ (JSON/MD) and doc chunks from knowledge/
-│   ├── prompts.json        # System prompts + multi-language no-answer messages
-│   └── knowledge/          # FAQ and docs per language (it/, en/, de/, es/, fr/, pt/)
-│
-├── prompts/
-│   ├── classifier.json     # System+user prompts for Flow 2 schema detection (invert_sign hint)
-│   └── categorizer.json    # System+user prompts for transaction categorization
-│
-├── tests/
-│   ├── test_normalizer.py          # Deterministic tests (parse_amount, SHA-256 …)
-│   ├── test_backends.py            # Backend factory, validation, Ollama mock
-│   ├── test_categorizer.py         # Static rules, cascade, taxonomy resolution
-│   ├── test_repository_rules.py    # Rule upsert, pattern matching, giroconto toggle, bulk ops
-│   └── test_taxonomy_onboarding.py # Multi-language taxonomy defaults + onboarding service (27 tests)
-│
-└── support/
-    ├── formatting.py       # format_amount_display, format_date_display, format_raw_amount_display
-    └── logging.py
+sw_artifacts/
+├── app.py                  # Streamlit entry point (onboarding gate + 14 pages)
+├── core/                   # Pipeline: orchestrator, normalizer, classifier, categorizer, sanitizer, llm_backends
+├── services/               # Facade layer for UI; async runner; settings; import
+├── ui/                     # Streamlit pages + i18n + widgets
+├── db/                     # SQLAlchemy ORM, repository pattern, schema with auto-hash migrations
+├── api/                    # FastAPI REST endpoints (optional)
+├── desktop/                # Native launcher (pywebview) + splash
+├── packaging/              # Build scripts: macos/, windows/, linux/, homebrew/, winget/
+├── docker/                 # Containerisation
+├── prompts/                # LLM prompt templates (versioned JSON)
+├── reports/                # HTML + CSV + XLSX export
+├── tests/                  # pytest suite (≥ 90% coverage target)
+├── benchmark/              # LLM benchmark suite (multi-provider)
+└── docs/                   # User & developer documentation
 ```
 
----
+More detail → [docs/developer_guide.en.md](docs/developer_guide.en.md).
 
-## Installation
+## 📚 Documentation
 
-### ⚡ Quick install (Docker — no git clone required)
-
-The only prerequisite is **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** installed and running.
-
-**Mac / Linux:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/drake69/spendifai/main/installer/install.sh | bash
-```
-
-**Windows (PowerShell):**
-```powershell
-irm https://raw.githubusercontent.com/drake69/spendifai/main/installer/install.ps1 | iex
-```
-
-The script downloads the pre-built image from GitHub Container Registry, starts the container and opens the browser at **http://localhost:8501** automatically.
-
-> **Optional local AI:** the installer prompts whether to add Ollama + `gemma3:12b` (downloaded automatically, ~8 GB). Works on Apple Silicon (arm64) and amd64.
-
-> **Update to latest version:**
-> ```bash
-> docker compose --project-directory ~/spendifai pull && docker compose --project-directory ~/spendifai up -d
-> ```
-
-> **Uninstall:** `curl -fsSL https://raw.githubusercontent.com/drake69/spendifai/main/installer/uninstall.sh | bash`
-
----
-
-### 🖥️ Native desktop app (no Docker, no Terminal)
-
-One-click installers that download the AI model automatically and launch a native window:
-
-| Platform | Command |
-|----------|---------|
-| **macOS** | `bash packaging/macos/install.sh` or `brew install --cask spendifai` |
-| **Windows** | `winget install SpendifAi.SpendifAi` or run `install.ps1` |
-| **Ubuntu/Debian** | `sudo apt install ./spendifai_*.deb` (build with `bash packaging/linux/build-deb.sh`) |
-| **Fedora/RHEL** | `sudo dnf install ./spendifai-*.rpm` (build with `bash packaging/linux/build-rpm.sh`) |
-
-> The installer detects your hardware, downloads the best LLM model for your RAM (1–7 GB), and configures llama.cpp — **zero user intervention**. The app runs in a native window (pywebview) with no Terminal or browser needed.
-
----
-
-### Developer install (native, Mac recommended)
-
-> Full setup instructions, coding conventions, priority system and PR workflow → **[CONTRIBUTING.md](CONTRIBUTING.md)**
-
-### Prerequisites
-
-- **Python 3.13+**
-- **[uv](https://github.com/astral-sh/uv)** (recommended package manager) or `pip`
-- **[Ollama](https://ollama.com)** for the local LLM backend (default)
-
-### 1. Clone the repository
-
-```bash
-git clone https://github.com/drake69/spendify.git
-cd spendifai
-```
-
-### 2. Install dependencies
-
-```bash
-uv sync
-```
-
-### 3. Configure environment variables
-
-```bash
-cp .env.example .env
-# No edits needed for a standard local install — DB path and taxonomy path are already set
-```
-
-### 4. Pull the local LLM model (optional)
-
-```bash
-ollama pull gemma3:12b   # ~8 GB — skip if you plan to use OpenAI/Anthropic
-```
-
-> Keep Ollama running (`ollama serve`) while using the app. LLM backend, model and API keys are configured from **⚙️ Settings** in the UI — not in `.env`.
-
----
-
-## Configuration
-
-The `.env` file contains only infrastructure parameters. Everything else — LLM backend, API keys, model, owner names for PII redaction, date format, language — is configured from the **⚙️ Settings** page and persisted in the DB:
-
-```dotenv
-# Database URI — leave as-is for local use; overridden by docker-compose for Docker installs
-SPENDIFAI_DB=sqlite:///ledger.db
-```
-
-> **Nothing else belongs in `.env`.** LLM backend, Ollama URL, model name, OpenAI/Anthropic API keys and owner names for PII redaction are all stored in the `user_settings` table and editable live from the UI without restarting the app.
-
-### Transfer mode (giroconto)
-
-Configurable from the app sidebar:
-
-| Mode | Behaviour |
+| Topic | Languages |
 |---|---|
-| `neutral` | Internal transfers stay in the ledger as `internal_out` / `internal_in` (default) |
-| `exclude` | Internal transfers are removed from the ledger (net balance unaffected) |
+| Install & first launch | [EN](docs/installazione.en.md) · [IT](docs/installazione.md) |
+| User guide (every page) | [EN](docs/guida_utente.en.md) · [IT](docs/guida_utente.md) |
+| Reference guide (pipeline, taxonomy, RF-03/04) | [EN](docs/reference_guide.en.md) · [IT](docs/reference_guide.md) |
+| Architecture | [EN](docs/architecture.md) · [IT](docs/architecture.it.md) |
+| Design decisions | [EN](docs/design_decisions.md) · [IT](docs/design_decisions.it.md) |
+| Configuration | [EN](docs/configurazione.en.md) · [IT](docs/configurazione.md) |
+| Developer guide | [EN](docs/developer_guide.en.md) · [IT](docs/developer_guide.md) |
+| Categorisation guide | [EN](docs/guida_classificazione.en.md) · [IT](docs/guida_classificazione.md) |
+| Database schema | [EN](docs/database.en.md) · [IT](docs/database.md) |
+| Deployment | [EN](docs/deployment.en.md) · [IT](docs/deployment.md) |
+| Release process | [EN](docs/release_process.md) · [IT](docs/release_process.it.md) |
+| Contributing | [EN](CONTRIBUTING.en.md) · [IT](CONTRIBUTING.md) |
+| Security policy | [EN](SECURITY.md) · [IT](SECURITY.it.md) |
+| Changelog | [EN](CHANGELOG.md) · [IT](CHANGELOG.it.md) |
 
-### Privacy and remote backends
+## Contributing
+
+Bug reports, feature ideas and PRs welcome. See [CONTRIBUTING.en.md](CONTRIBUTING.en.md) for the workflow, branch policy, priority framework, and CI gates.
+
+## License
+
+**PolyForm Noncommercial 1.0.0** — see [LICENSE](LICENSE). Free for personal use; commercial use requires a separate licence.
+
+---
+
+### What leaves the machine — be precise
+
+All financial data is stored locally in `~/.spendifai/ledger.db`.
+
+**Local LLM backend (default — llama.cpp, Ollama)**: nothing leaves the machine.
+
+**Remote LLM backend (opt-in — OpenAI, Claude)**: the payload contains
+sanitised descriptions **plus** transaction **amounts**, **dates**, and
+**column metadata**.
+
+#### Redaction example — categorizer (`core/categorizer.py:303`)
+
+Raw transaction row from the CSV:
 
 ```
-[LOCAL — default]  Local Ollama: no data leaves the process.
-                   No sanitization required.
-
-[REMOTE — opt-in]  OpenAI / Claude: PII sanitization MANDATORY.
-                   IBAN → <ACCOUNT_ID>  |  PAN → <CARD_ID>
-                   CF   → <FISCAL_ID>  |  owner → <OWNER>
-                   Call blocked if assert_sanitized() fails.
+date:        2026-03-15
+description: "BONIFICO da MARIO ROSSI IT60X0542811101000000123456 CAU 12345 STIPENDIO MENSILE"
+amount:      1500.00
 ```
 
----
+What the remote LLM actually receives:
 
-## Running the app
-
-```bash
-# Startup script (recommended) — checks prerequisites, activates virtualenv and starts
-./start.sh          # UI only (default)
-./start.sh api      # REST API only
-./start.sh all      # UI + API
-
-# On Windows
-start.bat           # same options: ui | api | all
-
-# Or manually
-uv run streamlit run app.py
+```json
+{
+  "amount": "1500.00",
+  "description": "BONIFICO da Carlo Brambilla <ACCOUNT_ID> <TX_CODE> STIPENDIO MENSILE"
+}
 ```
 
-On the **first run** the onboarding wizard appears automatically (4 steps: language, owner names, bank accounts, confirmation). Existing installations with data already in the taxonomy are detected automatically and skip the wizard.
-
-The app opens at `http://localhost:8501` with 13 pages:
-
-| Page | Description |
-|---|---|
-| **📥 Import** | Upload one or more files (CSV / XLSX). Shows live progress (visible across all browser sessions). Summary: imported transactions, reconciliations, transfer links, flow used (1/2). |
-| **📋 Ledger** | Filterable table (date, type, description, category, context, review flag). Click any row to select it instantly. Split Entrata/Uscita columns, right-aligned. Net/income/expense metrics. Context filter + assignment expander with Jaccard similarity suggestions. Giroconto toggle with bulk-apply. CSV/XLSX download. |
-| **✏️ Bulk Edit** | Bulk operations on a reference transaction: giroconto toggle, context assignment (with Jaccard similarity), category correction + rule save. LLM reprocessing by scope. Mass deletion by combined filters (date, account, type, description, category) with preview and mandatory confirmation keyword. Cross-account duplicate detection and cleanup. |
-| **📊 Analytics** | 7 interactive Plotly charts: monthly bar chart, cumulative balance, expense pie+treemap, interactive category drill-down with subcategory bar + monthly trend, income pie+treemap, top-10 descriptions, stacked by account. HTML export. |
-| **🔍 Review** | Transactions with `to_review=True`. Giroconto toggle (with bulk-apply). Category/subcategory correction + optional save as permanent rule applied immediately. "Re-run LLM" button for uncleaned transactions. "Re-detect cross-account giroconti" button. |
-| **📜 Import History** | Import timeline with undo capability. Shows date, file, account, transaction count, status. Cancel import to permanently delete all transactions from a batch. |
-| **📏 Rules** | Full CRUD for category rules. Edit/delete existing rules + optional bulk re-categorization of already-matched transactions. "Run all rules" button applies all rules to every transaction in the ledger at once. |
-| **🗂️ Taxonomy** | DB-backed CRUD for categories and subcategories (expenses and income). Changes take effect immediately without restarting. |
-| **💰 Budget** | Define spending % targets per expense category. Visual allocation bar with remaining liquidity and over-100% warnings. |
-| **📊 Budget vs Actual** | Compare actual spending with budget targets by period (month/quarter/year/custom). Traffic-light status per category, bar chart + donut distribution. |
-| **⚙️ Settings** | Date format, amount separators, description language, UI language, life contexts, bank account list, schema cache, LLM backend (6 backends: llama.cpp, Ollama, OpenAI, Claude, OpenAI-compatible), power user profile. All persisted in DB. |
-| **✅ Check List** | Pivot table (month × account). Current month at top, descending. Cells show tx count; **—** = no transactions. Color-coded by volume. Filters: account selection, last N months, hide empty rows. CSV export. |
-
----
-
-## Taxonomy
-
-The taxonomy is stored in the database (`taxonomy_category` / `taxonomy_subcategory` tables) and managed from the **🗂️ Tassonomia** page.
-
-### Multi-language built-in templates
-
-The `taxonomy_default` table contains immutable built-in templates in 5 languages — Italian, English, French, German, Spanish. These are seeded from `db/taxonomy_defaults.py` on first startup (no YAML file required). During onboarding the user selects a language and the matching template is copied into the editable user taxonomy.
-
-To reset the user taxonomy to a different language at any time: **⚙️ Settings → 🔄 Reset Taxonomy**.
-
-### Default taxonomy (Italian)
-
-**Expense categories (15):** Casa · Alimentari · Ristorazione · Trasporti · Salute · Istruzione · Abbigliamento · Comunicazioni · Svago e tempo libero · Animali domestici · Finanza e assicurazioni · Cura personale · Tasse e tributi · Regali e donazioni · Altro
-
-**Income categories (7):** Lavoro dipendente · Lavoro autonomo · Rendite finanziarie · Rendite immobiliari · Trasferimenti e rimborsi · Prestazioni sociali · Altro entrate
-
-**Subcategory is authoritative:** if the LLM or a rule assigns a subcategory that exists in the taxonomy, the correct parent category is resolved automatically — the two levels are always consistent in the DB.
-
----
-
-## Rule engine
-
-Category rules are stored in the `category_rule` table and applied at multiple points in the lifecycle:
-
-### Rule matching
-
-Rules support three match types, all case-insensitive:
-
-| Match type | Behaviour |
-|---|---|
-| `contains` | Pattern appears anywhere in the description (case-insensitive) |
-| `exact` | Description equals the pattern exactly (case-insensitive) |
-| `regex` | Full Python regex matched against the description |
-
-`get_transactions_by_rule_pattern` searches **all** transactions regardless of how they were previously categorized (LLM, rule, or manual correction). This means saving a new rule will correctly identify and update transactions that the LLM had already categorized.
-
-### Rule priority
-
-When multiple rules match the same transaction the one with the highest `priority` value wins. The default priority is 10; you can assign any integer.
-
-### Upsert semantics
-
-Creating a rule with the same `(pattern, match_type)` pair as an existing rule **updates** it in place (category, subcategory, priority), rather than creating a duplicate. The return value indicates whether the rule was newly created or updated.
-
-### Retroactive application
-
-Saving a rule from the **Ledger** or **Review** pages applies it immediately to all existing transactions that match the pattern, not just future imports. The success message reports how many transactions were updated. The same behaviour is available from the **Regole** page via the bulk re-categorization option on each rule.
-
-Additionally, the **▶️ Esegui tutte le regole** button on the **Regole** page runs all rules against every transaction in the ledger at once (not limited to `to_review=True`). Useful after creating several rules at once or after importing historic data.
-
----
-
-## Giroconto (internal transfers)
-
-A *giroconto* is an internal fund movement between accounts you own (e.g., a transfer from a current account to a savings account, or a top-up of a prepaid card). Including both sides in the balance would cause double-counting.
-
-### Transaction types
-
-| `tx_type` | Meaning |
-|---|---|
-| `internal_out` | Outgoing side of an internal transfer (negative amount) |
-| `internal_in` | Incoming side of an internal transfer (positive amount) |
-
-Both types are excluded from net balance, income, and expense metrics.
-
-### Automatic detection (RF-04)
-
-The pipeline tries to match transfers automatically during import using three passes:
-
-1. **Keyword regex** — description matches a configured keyword pattern (e.g. "Giroconto", "Bonifico tra i miei conti") → high confidence
-2. **Amount + date matching** — same absolute amount within a ±3-day window, on different `account_label` values → medium/high confidence
-3. **Owner-name permutation** — description contains any permutation of the account-holder name tokens → high confidence (catches "Corsaro Luigi Gerotti Elena" and "Luigi Corsaro Elena Gerotti" equally)
-
-### Cross-account re-detection
-
-When two counterpart transactions belong to files imported at different times, the first import cannot find the pair. Use the **"🔁 Re-run internal transfer detection"** button on the **🔍 Review** page to re-run detection globally on all non-giroconto transactions and update newly detectable pairs.
-
-### Manual toggle
-
-From the **Ledger** or **Review** pages you can manually mark any transaction as a giroconto (or revert it):
-
-- **Single toggle** — flips the `tx_type` of the selected transaction (`expense` ↔ `internal_out`, `income` ↔ `internal_in`).
-- **Bulk apply** — if other transactions share the same description, a checkbox (default: enabled) offers to apply the same change to all of them in one click. The count of affected transactions is shown before confirming.
-
-`bulk_set_giroconto_by_description` in `db/repository.py` implements the bulk operation: it updates all transactions with the given description except the one already toggled, and returns the number of rows changed.
-
----
-
-## Life contexts
-
-Life contexts are an orthogonal classification dimension that complements the category taxonomy. Where a category answers *what was bought*, a context answers *for which area of life*.
-
-### Design
-
-| Aspect | Detail |
-|---|---|
-| **Storage** | Nullable `VARCHAR(64)` column `context` on the `Transaction` table |
-| **Orthogonality** | Independent of category/subcategory — any combination is valid |
-| **User-configurable** | Add, rename, or remove contexts from the **⚙️ Impostazioni** page (stored as JSON in `user_settings`) |
-| **Default contexts** | Everyday · Work · Vacation |
-
-### Assignment
-
-From the **📋 Ledger** page, select any transaction and open the "🌍 Assign context" expander:
-
-1. Choose a context from the dropdown (or clear it)
-2. Optionally enable **"Also apply to similar transactions"** — Jaccard token similarity (threshold 0.35) finds other transactions whose cleaned description is semantically close and pre-fills the same context
-3. Click **Apply**
-
-### Filtering
-
-The ledger's filter bar includes a context selector: *all*, individual context values, or *— none —* (transactions with no context assigned).
-
----
-
-## Support chatbot
-
-An adaptive, in-app support chatbot accessible from the **💬 Assistente** sidebar button. The chatbot answers questions about Spendif.ai features, configuration, and usage based on a multi-language knowledge base.
-
-### Three modes (auto-selected)
-
-| Mode | Trigger | How it works |
-|---|---|---|
-| **RAG Cloud** | User configured a cloud API (OpenAI, Claude, OpenAI-compatible) with a valid key | TF-IDF retrieval over FAQ + docs → LLM generates the answer |
-| **RAG Local** | User configured Ollama or vLLM as LLM backend | TF-IDF retrieval over FAQ + docs → local LLM generates the answer |
-| **FAQ Match** | llama.cpp backend or no LLM configured | Deterministic TF-IDF cosine similarity matching to known FAQ entries — zero LLM calls, works on any hardware |
-
-The mode is determined by the user's **LLM backend setting** (configured in Settings page), not by hardware probing.
-
-### Knowledge base
-
-```
-chat_bot/knowledge/
-├── it/           # Italian FAQ + docs
-│   ├── faq.json  # Q&A pairs
-│   └── docs/     # Markdown/text documents for RAG
-├── en/           # English
-├── de/           # German
-├── es/           # Spanish
-├── fr/           # French
-└── pt/           # Portuguese
-```
-
-FAQ files support JSON (`[{"q": "...", "a": "..."}]`) and Markdown (`## Question` + body) formats.
-
-### Security
-
-The chatbot answers **only** from the provided knowledge base context. The system prompt instructs the LLM to never invent information and to reply "contact support" when context is insufficient.
-
----
-
-## Tests
-
-```bash
-# Full suite (no LLM mocks required)
-uv run python -m pytest tests/ -v
-
-# With coverage
-uv run python -m pytest tests/ --cov=core --cov=db --cov-report=term-missing
-```
-
-### LLM Benchmark
-
-End-to-end benchmark against real LLM backends. Measures classifier accuracy (schema detection, parsing) and categorizer accuracy across all supported backends and models.
-
-```bash
-# macOS / Linux
-bash tests/run_benchmark_full.sh
-
-# Windows (PowerShell)
-powershell -ExecutionPolicy Bypass -File .\tests\run_benchmark_full.ps1
-
-# With options
-bash tests/run_benchmark_full.sh --benchmark both --runs 3
-bash tests/run_benchmark_full.sh --skip-ollama --skip-vllm   # llama.cpp only
-```
-
-GPU utilization is tracked cross-platform during benchmark runs via a background-thread HW monitor (`tests/hw_monitor.py`): macOS Apple Silicon (`ioreg`), Linux NVIDIA (`nvidia-smi`), Linux AMD (`rocm-smi`). All GGUF models are now included (no size filter).
-
-Results are appended to `tests/generated_files/benchmark/results_all_runs.csv` (resume-safe). Logs are saved to `tests/logs/` (timestamped, one per run). See [`tests/README.md`](tests/README.md) for full documentation (backends, GPU setup, model list, context auto-detect, collaborative workflow).
-
-On Windows, run `diagnose.ps1` first to verify prerequisites (Python, uv, VC++ Redistributable, GPU, GGUF models, network).
-
-### Test files
-
-| File | Coverage |
-|---|---|
-| `test_normalizer.py` | `parse_amount`, SHA-256 dedup, encoding detection |
-| `test_backends.py` | Backend factory, validation, Ollama mock |
-| `test_categorizer.py` | Static rules, 4-step cascade, taxonomy resolution |
-| `test_repository_rules.py` | Rule upsert, `get_transactions_by_rule_pattern` (all match types + regression for LLM-sourced), `apply_rules_to_review_transactions`, `toggle_transaction_giroconto`, `bulk_set_giroconto_by_description` |
-| `test_taxonomy_onboarding.py` | Multi-language `TAXONOMY_DEFAULTS` structure validation, `taxonomy_default` DB migration (seeding + idempotency), `SettingsService` onboarding methods (`apply_default_taxonomy`, `is_onboarding_done`, `set_onboarding_done`), auto-skip migration for existing users |
-
-All tests use an in-memory SQLite database — no file I/O, no external services required.
-
----
-
-## Design decisions
-
-### `Decimal` — never `float`
-
-All amounts are `decimal.Decimal`. IEEE 754 floats introduce rounding errors that corrupt balances and reconciliation results.
-
-### SHA-256 idempotency
-
-Each transaction has a 24-character `id` (truncated SHA-256) computed deterministically from `(source_file, date, amount, description)`. Re-importing the same file does not create duplicates.
-
-### Card sign correction (`invert_sign`)
-
-Italian card exports often store purchases as positive values. The `DocumentSchema.invert_sign` flag, set by the LLM during Flow 2 classification, instructs the normalizer to negate all amounts so that expenses become negative and refunds become positive — with a single symmetric operation.
-
-#### Two-step detection algorithm
-
-The classifier decides the value of `invert_sign` using a two-step algorithm. **Step 0 takes priority: if it fires, Step 1 is skipped entirely.** Step 1 is only consulted when Step 0 finds no definitive answer.
-
-**Step 0 — Column name synonym check (highest priority)**
-
-The column name is inspected for membership in one of three synonym groups:
-
-| Group | Example names | Decision |
-|---|---|---|
-| **Outflow synonyms** | Uscita, Uscite, Addebito, Addebiti, Pagamento, Spesa, Dare, Importo addebitato | `invert_sign = true` (expenses stored as positive → negate) |
-| **Inflow synonyms** | Entrata, Entrate, Accredito, Accrediti, Avere, Credito, Importo accreditato | `invert_sign = false` (incomes already positive → no change) |
-| **Neutral names** | Importo, Amount, Valore, Totale | No decision — proceed to Step 1 |
-
-Outflow and inflow synonym matching is case-insensitive and partial (e.g. "Addebiti carta" matches "Addebito"). The outflow rule applies to card doc_types only; bank account and savings files always keep `invert_sign = false` regardless of column name.
-
-**Step 1 — Sign distribution analysis (neutral column names only)**
-
-When Step 0 finds a neutral column name it cannot classify by name alone, the classifier counts positive vs. negative values in the sample and computes `positive_ratio` and `negative_ratio`:
-
-- Card file, majority positive (> 60 %): expenses are stored as positive (AMEX / typical Italian export convention) → `invert_sign = true`
-- Card file, majority negative (> 60 %): expenses already carry the correct sign → `invert_sign = false`
-- Roughly 50/50 split: descriptions are inspected (merchant names with positive amounts → `invert_sign = true`; "bonifico ricevuto" with positive amounts → `invert_sign = false`)
-- Bank account / savings: always `invert_sign = false`, regardless of distribution
-
-#### Diagnostic fields
-
-Every `DocumentSchema` produced by Flow 2 includes four diagnostic fields for audit and debugging:
-
-| Field | Type | Content |
-|---|---|---|
-| `positive_ratio` | `float \| null` | Fraction of amount-column values > 0 in the sample |
-| `negative_ratio` | `float \| null` | Fraction of amount-column values < 0 in the sample |
-| `semantic_evidence` | `list[str]` | 2–4 short sentences from the LLM explaining the decision |
-| `normalization_case_id` | `str \| null` | C1 = bank signed_single · C2 = card inverted · C3 = card already negative · C4 = Dare/Avere columns · C5 = ambiguous · C6 = debit\_credit\_signed (separate debit/credit columns, values already carry sign) |
-
-These fields are persisted in the `document_schema` DB table and are visible in the Flow 2 schema review step in the UI.
-
-### Subcategory as primary key
-
-The categorizer treats subcategory as authoritative. `TaxonomyConfig.find_category_for_subcategory()` resolves the parent category from any valid subcategory name. This means LLMs and rules can specify the most granular level and the hierarchy is always consistent in the DB.
-
-### Taxonomy in DB
-
-The 2-level taxonomy (categories + subcategories) lives in two DB tables (`taxonomy_category`, `taxonomy_subcategory`). On first run the onboarding wizard copies the chosen language template from the immutable `taxonomy_default` table into the user's editable taxonomy. No YAML files involved. Changes are managed entirely from the UI — no file edits or restarts required.
-
-### PII sanitization as a precondition
-
-`assert_sanitized()` is called inside `call_with_fallback()` before any request to a remote backend. If the text contains detectable IBAN/PAN/fiscal-code patterns, the call is rejected — not silently degraded.
-
-### Circuit breaker and quarantine
-
-`call_with_fallback(primary, ...)` tries the primary backend, then local Ollama as fallback. If both fail, the transaction receives `to_review=True` and is queued for manual review without blocking the rest of the batch.
-
-### No LangChain
-
-LLM backends use the `openai` SDK, `anthropic` SDK, and `requests` (for Ollama) directly. No LLM orchestration framework dependency — smaller attack surface, independent SDK updates.
-
-### RF-03: 3-phase algorithm
-
-Card–account reconciliation uses: (1) temporal window ±45 days, (2) contiguous sliding window (gap ≤ 5 days, O(n²)), (3) boundary subset sum (k=10 txs, ~10⁶ operations). Reconciled transactions are excluded from the net balance to prevent double-counting.
-
----
-
-## Key dependencies
-
-| Package | Version | Purpose |
-|---|---|---|
-| `streamlit` | ≥ 1.35 | UI |
-| `pandas` | ≥ 2.2 | Data processing |
-| `sqlalchemy` | ≥ 2.0 | ORM / persistence |
-| `pydantic` | ≥ 2.0 | Schema validation |
-| `openai` | ≥ 1.30 | OpenAI backend |
-| `anthropic` | ≥ 0.28 | Claude backend |
-| `requests` | ≥ 2.31 | Ollama backend |
-| `chardet` | ≥ 5.0 | Encoding detection |
-| `plotly` | ≥ 5.20 | Charts |
-| `jinja2` | ≥ 3.1 | HTML report template |
-| `pyyaml` | ≥ 6.0 | YAML utilities |
-| `pytest` | ≥ 8.0 | Tests |
-
----
-
-*All data is stored locally in the SQLite database (`ledger.db`). No financial information is transmitted to external services unless a remote backend is explicitly configured with mandatory PII sanitization.*
+What changed:
+- `MARIO ROSSI` (configured owner name) → `Carlo Brambilla` (fake from Italian pool, restored after the LLM responds)
+- `IT60X...` (IBAN) → `<ACCOUNT_ID>`
+- `CAU 12345` (bank transaction code) → `<TX_CODE>`
+- `amount` and date metadata: **sent in the clear**
+
+The categorizer prompt instructs the model to "base the decision on the
+description, amount, and context" (`prompts/categorizer.json`). Whether
+the amount actually changes accuracy in practice has not been benchmarked
+against an amount-stripped baseline — the conservative default keeps it
+in the payload until measured.
+
+#### Roadmap
+
+Amount + date redaction modes for remote backends (`none` / `buckets` /
+`strip`) are on the roadmap — backlog item **AI-55**.

--- a/docs/architecture.it.md
+++ b/docs/architecture.it.md
@@ -1,0 +1,144 @@
+# Spendif.ai — Architettura
+
+> 🇬🇧 [Read in English](architecture.md)
+
+Questo documento descrive l'architettura runtime di Spendif.ai:
+struttura a layer, i due flussi di ingestione, e dove vive ciascuna
+responsabilità nel codice.
+
+---
+
+## Diagramma a layer
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                            app.py  (Streamlit)                           │
+│  [onboarding gate] → sidebar → upload │ ledger │ bulk-edit │ analytics  │
+│                               review │ rules │ taxonomy │ settings │ chat │
+└──────────────────────────┬───────────────────────────────────────────────┘
+                           │ services.*  (facade layer)
+               core/orchestrator.py
+               ProcessingConfig  ·  process_file()
+                           │
+        ┌──────────────────┼───────────────────┐
+        │                  │                   │
+ Flow 1 (template)    Flow 2 (schema-on-read)
+ DocumentSchema        classifier.py → LLM  → DocumentSchema
+ già in DB             (sample sanitizzato)    rilevazione invert_sign
+        │
+ normalizer.py          sanitizer.py      llm_backends.py
+ ├─ encoding detect     ├─ IBAN/PAN/CF    ├─ OllamaBackend
+ ├─ parse_amount()      ├─ owner names    ├─ OpenAIBackend
+ ├─ SHA-256 tx_id       └─ assert_sani.. ├─ ClaudeBackend
+ ├─ invert_sign                           └─ BackendFactory
+ ├─ RF-03 reconcile                          call_with_fallback()
+ └─ RF-04 transfers
+        │
+ categorizer.py  ←── TaxonomyConfig (caricata dal DB)
+ Step 0: regole utente  (subcategory → category resolution)
+ Step 1: regex statici
+ Step 2: ML stub
+ Step 3: LLM structured output  (subcategory constrained enum)
+ Step 4: fallback "Altro"
+        │
+    db/repository.py   (SQLAlchemy, idempotente)
+    └─ Transaction · ImportBatch · DocumentSchemaModel
+       ReconciliationLink · InternalTransferLink · CategoryRule
+       UserSettings · ImportJob · Account
+       TaxonomyCategory · TaxonomySubcategory · TaxonomyDefault
+        │
+    reports/generator.py
+    └─ HTML (Jinja2+Plotly) · CSV · XLSX
+
+ chat_bot/engine.py  ←── chatbot di supporto adattivo
+ ├─ RAG Cloud (Claude/OpenAI API)
+ ├─ RAG Local (Ollama/vLLM)
+ └─ FAQ Match (classificatore TF-IDF, no LLM)
+     knowledge/<lang>/faq.json · docs/
+```
+
+## Regole di layering
+
+- **UI → solo services** — le pagine sotto `ui/` possono importare solo
+  da `services/`, mai da `core/` o `db/`. Enforcement via
+  `tools/coupling_check.py --strict` in CI.
+- **Services → core + db** — i service orchestrano logica di dominio e
+  persistenza.
+- **Core non importa mai services o db** — mantiene puro il dominio.
+- **Persistence (`db/`) non importa mai verso l'alto** — niente dipendenze
+  cicliche.
+
+## Flow 1 vs Flow 2
+
+| | Flow 1 | Flow 2 |
+|---|---|---|
+| **Trigger** | `DocumentSchema` già in DB per quel fingerprint di colonne | Primo import di un formato nuovo |
+| **Schema** | Recuperato dal DB e applicato direttamente | LLM deduce lo schema da un sample anonimizzato |
+| **Promozione** | — | Template Flow 2 approvato viene salvato e diventa Flow 1 |
+| **Auto-invalidazione** | Se parse rate < 10 %, lo schema viene eliminato e Flow 2 ripartirà al prossimo import | — |
+| **Costo LLM** | Zero (solo categorizzazione) | Una call per classificazione + una per batch categorizzazione |
+
+### Dettagli Flow 2
+
+`core/classifier.py` lavora in tre fasi:
+
+1. **Phase 0 (Python, pre-LLM)** — content-type detection deterministica
+   sui dati reali. Classifica ogni colonna come `date`, `amount` o
+   `text` ispezionando i valori. Synonym di nome colonna usati solo
+   come tiebreaker tra colonne dello stesso content-type. A volte
+   risolve la semantica dell'amount (outflow/inflow/debit_positive) e
+   l'`invert_sign` senza mai chiamare l'LLM.
+2. **Phase 1 (LLM)** — riceve i risultati di Phase 0 come fatti, si
+   concentra sui campi genuinamente ambigui (doc_type, date_format,
+   sign_convention per amount neutri). L'opzione multi-step suddivide
+   questa fase in tre LLM call più piccole per modelli sotto i 7B
+   parametri.
+3. **Post-LLM (Python)** — merge dei risultati Phase 0 (Phase 0 vince),
+   coerce dei nomi colonna, safety-net re-enforcement di `invert_sign`.
+
+## Launcher desktop nativo
+
+`desktop/launcher.py` è l'entry point dell'app desktop congelata da
+PyInstaller:
+
+1. Apre una finestra `pywebview` nativa con uno splash screen.
+2. Chiama `core.model_manager.ensure_model_available()` che rileva
+   RAM/VRAM e scarica il GGUF più grande compatibile (Qwen 2.5, Gemma 3).
+3. Scrive un `.env` per-utente con `LLM_BACKEND=local_llama_cpp`.
+4. Avvia un sottoprocesso Streamlit su una porta libera casuale.
+5. Naviga la finestra pywebview all'URL Streamlit quando risponde.
+
+Lo stesso `app.py` gira sia nel bundle desktop sia in Streamlit
+standalone (`streamlit run app.py`) — il launcher è solo un wrapper
+sottile.
+
+## Supporto multi-database (pool pattern)
+
+`db/pool.py` fornisce un'interfaccia asincrona unificata su più dialetti
+SQL. Attualmente solo SQLite è in produzione, ma l'astrazione fa sì che
+uno switch a PostgreSQL richiederebbe solo un cambio di connection
+string e zero modifiche ai repository.
+
+## Async runner
+
+Streamlit è sincrono; la sessione SQLAlchemy async e ogni futura call
+HTTP async vivono dietro `services/async_runner.py`, che mantiene un
+event loop persistente in un thread dedicato ed espone `run_async(coro)`
+per i call site sincroni.
+
+## Migrazioni schema
+
+`db/schema.py` usa un approccio **auto-hash**: il sorgente della
+funzione `_run_schema()` viene SHA-256 hashato; se l'hash matcha quello
+salvato nella tabella `schema_version`, le migrazioni vengono saltate
+(singolo `SELECT` leggero). Su mismatch, la funzione gira in una singola
+transazione atomica. Idempotente: `CREATE TABLE IF NOT EXISTS` ovunque,
+errori `ALTER TABLE ADD COLUMN` ignorati silenziosamente se la colonna
+esiste già.
+
+## Dove leggere dopo
+
+- [Reference guide](reference_guide.md) — ogni pagina, ogni algoritmo
+- [Design decisions](design_decisions.it.md) — `Decimal`, SHA-256, RF-03, ecc.
+- [Developer guide](developer_guide.md) — service layer, coupling gate, classifier multi-step
+- [Configurazione](configurazione.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,141 @@
+# Spendif.ai — Architecture
+
+> 🇮🇹 [Leggi in italiano](architecture.it.md)
+
+This document describes the runtime architecture of Spendif.ai: the
+layered structure, the two ingestion flows, and where each responsibility
+lives in the codebase.
+
+---
+
+## Layer diagram
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│                            app.py  (Streamlit)                           │
+│  [onboarding gate] → sidebar → upload │ ledger │ bulk-edit │ analytics  │
+│                               review │ rules │ taxonomy │ settings │ chat │
+└──────────────────────────┬───────────────────────────────────────────────┘
+                           │ services.*  (facade layer)
+               core/orchestrator.py
+               ProcessingConfig  ·  process_file()
+                           │
+        ┌──────────────────┼───────────────────┐
+        │                  │                   │
+ Flow 1 (template)    Flow 2 (schema-on-read)
+ DocumentSchema        classifier.py → LLM  → DocumentSchema
+ already in DB         (sanitized sample)      invert_sign detection
+        │
+ normalizer.py          sanitizer.py      llm_backends.py
+ ├─ encoding detect     ├─ IBAN/PAN/CF    ├─ OllamaBackend
+ ├─ parse_amount()      ├─ owner names    ├─ OpenAIBackend
+ ├─ SHA-256 tx_id       └─ assert_sani.. ├─ ClaudeBackend
+ ├─ invert_sign                           └─ BackendFactory
+ ├─ RF-03 reconcile                          call_with_fallback()
+ └─ RF-04 transfers
+        │
+ categorizer.py  ←── TaxonomyConfig (loaded from DB)
+ Step 0: user rules  (subcategory → category resolution)
+ Step 1: static regex
+ Step 2: ML stub
+ Step 3: LLM structured output  (subcategory constrained enum)
+ Step 4: fallback "Other"
+        │
+    db/repository.py   (SQLAlchemy, idempotent)
+    └─ Transaction · ImportBatch · DocumentSchemaModel
+       ReconciliationLink · InternalTransferLink · CategoryRule
+       UserSettings · ImportJob · Account
+       TaxonomyCategory · TaxonomySubcategory · TaxonomyDefault
+        │
+    reports/generator.py
+    └─ HTML (Jinja2+Plotly) · CSV · XLSX
+
+ chat_bot/engine.py  ←── adaptive support chatbot
+ ├─ RAG Cloud (Claude/OpenAI API)
+ ├─ RAG Local (Ollama/vLLM)
+ └─ FAQ Match (TF-IDF classifier, no LLM)
+     knowledge/<lang>/faq.json · docs/
+```
+
+## Layer rules
+
+- **UI → services only** — pages under `ui/` may import only from
+  `services/`, never from `core/` or `db/`. Enforced by
+  `tools/coupling_check.py --strict` in CI.
+- **Services → core + db** — services orchestrate domain logic and
+  persistence.
+- **Core never imports services or db** — keeps the domain pure.
+- **Persistence (`db/`) never imports upward** — no cyclic dependencies.
+
+## Flow 1 vs Flow 2
+
+| | Flow 1 | Flow 2 |
+|---|---|---|
+| **Trigger** | `DocumentSchema` already in DB for that column fingerprint | First import of a new format |
+| **Schema** | Retrieved from DB and applied directly | LLM infers the schema from an anonymized sample |
+| **Promotion** | — | Approved Flow 2 template is saved and becomes Flow 1 |
+| **Auto-invalidation** | If parse rate < 10 %, schema is deleted and Flow 2 retry is triggered automatically | — |
+| **LLM cost** | Zero (categorization only) | One call for classification + one for batch categorization |
+
+### Flow 2 details
+
+`core/classifier.py` runs in three phases:
+
+1. **Phase 0 (Python, pre-LLM)** — deterministic content-type detection
+   on actual data. Classifies each column as `date`, `amount`, or `text`
+   by inspecting values. Column-name synonyms only as tiebreakers
+   within the same content type. Sometimes resolves amount semantics
+   (outflow/inflow/debit_positive) and `invert_sign` without ever
+   calling the LLM.
+2. **Phase 1 (LLM)** — receives Phase 0 findings as facts, focuses on
+   genuinely ambiguous fields (doc_type, date_format,
+   sign_convention for neutral amounts). Multi-step option splits this
+   into three smaller LLM calls for models below 7B parameters.
+3. **Post-LLM (Python)** — merge Phase 0 results (Phase 0 wins), coerce
+   column names, safety-net re-enforcement of `invert_sign`.
+
+## Native desktop launcher
+
+`desktop/launcher.py` is the entry point for the PyInstaller-frozen
+desktop app:
+
+1. Opens a `pywebview` native window with a splash screen.
+2. Calls `core.model_manager.ensure_model_available()` which detects
+   RAM/VRAM and downloads the largest GGUF that fits (Qwen 2.5, Gemma 3).
+3. Writes a per-user `.env` with `LLM_BACKEND=local_llama_cpp`.
+4. Starts a Streamlit subprocess on a random free port.
+5. Navigates the pywebview window to the Streamlit URL once it responds.
+
+The same `app.py` runs both in the desktop bundle and in standalone
+Streamlit (`streamlit run app.py`) — the launcher is just a thin wrapper.
+
+## Multi-database support (pool pattern)
+
+`db/pool.py` provides a unified async interface over multiple SQL dialects.
+Currently only SQLite is in production, but the abstraction means a switch
+to PostgreSQL would require only a connection-string change and no
+repository code changes.
+
+## Async runner
+
+Streamlit is synchronous; the SQLAlchemy async session and any future
+async HTTP calls live behind `services/async_runner.py`, which keeps a
+persistent event loop in a dedicated thread and exposes `run_async(coro)`
+for synchronous call sites.
+
+## Schema migrations
+
+`db/schema.py` uses an **auto-hash** approach: the source of the
+`_run_schema()` function is SHA-256 hashed; if the hash matches what is
+stored in the `schema_version` table, migrations are skipped (single
+lightweight `SELECT`). On mismatch, the function runs inside a single
+atomic transaction. Idempotent: `CREATE TABLE IF NOT EXISTS` everywhere,
+`ALTER TABLE ADD COLUMN` errors silently ignored if the column already
+exists.
+
+## Where to read next
+
+- [Reference guide](reference_guide.md) — every page, every algorithm
+- [Design decisions](design_decisions.md) — `Decimal`, SHA-256, RF-03, etc.
+- [Developer guide](developer_guide.md) — service layer, coupling gate, classifier multi-step
+- [Configuration](configurazione.en.md)

--- a/docs/design_decisions.it.md
+++ b/docs/design_decisions.it.md
@@ -1,0 +1,155 @@
+# Spendif.ai — Design decisions
+
+> 🇬🇧 [Read in English](design_decisions.md)
+
+Questo documento raccoglie le scelte non-ovvie integrate nel codebase
+e il ragionamento dietro di esse. Leggi qui se stai per refactorare
+qualcosa e ti chiedi "perché è fatto così?".
+
+---
+
+## `Decimal` — mai `float`
+
+Tutti gli importi sono `decimal.Decimal`. I float IEEE 754 introducono
+errori di arrotondamento che corrompono saldi e risultati di
+riconciliazione. Il normalizer non produce mai `float` per valori
+monetari; i test asseriscono questo.
+
+## Idempotenza SHA-256
+
+Ogni transazione ha un `id` di 24 caratteri (SHA-256 troncato)
+calcolato deterministicamente da `(source_file, date, amount, description)`.
+Re-importare lo stesso file non crea duplicati: la riga viene upsertata
+sul suo SHA-256, mai su una chiave primaria autoincrement sintetica.
+
+## Correzione segno carta (`invert_sign`)
+
+Gli export carta italiani spesso memorizzano gli acquisti come valori
+positivi. Il flag `DocumentSchema.invert_sign`, impostato dall'LLM
+durante la classificazione Flow 2, istruisce il normalizer a negare
+tutti gli importi così che le spese diventino negative e i rimborsi
+positivi — con una singola operazione simmetrica.
+
+### Algoritmo di rilevazione a due step
+
+Il classifier decide il valore di `invert_sign` con un algoritmo a due
+step. **Step 0 ha priorità: se scatta, Step 1 è saltato del tutto.**
+Step 1 è consultato solo quando Step 0 non trova una risposta definitiva.
+
+**Step 0 — Synonym check del nome colonna (massima priorità)**
+
+Il nome colonna viene ispezionato per appartenenza a uno di tre gruppi
+di sinonimi:
+
+| Gruppo | Nomi di esempio | Decisione |
+|---|---|---|
+| **Sinonimi outflow** | Uscita, Uscite, Addebito, Addebiti, Pagamento, Spesa, Dare, Importo addebitato | `invert_sign = true` (spese come positive → negate) |
+| **Sinonimi inflow** | Entrata, Entrate, Accredito, Accrediti, Avere, Credito, Importo accreditato | `invert_sign = false` (entrate già positive → no cambio) |
+| **Nomi neutri** | Importo, Amount, Valore, Totale | Nessuna decisione — procedi a Step 1 |
+
+Il matching outflow/inflow è case-insensitive e parziale (es.
+"Addebiti carta" matcha "Addebito"). La regola outflow vale solo per
+doc_type carta; conti bancari e di risparmio tengono sempre
+`invert_sign = false` indipendentemente dal nome colonna.
+
+**Step 1 — Analisi distribuzione segni (solo per nomi colonna neutri)**
+
+Quando Step 0 trova un nome neutro che non può classificare per nome,
+il classifier conta valori positivi vs negativi nel sample e calcola
+`positive_ratio` e `negative_ratio`:
+
+- File carta, maggioranza positivi (> 60 %): le spese sono memorizzate
+  come positive (AMEX / convenzione tipica export italiano) →
+  `invert_sign = true`
+- File carta, maggioranza negativi (> 60 %): le spese hanno già il segno
+  corretto → `invert_sign = false`
+- Split circa 50/50: si ispezionano le descrizioni (nomi commerciali
+  con importi positivi → `invert_sign = true`; "bonifico ricevuto" con
+  importi positivi → `invert_sign = false`)
+- Conto / risparmio: sempre `invert_sign = false`, indipendentemente
+  dalla distribuzione
+
+### Campi diagnostici
+
+Ogni `DocumentSchema` prodotto da Flow 2 include quattro campi
+diagnostici per audit e debug:
+
+| Campo | Tipo | Contenuto |
+|---|---|---|
+| `positive_ratio` | `float \| null` | Frazione di valori della colonna amount > 0 nel sample |
+| `negative_ratio` | `float \| null` | Frazione di valori della colonna amount < 0 nel sample |
+| `semantic_evidence` | `list[str]` | 2–4 frasi brevi dall'LLM che spiegano la decisione |
+| `normalization_case_id` | `str \| null` | C1 = bank signed_single · C2 = card inverted · C3 = card already negative · C4 = colonne Dare/Avere · C5 = ambigua · C6 = debit\_credit\_signed (debit/credit separati, valori già con segno) |
+
+Questi campi sono persistiti nella tabella DB `document_schema` e sono
+visibili nello step di review schema Flow 2 nell'UI.
+
+## Subcategory come chiave primaria
+
+Il categorizer tratta la subcategory come autoritativa.
+`TaxonomyConfig.find_category_for_subcategory()` risolve la category
+genitore da qualunque nome di subcategory valido. Questo significa che
+LLM e regole possono specificare il livello più granulare e la
+gerarchia è sempre coerente nel DB.
+
+## Tassonomia in DB
+
+La tassonomia a 2 livelli (categorie + subcategorie) vive in due tabelle
+DB (`taxonomy_category`, `taxonomy_subcategory`). Al primo avvio il
+wizard di onboarding copia il template della lingua scelta dalla
+tabella immutabile `taxonomy_default` nella tassonomia editabile
+dell'utente. Niente file YAML coinvolti. I cambiamenti sono gestiti
+interamente dall'UI — niente edit di file o restart.
+
+## PII sanitization come precondizione
+
+`assert_sanitized()` viene chiamata dentro `call_with_fallback()` prima
+di qualunque richiesta a un backend remoto. Se il testo contiene
+pattern IBAN/PAN/codice-fiscale rilevabili, la call viene rifiutata —
+non degradata silenziosamente.
+
+## Circuit breaker e quarantena
+
+`call_with_fallback(primary, ...)` prova il backend primario, poi
+Ollama locale come fallback. Se entrambi falliscono, la transazione
+riceve `to_review=True` e viene messa in coda per review manuale
+senza bloccare il resto del batch.
+
+## Niente LangChain
+
+I backend LLM usano direttamente l'SDK `openai`, l'SDK `anthropic` e
+`requests` (per Ollama). Niente dipendenza da framework di orchestrazione
+LLM — superficie d'attacco minore, aggiornamenti SDK indipendenti.
+
+## RF-03: algoritmo di riconciliazione a 3 fasi
+
+La riconciliazione carta-conto usa:
+
+1. **Finestra temporale** ± 45 giorni tra l'addebito carta e le
+   spese sottostanti candidate.
+2. **Sliding window contigua** con gap ≤ 5 giorni tra transazioni
+   adiacenti, O(n²) sulla dimensione della finestra di candidate.
+3. **Boundary subset sum** con k = 10 transazioni, ~10⁶ operazioni
+   massimo.
+
+Le transazioni riconciliate sono escluse dal saldo netto per prevenire
+il double-counting.
+
+**Stato: beta.** Edge cases (multi-currency, addebiti parziali, cambio
+emittente carta a metà mese) sono ancora in raffinamento.
+
+## RF-04: rilevazione giroconti interni
+
+Matching importo simbolico con finestra temporale e permutazioni nomi
+titolare:
+
+- Finestra: la coppia deve avvenire entro ± 7 giorni.
+- Segno: gli importi devono essere opposti (uno debito, uno credito)
+  ed uguali in valore assoluto.
+- Owner match: il nome controparte in una transazione matcha una
+  qualunque permutazione dei nomi titolare configurati. Le
+  permutazioni coprono export italiani che usano "Cognome Nome"
+  invece di "Nome Cognome".
+
+**Stato: beta.** Edge cases (conti di passaggio intermedi, commissioni
+di conversione valuta) sono ancora in raffinamento.

--- a/docs/design_decisions.md
+++ b/docs/design_decisions.md
@@ -1,0 +1,152 @@
+# Spendif.ai — Design decisions
+
+> 🇮🇹 [Leggi in italiano](design_decisions.it.md)
+
+This document collects the non-obvious choices baked into the codebase
+and the reasoning behind them. Read this if you are about to refactor
+something and wonder "why is it done this way?".
+
+---
+
+## `Decimal` — never `float`
+
+All amounts are `decimal.Decimal`. IEEE 754 floats introduce rounding
+errors that corrupt balances and reconciliation results. The normalizer
+never produces `float` for monetary values; tests assert this.
+
+## SHA-256 idempotency
+
+Each transaction has a 24-character `id` (truncated SHA-256) computed
+deterministically from `(source_file, date, amount, description)`.
+Re-importing the same file does not create duplicates: the row is upserted
+on its SHA-256, never on a synthetic auto-increment primary key.
+
+## Card sign correction (`invert_sign`)
+
+Italian card exports often store purchases as positive values. The
+`DocumentSchema.invert_sign` flag, set by the LLM during Flow 2
+classification, instructs the normalizer to negate all amounts so that
+expenses become negative and refunds become positive — with a single
+symmetric operation.
+
+### Two-step detection algorithm
+
+The classifier decides the value of `invert_sign` using a two-step
+algorithm. **Step 0 takes priority: if it fires, Step 1 is skipped
+entirely.** Step 1 is only consulted when Step 0 finds no definitive
+answer.
+
+**Step 0 — Column name synonym check (highest priority)**
+
+The column name is inspected for membership in one of three synonym
+groups:
+
+| Group | Example names | Decision |
+|---|---|---|
+| **Outflow synonyms** | Uscita, Uscite, Addebito, Addebiti, Pagamento, Spesa, Dare, Importo addebitato | `invert_sign = true` (expenses stored as positive → negate) |
+| **Inflow synonyms** | Entrata, Entrate, Accredito, Accrediti, Avere, Credito, Importo accreditato | `invert_sign = false` (incomes already positive → no change) |
+| **Neutral names** | Importo, Amount, Valore, Totale | No decision — proceed to Step 1 |
+
+Outflow and inflow synonym matching is case-insensitive and partial
+(e.g. "Addebiti carta" matches "Addebito"). The outflow rule applies to
+card doc_types only; bank account and savings files always keep
+`invert_sign = false` regardless of column name.
+
+**Step 1 — Sign distribution analysis (neutral column names only)**
+
+When Step 0 finds a neutral column name it cannot classify by name
+alone, the classifier counts positive vs. negative values in the sample
+and computes `positive_ratio` and `negative_ratio`:
+
+- Card file, majority positive (> 60 %): expenses are stored as positive
+  (AMEX / typical Italian export convention) → `invert_sign = true`
+- Card file, majority negative (> 60 %): expenses already carry the
+  correct sign → `invert_sign = false`
+- Roughly 50/50 split: descriptions are inspected (merchant names with
+  positive amounts → `invert_sign = true`; "bonifico ricevuto" with
+  positive amounts → `invert_sign = false`)
+- Bank account / savings: always `invert_sign = false`, regardless of
+  distribution
+
+### Diagnostic fields
+
+Every `DocumentSchema` produced by Flow 2 includes four diagnostic
+fields for audit and debugging:
+
+| Field | Type | Content |
+|---|---|---|
+| `positive_ratio` | `float \| null` | Fraction of amount-column values > 0 in the sample |
+| `negative_ratio` | `float \| null` | Fraction of amount-column values < 0 in the sample |
+| `semantic_evidence` | `list[str]` | 2–4 short sentences from the LLM explaining the decision |
+| `normalization_case_id` | `str \| null` | C1 = bank signed_single · C2 = card inverted · C3 = card already negative · C4 = Dare/Avere columns · C5 = ambiguous · C6 = debit\_credit\_signed (separate debit/credit columns, values already carry sign) |
+
+These fields are persisted in the `document_schema` DB table and are
+visible in the Flow 2 schema review step in the UI.
+
+## Subcategory as primary key
+
+The categorizer treats subcategory as authoritative.
+`TaxonomyConfig.find_category_for_subcategory()` resolves the parent
+category from any valid subcategory name. This means LLMs and rules can
+specify the most granular level and the hierarchy is always consistent
+in the DB.
+
+## Taxonomy in DB
+
+The 2-level taxonomy (categories + subcategories) lives in two DB
+tables (`taxonomy_category`, `taxonomy_subcategory`). On first run the
+onboarding wizard copies the chosen language template from the
+immutable `taxonomy_default` table into the user's editable taxonomy.
+No YAML files involved. Changes are managed entirely from the UI — no
+file edits or restarts required.
+
+## PII sanitization as a precondition
+
+`assert_sanitized()` is called inside `call_with_fallback()` before any
+request to a remote backend. If the text contains detectable
+IBAN/PAN/fiscal-code patterns, the call is rejected — not silently
+degraded.
+
+## Circuit breaker and quarantine
+
+`call_with_fallback(primary, ...)` tries the primary backend, then
+local Ollama as fallback. If both fail, the transaction receives
+`to_review=True` and is queued for manual review without blocking the
+rest of the batch.
+
+## No LangChain
+
+LLM backends use the `openai` SDK, `anthropic` SDK, and `requests` (for
+Ollama) directly. No LLM orchestration framework dependency — smaller
+attack surface, independent SDK updates.
+
+## RF-03: 3-phase reconciliation algorithm
+
+Card–account reconciliation uses:
+
+1. **Temporal window** ± 45 days between the card settlement and
+   candidate underlying expenses.
+2. **Contiguous sliding window** with gap ≤ 5 days between adjacent
+   transactions, O(n²) in the candidate window size.
+3. **Boundary subset sum** with k = 10 transactions, ~10⁶ operations
+   maximum.
+
+Reconciled transactions are excluded from the net balance to prevent
+double-counting.
+
+**Status: beta.** Edge cases (multi-currency, partial settlements, mid-month
+issuer changes) are still being refined.
+
+## RF-04: internal transfer detection
+
+Symbolic-amount matching with time window and owner-name permutations:
+
+- Window: pair must occur within ± 7 days.
+- Sign: amounts must be opposite (one debit, one credit) and equal in
+  absolute value.
+- Owner match: the counterpart name in one transaction matches any
+  permutation of the configured owner names. Permutations cover Italian
+  bank exports that use "Surname Firstname" instead of "Firstname Surname".
+
+**Status: beta.** Edge cases (intermediary holding accounts, currency
+conversion fees) are still being refined.

--- a/getting-started.de.html
+++ b/getting-started.de.html
@@ -50,6 +50,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -61,6 +66,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Was du bekommst</a>
         <a href="#download">Herunterladen</a>
         <a href="#install">Installation</a>
         <a href="#first-launch">Erster Start</a>
@@ -76,6 +82,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Was du bekommst</h2>
+      <ul class="features-list">
+        <li><strong>Importiert CSV/XLSX jeder Bank</strong> — erkennt das Format automatisch, kein manuelles Mapping</li>
+        <li><strong>KI-Kategorisierung, vollständig offline</strong> — lokales LLM enthalten, keine Cloud nötig</li>
+        <li><strong>Lokale KI als Standard</strong> — Daten bleiben auf deinem Rechner; Remote-LLM ist opt-in und schwärzt IBAN / Karten / Inhaber-Namen (Beträge und Daten reisen weiterhin — siehe Roadmap)</li>
+        <li><strong>Fünf Sprachen</strong> — Italienisch, Englisch, Französisch, Deutsch, Spanisch</li>
+        <li><strong>Karten-Konto-Abgleich</strong> <span class="beta-tag">(beta)</span> — verknüpft Kartenabrechnungen mit den zugrundeliegenden Ausgaben, um Doppelzählung zu vermeiden<span class="beta-note">(Edge Cases werden noch verfeinert)</span></li>
+        <li><strong>Erkennung interner Überweisungen</strong> <span class="beta-tag">(beta)</span> — gleicht Überweisungen zwischen deinen eigenen Konten ab, damit sie die Dashboards nicht verfälschen<span class="beta-note">(Edge Cases werden noch verfeinert)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Für dein System herunterladen</h2>
       <p>Die offiziellen Installer werden als Assets jedes <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a> veröffentlicht. Wähle das passende Format für dein Betriebssystem.</p>

--- a/getting-started.en.html
+++ b/getting-started.en.html
@@ -138,6 +138,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">What you get</a>
         <a href="#download">Download</a>
         <a href="#install">Install</a>
         <a href="#first-launch">First launch</a>
@@ -153,6 +154,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>What you get</h2>
+      <ul class="features-list">
+        <li><strong>Imports any bank's CSV/XLSX</strong> — auto-detects format, no manual mapping</li>
+        <li><strong>AI categorisation, fully offline</strong> — local LLM included, no cloud needed</li>
+        <li><strong>Local AI by default</strong> — data stays on your machine; remote LLM is opt-in and redacts IBAN / cards / owner names (amounts and dates still travel — see roadmap)</li>
+        <li><strong>Five languages</strong> — Italian, English, French, German, Spanish</li>
+        <li><strong>Card-account reconciliation</strong> <span class="beta-tag">(beta)</span> — pairs credit-card settlements with the underlying expenses to avoid double-counting<span class="beta-note">(edge cases still being refined)</span></li>
+        <li><strong>Internal transfer detection</strong> <span class="beta-tag">(beta)</span> — matches transfers across your own accounts so they don't inflate dashboards<span class="beta-note">(edge cases still being refined)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Download for your system</h2>
       <p>Official installers are published as assets on each <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Pick the format for your OS.</p>

--- a/getting-started.es.html
+++ b/getting-started.es.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Qué obtienes</a>
         <a href="#download">Descargar</a>
         <a href="#install">Instalar</a>
         <a href="#first-launch">Primer inicio</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Qué obtienes</h2>
+      <ul class="features-list">
+        <li><strong>Importa CSV/XLSX de cualquier banco</strong> — detecta el formato automáticamente, sin mapeo manual</li>
+        <li><strong>Categorización por IA, totalmente offline</strong> — LLM local incluido, no se necesita cloud</li>
+        <li><strong>IA local por defecto</strong> — los datos se quedan en tu máquina; el LLM remoto es opt-in y redacta IBAN / tarjetas / nombres del titular (los importes y fechas siguen viajando — ver roadmap)</li>
+        <li><strong>Cinco idiomas</strong> — italiano, inglés, francés, alemán, español</li>
+        <li><strong>Reconciliación tarjeta-cuenta</strong> <span class="beta-tag">(beta)</span> — empareja los cargos de tarjeta con los gastos subyacentes para evitar doble cómputo<span class="beta-note">(casos límite aún en refinamiento)</span></li>
+        <li><strong>Detección de transferencias internas</strong> <span class="beta-tag">(beta)</span> — relaciona las transferencias entre tus cuentas para que no inflen los dashboards<span class="beta-note">(casos límite aún en refinamiento)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Descarga para tu sistema</h2>
       <p>Los instaladores oficiales se publican como activos de cada <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Elige el formato adecuado para tu SO.</p>

--- a/getting-started.fr.html
+++ b/getting-started.fr.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Ce que vous obtenez</a>
         <a href="#download">Télécharger</a>
         <a href="#install">Installer</a>
         <a href="#first-launch">Premier lancement</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Ce que vous obtenez</h2>
+      <ul class="features-list">
+        <li><strong>Importe les CSV/XLSX de n'importe quelle banque</strong> — détecte automatiquement le format, pas de mapping manuel</li>
+        <li><strong>Catégorisation par IA, totalement hors ligne</strong> — LLM local inclus, pas besoin de cloud</li>
+        <li><strong>IA locale par défaut</strong> — les données restent sur votre machine ; le LLM distant est opt-in et masque IBAN / cartes / noms du titulaire (les montants et les dates voyagent toujours — voir feuille de route)</li>
+        <li><strong>Cinq langues</strong> — italien, anglais, français, allemand, espagnol</li>
+        <li><strong>Réconciliation carte-compte</strong> <span class="beta-tag">(bêta)</span> — apparie les débits carte avec les dépenses sous-jacentes pour éviter le double comptage<span class="beta-note">(cas limites encore en cours de raffinement)</span></li>
+        <li><strong>Détection des virements internes</strong> <span class="beta-tag">(bêta)</span> — apparie les virements entre vos propres comptes pour qu'ils ne gonflent pas les tableaux de bord<span class="beta-note">(cas limites encore en cours de raffinement)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Téléchargez pour votre système</h2>
       <p>Les installeurs officiels sont publiés en tant qu'assets de chaque <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Choisissez le format adapté à votre OS.</p>

--- a/getting-started.html
+++ b/getting-started.html
@@ -146,6 +146,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Cosa ottieni</a>
         <a href="#download">Scarica</a>
         <a href="#install">Installa</a>
         <a href="#first-launch">Primo avvio</a>
@@ -162,6 +163,18 @@
   <div class="wrap">
 
     <!-- ── Step 1 — Download ─────────────────────────────────────────── -->
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Cosa ottieni</h2>
+      <ul class="features-list">
+        <li><strong>Importa CSV/XLSX di qualsiasi banca</strong> — riconosce il formato in automatico, nessun mapping manuale</li>
+        <li><strong>Categorizzazione AI, completamente offline</strong> — LLM locale incluso, nessun cloud</li>
+        <li><strong>AI locale di default</strong> — i dati restano sulla tua macchina; LLM remoto opt-in con redazione di IBAN / carte / nomi titolare (importi e date viaggiano comunque — roadmap aperta)</li>
+        <li><strong>Cinque lingue</strong> — italiano, inglese, francese, tedesco, spagnolo</li>
+        <li><strong>Riconciliazione carta-conto</strong> <span class="beta-tag">(beta)</span> — appaia gli addebiti carta con le spese sottostanti per evitare il double-counting<span class="beta-note">(edge cases ancora in raffinamento)</span></li>
+        <li><strong>Rilevazione giroconti</strong> <span class="beta-tag">(beta)</span> — matcha i giroconti tra i tuoi conti perché non gonfino i dashboard<span class="beta-note">(edge cases ancora in raffinamento)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Scarica per il tuo sistema</h2>
       <p>Gli installer ufficiali sono pubblicati come asset di ogni <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Scegli il formato adatto al tuo OS.</p>

--- a/getting-started.ja.html
+++ b/getting-started.ja.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">得られるもの</a>
         <a href="#download">ダウンロード</a>
         <a href="#install">インストール</a>
         <a href="#first-launch">初回起動</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>得られるもの</h2>
+      <ul class="features-list">
+        <li><strong>任意の銀行のCSV/XLSXをインポート</strong> — フォーマットを自動検出、手動マッピング不要</li>
+        <li><strong>AIによる分類、完全オフライン</strong> — ローカルLLMを同梱、クラウド不要</li>
+        <li><strong>デフォルトでローカルAI</strong> — データはあなたのマシンに留まります。リモートLLMはオプトインで、IBAN / カード / 名義人名をマスクします (金額と日付は依然として送信されます — ロードマップ参照)</li>
+        <li><strong>5つの言語</strong> — イタリア語、英語、フランス語、ドイツ語、スペイン語</li>
+        <li><strong>カード・口座の照合</strong> <span class="beta-tag">(ベータ)</span> — クレジットカードの請求と元の支出をペアにして二重計上を回避<span class="beta-note">(エッジケースを精緻化中)</span></li>
+        <li><strong>内部送金の検出</strong> <span class="beta-tag">(ベータ)</span> — 自分の口座間の送金をマッチングしてダッシュボードを膨張させない<span class="beta-note">(エッジケースを精緻化中)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>お使いの OS 用にダウンロード</h2>
       <p>公式インストーラーは各 <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a> のアセットとして公開されています。OS に合ったフォーマットを選んでください。</p>

--- a/getting-started.nl.html
+++ b/getting-started.nl.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Wat je krijgt</a>
         <a href="#download">Downloaden</a>
         <a href="#install">Installeren</a>
         <a href="#first-launch">Eerste start</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Wat je krijgt</h2>
+      <ul class="features-list">
+        <li><strong>Importeert CSV/XLSX van elke bank</strong> — herkent het formaat automatisch, geen handmatige mapping</li>
+        <li><strong>AI-categorisatie, volledig offline</strong> — lokaal LLM inbegrepen, geen cloud nodig</li>
+        <li><strong>Lokale AI standaard</strong> — gegevens blijven op je machine; remote LLM is opt-in en redigeert IBAN / kaarten / rekeninghouder-namen (bedragen en datums reizen nog steeds — zie roadmap)</li>
+        <li><strong>Vijf talen</strong> — Italiaans, Engels, Frans, Duits, Spaans</li>
+        <li><strong>Kaart-rekening reconciliatie</strong> <span class="beta-tag">(bèta)</span> — koppelt creditcard-afschrijvingen aan de onderliggende uitgaven om dubbeltelling te voorkomen<span class="beta-note">(edge cases nog in verfijning)</span></li>
+        <li><strong>Detectie van interne overboekingen</strong> <span class="beta-tag">(bèta)</span> — matcht overboekingen tussen je eigen rekeningen zodat ze de dashboards niet opblazen<span class="beta-note">(edge cases nog in verfijning)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Download voor jouw systeem</h2>
       <p>De officiële installers worden gepubliceerd als assets van elke <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Kies het juiste formaat voor je OS.</p>

--- a/getting-started.pl.html
+++ b/getting-started.pl.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">Co otrzymujesz</a>
         <a href="#download">Pobierz</a>
         <a href="#install">Instaluj</a>
         <a href="#first-launch">Pierwsze uruchomienie</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>Co otrzymujesz</h2>
+      <ul class="features-list">
+        <li><strong>Importuje CSV/XLSX z dowolnego banku</strong> — automatyczne rozpoznawanie formatu, bez ręcznego mapowania</li>
+        <li><strong>Kategoryzacja AI, w pełni offline</strong> — lokalny LLM w zestawie, chmura nie jest potrzebna</li>
+        <li><strong>Lokalna AI domyślnie</strong> — dane pozostają na Twoim komputerze; zdalny LLM jest opt-in i redaguje IBAN / karty / nazwiska właścicieli (kwoty i daty nadal podróżują — zobacz roadmap)</li>
+        <li><strong>Pięć języków</strong> — włoski, angielski, francuski, niemiecki, hiszpański</li>
+        <li><strong>Uzgadnianie karta-konto</strong> <span class="beta-tag">(beta)</span> — paruje obciążenia kartą z pierwotnymi wydatkami, aby uniknąć podwójnego liczenia<span class="beta-note">(przypadki brzegowe są jeszcze dopracowywane)</span></li>
+        <li><strong>Wykrywanie transferów wewnętrznych</strong> <span class="beta-tag">(beta)</span> — dopasowuje transfery między Twoimi kontami, aby nie zawyżały dashboardów<span class="beta-note">(przypadki brzegowe są jeszcze dopracowywane)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Pobierz dla swojego systemu</h2>
       <p>Oficjalne instalatory są publikowane jako zasoby każdego <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Wybierz format odpowiedni dla Twojego systemu.</p>

--- a/getting-started.pt.html
+++ b/getting-started.pt.html
@@ -49,6 +49,11 @@
     .step-img img { max-width: 100%; max-height: 100%; border-radius: 8px; }
     .step-img .ph { display: flex; flex-direction: column; align-items: center; gap: 0.5rem; }
     .step-img .ph code { background: var(--bg); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.8rem; }
+.features-list { list-style: none; padding: 0; margin: 1.5rem 0 0 0; }
+    .features-list li { padding: 1rem 1.2rem; background: var(--surface); border-radius: 8px; margin-bottom: 0.75rem; border-left: 3px solid var(--blue); color: var(--muted); }
+    .features-list li strong { color: var(--text); }
+    .features-list li .beta-tag { color: var(--orange); font-weight: 600; font-size: 0.85rem; margin-left: 0.3rem; }
+    .features-list li .beta-note { color: var(--muted); font-size: 0.85rem; font-style: italic; display: block; margin-top: 0.3rem; }
     .note { background: var(--surface); border-left: 4px solid var(--orange); padding: 1rem 1.2rem; border-radius: 6px; margin: 1.5rem 0; }
     .note strong { color: var(--orange); }
     footer { border-top: 1px solid var(--border); padding: 2rem 1.5rem; text-align: center; color: var(--muted); font-size: 0.9rem; }
@@ -60,6 +65,7 @@
     <div class="nav-inner">
       <div class="nav-brand"><a href="/">Spendif.ai</a></div>
       <div class="nav-links">
+        <a href="#what-you-get">O que você obtém</a>
         <a href="#download">Baixar</a>
         <a href="#install">Instalar</a>
         <a href="#first-launch">Primeira execução</a>
@@ -75,6 +81,18 @@
 
   <div class="wrap">
 
+
+    <section id="what-you-get">
+      <h2><span class="step-num" style="background:var(--green)">✨</span>O que você obtém</h2>
+      <ul class="features-list">
+        <li><strong>Importa CSV/XLSX de qualquer banco</strong> — detecta o formato automaticamente, sem mapeamento manual</li>
+        <li><strong>Categorização por IA, totalmente offline</strong> — LLM local incluído, sem nuvem</li>
+        <li><strong>IA local por padrão</strong> — os dados permanecem na sua máquina; o LLM remoto é opt-in e redige IBAN / cartões / nomes do titular (os valores e datas ainda viajam — ver roadmap)</li>
+        <li><strong>Cinco idiomas</strong> — italiano, inglês, francês, alemão, espanhol</li>
+        <li><strong>Reconciliação cartão-conta</strong> <span class="beta-tag">(beta)</span> — pareia os débitos do cartão com os gastos subjacentes para evitar dupla contagem<span class="beta-note">(casos extremos ainda em refinamento)</span></li>
+        <li><strong>Detecção de transferências internas</strong> <span class="beta-tag">(beta)</span> — relaciona as transferências entre as suas contas para que não inflacionem os dashboards<span class="beta-note">(casos extremos ainda em refinamento)</span></li>
+      </ul>
+    </section>
     <section id="download">
       <h2><span class="step-num">1</span>Baixe para o seu sistema</h2>
       <p>Os instaladores oficiais são publicados como assets de cada <a href="https://github.com/drake69/spendify/releases/latest" target="_blank">GitHub Release</a>. Escolha o formato adequado para o seu SO.</p>


### PR DESCRIPTION
## Summary

- **README rewrite for dev audience** (663 → ~180 lines per locale). End-user material now lives on the gh-pages Getting Started page; README points them there with a banner. "What's implemented" replaces the 35-row feature table with 6 honest bullets (file paths, RF-codes, explicit `(beta)` flags). Develop-locally section clarifies Ollama vs llama.cpp.
- **New `docs/architecture.{md,it.md}`** — layer diagram, Flow 1 vs Flow 2, desktop launcher flow, pool pattern, async runner, auto-hash migrations.
- **New `docs/design_decisions.{md,it.md}`** — Decimal/SHA-256/invert_sign/subcategory/taxonomy-in-DB/PII precondition/circuit breaker/no-LangChain/RF-03/RF-04 with explicit `(beta)` status on RF-03 + RF-04.
- **New "What you get" section** on all 9 `getting-started.*.html` locales (it/en/de/es/fr/ja/nl/pl/pt): six user-value bullets translated natively, with honest beta disclaimers on the reconciliation features.
- **Honest privacy claim everywhere**: the previous "PII sanitization before any remote call" was technically true but misleading — it hid the fact that **amounts and dates** still travel to remote backends. README now shows a concrete before/after redaction example and points at the new backlog item **AI-55** for the planned `none`/`buckets`/`strip` redaction modes. The Privacy-first bullet on every getting-started locale is rephrased accordingly.

Backlog: **AI-52** done on merge. **AI-55** opened as P1 (M effort).

## Test plan

- [ ] **CI green** — `ci.yml` runs on this PR. The fix from #108 is already on `main`, so the sanitizer regression tests continue to pass.
- [ ] **All internal links resolve** — verified locally with a Python script: 102/102 markdown links across README + new docs reach existing files.
- [ ] **All 9 getting-started HTML parse** without errors and include the Cloudflare beacon (the memory rule).
- [ ] **Reciprocal language switch** — README.md ↔ README.it.md, every doc EN ↔ IT, every getting-started locale ↔ EN+IT.

## Risks

- The new privacy claim is louder about what travels. This is intentional — the project positions itself as privacy-first and the README must back that up. If the wording is too pessimistic for a marketing context, the gh-pages bullet (separate from README) can be softened without breaking the developer-facing message.
- The two new docs (`architecture`, `design_decisions`) duplicate ~no content with existing `reference_guide.md` and `developer_guide.md` — verified by inspection. If duplication creeps in over time, the new docs should be the source of truth and `reference_guide.md` should link to them.