### PR TITLE
feat(routing): empty-state on Import + data-driven default page

### DIFF
--- a/app.py
+++ b/app.py
@@ -134,6 +134,14 @@ from ui.i18n import set_language as _set_lang
 _set_lang(_cfg_check.get_all().get("ui_language", "it"))
 
 # ── Sidebar navigation ────────────────────────────────────────────────────────
+# Default landing page is data-driven: with at least one transaction we go
+# straight to the Home dashboard; on an empty DB we land on Import (whose
+# empty state nudges the user to upload). Computed once here so sidebar
+# can stay engine-free.
+if "page" not in st.session_state:
+    from services.transaction_service import TransactionService as _TxSvc
+    st.session_state["page"] = "home" if _TxSvc(engine).has_transactions() else "import"
+
 from ui.sidebar import render_sidebar
 
 page = render_sidebar()

--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -26,6 +26,16 @@ class TransactionService:
         with self._session() as s:
             return repository.get_transactions(s, filters or {}, limit, offset)
 
+    def has_transactions(self) -> bool:
+        """True if the `transaction` table has at least one row.
+
+        Used by the default-page selector after onboarding: if the DB is
+        empty we land the user on the Import page (with an empty-state
+        message), otherwise on the Home dashboard.
+        """
+        with self._session() as s:
+            return s.query(Transaction.id).limit(1).first() is not None
+
     def update_category(self, tx_id: str, category: str, subcategory: str) -> bool:
         with self._session() as s:
             result = repository.update_transaction_category(s, tx_id, category, subcategory)

--- a/tests/test_service_transaction.py
+++ b/tests/test_service_transaction.py
@@ -164,3 +164,16 @@ def test_get_by_raw_pattern(seeded_engine):
     result = svc.get_by_raw_pattern("netflix", "contains")
     assert len(result) == 1
     assert result[0].id == "r1"
+
+
+# ── has_transactions ─────────────────────────────────────────────────────────
+
+def test_has_transactions_empty_db(svc):
+    """Empty `transaction` table → returns False."""
+    assert svc.has_transactions() is False
+
+
+def test_has_transactions_after_first_insert(seeded_engine):
+    """At least one row in `transaction` → returns True."""
+    from services.transaction_service import TransactionService
+    assert TransactionService(seeded_engine).has_transactions() is True

--- a/ui/i18n/de.json
+++ b/ui/i18n/de.json
@@ -835,5 +835,7 @@
   "onboarding.first_import.upload_now_help": "Zur Import-Seite gehen",
   "onboarding.first_import.skip_for_now": "⏭️ Mache ich später",
   "onboarding.first_import.skip_help": "Landet auf der Startseite, du kannst jederzeit importieren",
-  "onboarding.first_import.step_label": "Erster Import"
+  "onboarding.first_import.step_label": "Erster Import",
+  "upload.empty_state.title": "📥 Noch keine Transaktionen",
+  "upload.empty_state.caption": "Lade unten deinen ersten Kontoauszug (CSV oder XLSX) hoch, um zu starten. Spendif.ai analysiert die Transaktionen und sortiert sie in die Kategorien, die du beim Setup gewählt hast."
 }

--- a/ui/i18n/en.json
+++ b/ui/i18n/en.json
@@ -835,5 +835,7 @@
   "onboarding.first_import.upload_now_help": "Go to the Import page",
   "onboarding.first_import.skip_for_now": "⏭️ I'll do it later",
   "onboarding.first_import.skip_help": "Lands on the Home, you can import any time",
-  "onboarding.first_import.step_label": "First import"
+  "onboarding.first_import.step_label": "First import",
+  "upload.empty_state.title": "📥 No transactions yet",
+  "upload.empty_state.caption": "Upload your first bank statement (CSV or XLSX) below to get started. Spendif.ai will parse the transactions and sort them into the categories you picked during setup."
 }

--- a/ui/i18n/es.json
+++ b/ui/i18n/es.json
@@ -835,5 +835,7 @@
   "onboarding.first_import.upload_now_help": "Ir a la página Importar",
   "onboarding.first_import.skip_for_now": "⏭️ Lo haré después",
   "onboarding.first_import.skip_help": "Aterriza en el Inicio, puedes importar en cualquier momento",
-  "onboarding.first_import.step_label": "Primer import"
+  "onboarding.first_import.step_label": "Primer import",
+  "upload.empty_state.title": "📥 Sin transacciones importadas",
+  "upload.empty_state.caption": "Carga tu primer extracto bancario (CSV o XLSX) debajo para empezar. Spendif.ai analiza las transacciones y las organiza en las categorías que elegiste durante la configuración."
 }

--- a/ui/i18n/fr.json
+++ b/ui/i18n/fr.json
@@ -835,5 +835,7 @@
   "onboarding.first_import.upload_now_help": "Aller à la page Import",
   "onboarding.first_import.skip_for_now": "⏭️ Je le ferai plus tard",
   "onboarding.first_import.skip_help": "Atterrit sur l'Accueil, vous pouvez importer à tout moment",
-  "onboarding.first_import.step_label": "Premier import"
+  "onboarding.first_import.step_label": "Premier import",
+  "upload.empty_state.title": "📥 Aucune transaction importée",
+  "upload.empty_state.caption": "Chargez votre premier relevé bancaire (CSV ou XLSX) ci-dessous pour commencer. Spendif.ai analyse les transactions et les classe dans les catégories choisies lors de la configuration."
 }

--- a/ui/i18n/it.json
+++ b/ui/i18n/it.json
@@ -835,5 +835,7 @@
   "onboarding.first_import.upload_now_help": "Vai alla pagina Import",
   "onboarding.first_import.skip_for_now": "⏭️ Lo faccio dopo",
   "onboarding.first_import.skip_help": "Atterra sulla Home, puoi importare in qualunque momento",
-  "onboarding.first_import.step_label": "Primo import"
+  "onboarding.first_import.step_label": "Primo import",
+  "upload.empty_state.title": "📥 Nessuna transazione importata",
+  "upload.empty_state.caption": "Carica il tuo primo estratto bancario (CSV o XLSX) qui sotto per iniziare. Spendif.ai analizza le transazioni e le organizza nelle categorie che hai scelto durante il setup."
 }

--- a/ui/upload_page.py
+++ b/ui/upload_page.py
@@ -449,7 +449,16 @@ def render_upload_page(engine):
     )
 
     if not uploaded_files:
-        st.info(t_fn("upload.no_files_hint"))
+        # Empty-state amichevole quando il DB non ha ancora transazioni:
+        # è il caso classico del post-onboarding "Lo faccio dopo". Una volta
+        # importata anche una sola transazione, mostriamo invece il normale
+        # hint del file picker.
+        from services.transaction_service import TransactionService
+        if not TransactionService(engine).has_transactions():
+            st.markdown(f"### {t_fn('upload.empty_state.title')}")
+            st.caption(t_fn("upload.empty_state.caption"))
+        else:
+            st.info(t_fn("upload.no_files_hint"))
         _render_job_status_poll(import_svc)
         _render_last_import_summary()
         return


### PR DESCRIPTION
## Summary

Realign the post-onboarding flow with the user's view:

- "**Lo faccio dopo**" (step 6 wizard) lands on the **Import** page — unchanged.
- **Import** now shows a friendly empty state when the `transaction` table is empty AND no file is queued. With ≥1 transaction the page reverts to the generic "no files selected" hint.
- **Default page selector** in `app.py` is now data-driven: `home` if `TransactionService(engine).has_transactions()`, `import` otherwise. After the first import the next launch routes the user to Home.

## New helper

`TransactionService.has_transactions()` — `SELECT id FROM transaction LIMIT 1`, cheaper than `COUNT(*)`.

## i18n

`upload.empty_state.title` + `upload.empty_state.caption` × 5 lingue (839 keys total, parity preserved). Wording neutro (no antropomorfizzazioni, coerente con AI-28).

## Test plan

- [x] `services/transaction_service.has_transactions` — 2 cases (empty DB → False, post-seed → True).
- [x] Suite locale: 77/77 verde sui file impattati.
- [ ] CI ubuntu/macos/windows verde su Python 3.13.
- [ ] Coupling check 0 violazioni (touch solo `services/` + `ui/upload_page.py`).
- [ ] Codecov/patch ≥ 90%.

## Out of scope

- **Home page** (AI-63) — i grafici Sankey/stacked bar restano roadmap separata. Quando atterrerà, l'utente con DB pieno la vedrà come default page automaticamente via `has_transactions()`. Nessun ritocco al wizard sarà necessario.

Closes AI-70