### PR TITLE
docs(roadmap): public 'What's coming next' section × 5 entry points

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -38,6 +38,18 @@ Registro finanziario personale unificato con pipeline ibrida deterministica + LL
 - **Riconciliazione carta-conto (RF-03, beta)** — algoritmo a 3 fasi in `core/normalizer.py`: appaia gli addebiti carta con le spese sottostanti per eliminare il double-counting *(edge cases ancora in raffinamento)*
 - **Rilevazione giroconti interni (RF-04, beta)** — matching su importo simbolico + finestra di ±7 giorni, con permutazioni dei nomi titolare per intercettare export tipo "Cognome Nome" *(edge cases ancora in raffinamento)*
 
+## Cosa arriva dopo
+
+Spendif.ai è in alpha test. Le funzioni che aggiungeremo le decidiamo insieme a chi usa l'app oggi: nessun lavoro speculativo, nessuna roadmap calata dall'alto.
+
+Funzioni in valutazione in base ai feedback degli alpha tester:
+
+- **Tracking del cash** — registrare manualmente le spese in contanti, senza estratto bancario
+- **Performance degli investimenti** — vedere a colpo d'occhio come stanno andando gli strumenti del portafoglio
+- **App mobile compagna** — registrare cash al volo dal telefono e sincronizzare col desktop
+
+Una di queste ti servirebbe? Faccelo sapere su [GitHub Discussions](https://github.com/drake69/spendify/discussions). Quando arrivano abbastanza richieste sulla stessa funzione, sale in cima alla coda.
+
 ## 👩‍💻 Sviluppo locale
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,6 +38,18 @@ Unified personal finance ledger with a hybrid deterministic + LLM pipeline. Aggr
 - **Card-account reconciliation (RF-03, beta)** — 3-phase algorithm in `core/normalizer.py`: pairs credit-card settlements with the underlying expenses to eliminate double-counting *(edge cases still being refined)*
 - **Internal transfer detection (RF-04, beta)** — symbolic-amount + ±7-day window matching, with owner-name permutations to catch "Cognome Nome" exports *(edge cases still being refined)*
 
+## What's coming next
+
+Spendif.ai is in alpha. The features we add next are decided together with the people using the app today: no speculative work, no roadmap dictated from above.
+
+Features under evaluation based on alpha-tester feedback:
+
+- **Cash tracking** — log cash purchases manually, with no bank statement attached
+- **Investment performance** — see at a glance how the instruments in your portfolio are doing
+- **Companion mobile app** — capture cash on the fly from your phone and sync with the desktop
+
+Would one of these help you? Tell us in [GitHub Discussions](https://github.com/drake69/spendify/discussions). When enough requests stack up on the same feature, it moves to the top of the queue.
+
 ## 👩‍💻 Develop locally
 
 ```bash

--- a/docs/guida_utente.en.md
+++ b/docs/guida_utente.en.md
@@ -558,3 +558,17 @@ In Analytics you'll find the **Esporta** button which generates HTML, CSV, or XL
 
 **I changed the Taxonomy but the old transactions haven't updated.**
 Old categories stay as they are. You can reprocess them manually from the Review page or by re-applying the rules.
+
+---
+
+## What's coming next
+
+Spendif.ai is in alpha. The features we add next are decided together with the people using the app today: no speculative work, no roadmap dictated from above.
+
+Features under evaluation based on alpha-tester feedback:
+
+- **Cash tracking** — log cash purchases manually, with no bank statement attached
+- **Investment performance** — see at a glance how the instruments in your portfolio are doing
+- **Companion mobile app** — capture cash on the fly from your phone and sync with the desktop
+
+Would one of these help you? Tell us in [GitHub Discussions](https://github.com/drake69/spendify/discussions). When enough requests stack up on the same feature, it moves to the top of the queue.

--- a/docs/guida_utente.md
+++ b/docs/guida_utente.md
@@ -560,3 +560,17 @@ In Analytics trovi il pulsante **Esporta** che genera HTML, CSV o XLSX.
 
 **Ho cambiato la tassonomia ma le transazioni vecchie non si sono aggiornate.**
 Le categorie vecchie rimangono come sono. Puoi rielaborarle manualmente dalla pagina Review o ri-applicando le regole.
+
+---
+
+## Cosa arriva dopo
+
+Spendif.ai è in alpha test. Le funzioni che aggiungeremo le decidiamo insieme a chi usa l'app oggi: nessun lavoro speculativo, nessuna roadmap calata dall'alto.
+
+Funzioni in valutazione in base ai feedback degli alpha tester:
+
+- **Tracking del cash** — registrare manualmente le spese in contanti, senza estratto bancario
+- **Performance degli investimenti** — vedere a colpo d'occhio come stanno andando gli strumenti del portafoglio
+- **App mobile compagna** — registrare cash al volo dal telefono e sincronizzare col desktop
+
+Una di queste ti servirebbe? Faccelo sapere su [GitHub Discussions](https://github.com/drake69/spendify/discussions). Quando arrivano abbastanza richieste sulla stessa funzione, sale in cima alla coda.

--- a/getting-started.de.html
+++ b/getting-started.de.html
@@ -233,6 +233,20 @@
       </p>
       <p>Bugs, Fragen, Anregungen: <a href="https://github.com/drake69/spendify/issues" target="_blank">GitHub Issue eröffnen</a>.</p>
     </section>
+    <!-- ── What's coming next (alpha-driven roadmap) ─────────────────── -->
+    <section id="roadmap">
+      <h2>Was als Nächstes kommt</h2>
+      <p>Spendif.ai ist im Alpha-Test. Die Funktionen, die wir als Nächstes hinzufügen, entscheiden wir gemeinsam mit den Menschen, die die App heute nutzen: keine spekulative Arbeit, keine Roadmap von oben.</p>
+      <p>Funktionen in Bewertung anhand der Rückmeldungen der Alpha-Tester:</p>
+      <ul>
+        <li><strong>Bargeld-Tracking</strong> — Bargeld-Ausgaben manuell erfassen, ohne Kontoauszug</li>
+        <li><strong>Investment-Performance</strong> — auf einen Blick sehen, wie sich die Instrumente im Portfolio entwickeln</li>
+        <li><strong>Mobile Begleit-App</strong> — Bargeld unterwegs vom Telefon erfassen und mit dem Desktop synchronisieren</li>
+      </ul>
+      <p>Würde dir eines davon helfen? Sag es uns in <a href="https://github.com/drake69/spendify/discussions" target="_blank">GitHub Discussions</a>. Wenn genug Anfragen für dieselbe Funktion zusammenkommen, rutscht sie an die Spitze der Warteschlange.</p>
+    </section>
+
+
 
   </div>
 

--- a/getting-started.en.html
+++ b/getting-started.en.html
@@ -337,6 +337,20 @@
       </p>
       <p>Bugs, questions, requests: <a href="https://github.com/drake69/spendify/issues" target="_blank">open a GitHub issue</a>.</p>
     </section>
+    <!-- ── What's coming next (alpha-driven roadmap) ─────────────────── -->
+    <section id="roadmap">
+      <h2>What's coming next</h2>
+      <p>Spendif.ai is in alpha. The features we add next are decided together with the people using the app today: no speculative work, no roadmap dictated from above.</p>
+      <p>Features under evaluation based on alpha-tester feedback:</p>
+      <ul>
+        <li><strong>Cash tracking</strong> — log cash purchases manually, with no bank statement attached</li>
+        <li><strong>Investment performance</strong> — see at a glance how the instruments in your portfolio are doing</li>
+        <li><strong>Companion mobile app</strong> — capture cash on the fly from your phone and sync with the desktop</li>
+      </ul>
+      <p>Would one of these help you? Tell us in <a href="https://github.com/drake69/spendify/discussions" target="_blank">GitHub Discussions</a>. When enough requests stack up on the same feature, it moves to the top of the queue.</p>
+    </section>
+
+
 
   </div>
 

--- a/getting-started.es.html
+++ b/getting-started.es.html
@@ -232,6 +232,20 @@
       </p>
       <p>Bugs, preguntas, solicitudes: <a href="https://github.com/drake69/spendify/issues" target="_blank">abre una issue en GitHub</a>.</p>
     </section>
+    <!-- ── What's coming next (alpha-driven roadmap) ─────────────────── -->
+    <section id="roadmap">
+      <h2>Lo que viene a continuación</h2>
+      <p>Spendif.ai está en alpha. Las funciones que añadimos se deciden junto a las personas que usan la app hoy: nada de trabajo especulativo, ninguna roadmap impuesta desde arriba.</p>
+      <p>Funciones en evaluación según los comentarios de los alpha testers:</p>
+      <ul>
+        <li><strong>Seguimiento del cash</strong> — registrar manualmente los gastos en efectivo, sin extracto bancario</li>
+        <li><strong>Rendimiento de las inversiones</strong> — ver de un vistazo cómo están funcionando los instrumentos de la cartera</li>
+        <li><strong>App móvil compañera</strong> — registrar el efectivo al vuelo desde el móvil y sincronizar con el escritorio</li>
+      </ul>
+      <p>¿Te resultaría útil alguna de estas? Dínoslo en <a href="https://github.com/drake69/spendify/discussions" target="_blank">GitHub Discussions</a>. Cuando se acumulan suficientes peticiones sobre la misma función, sube al principio de la cola.</p>
+    </section>
+
+
 
   </div>
 

--- a/getting-started.fr.html
+++ b/getting-started.fr.html
@@ -232,6 +232,20 @@
       </p>
       <p>Bugs, questions, demandes : <a href="https://github.com/drake69/spendify/issues" target="_blank">ouvrir une issue sur GitHub</a>.</p>
     </section>
+    <!-- ── What's coming next (alpha-driven roadmap) ─────────────────── -->
+    <section id="roadmap">
+      <h2>Ce qui arrive ensuite</h2>
+      <p>Spendif.ai est en alpha. Les fonctionnalités que nous ajouterons seront décidées avec les personnes qui utilisent l'app aujourd'hui : pas de travail spéculatif, pas de roadmap imposée d'en haut.</p>
+      <p>Fonctionnalités à l'étude selon les retours des alpha testeurs :</p>
+      <ul>
+        <li><strong>Suivi du cash</strong> — enregistrer manuellement les dépenses en espèces, sans relevé bancaire</li>
+        <li><strong>Performance des investissements</strong> — voir d'un coup d'œil comment les instruments de votre portefeuille évoluent</li>
+        <li><strong>App mobile compagne</strong> — saisir les espèces à la volée depuis le téléphone et synchroniser avec le bureau</li>
+      </ul>
+      <p>L'une de ces options vous serait-elle utile ? Dites-le-nous sur <a href="https://github.com/drake69/spendify/discussions" target="_blank">GitHub Discussions</a>. Quand suffisamment de demandes s'accumulent sur la même fonctionnalité, elle monte en tête de file.</p>
+    </section>
+
+
 
   </div>
 

--- a/getting-started.html
+++ b/getting-started.html
@@ -359,6 +359,20 @@
       </p>
       <p>Bug, domande, richieste: <a href="https://github.com/drake69/spendify/issues" target="_blank">apri una issue su GitHub</a>.</p>
     </section>
+    <!-- ── What's coming next (alpha-driven roadmap) ─────────────────── -->
+    <section id="roadmap">
+      <h2>Cosa arriva dopo</h2>
+      <p>Spendif.ai è in alpha test. Le funzioni che aggiungeremo le decidiamo insieme a chi usa l'app oggi: nessun lavoro speculativo, nessuna roadmap calata dall'alto.</p>
+      <p>Funzioni in valutazione in base ai feedback degli alpha tester:</p>
+      <ul>
+        <li><strong>Tracking del cash</strong> — registrare manualmente le spese in contanti, senza estratto bancario</li>
+        <li><strong>Performance degli investimenti</strong> — vedere a colpo d'occhio come stanno andando gli strumenti del portafoglio</li>
+        <li><strong>App mobile compagna</strong> — registrare cash al volo dal telefono e sincronizzare col desktop</li>
+      </ul>
+      <p>Una di queste ti servirebbe? Faccelo sapere su <a href="https://github.com/drake69/spendify/discussions" target="_blank">GitHub Discussions</a>. Quando arrivano abbastanza richieste sulla stessa funzione, sale in cima alla coda.</p>
+    </section>
+
+
 
   </div>
 


### PR DESCRIPTION
## Summary

Esplicito verso l'utente finale la policy "alpha-driven" che abbiamo già come memoria interna: ogni feature non-core resta in icebox finché ≥2 alpha tester non la chiedono. Lo stesso messaggio in 5 sedi.

| Sede | Lingue | Posizione |
|---|---|---|
| `README.md` / `README.it.md` | EN + IT | tra Features e Develop locally |
| `docs/guida_utente.md` / `.en.md` | IT + EN | sezione finale dopo FAQ |
| `getting-started.*.html` | IT + EN + FR + DE + ES | nuova `<section id="roadmap">` tra help e footer |

3 feature in valutazione visibili agli utenti:
- **Cash tracking** (AI-71)
- **Investment performance** (AI-73)
- **Companion mobile app** (AI-72)

CTA: [GitHub Discussions](https://github.com/drake69/spendify/discussions).

## Tono e brand

- Neutro, no antropomorfizzazioni (AI-28).
- Coerente con il ruolo brand "companion" (memoria `project_brand_role`): trasparente, non pressante, sceglie insieme.
- Stesso wording in IT/EN, adattato in FR/DE/ES.

## Note operative

- `getting-started.{ja,nl,pl,pt}.html` intenzionalmente NON toccati — fuori scope dichiarato (5 lingue IT/EN/FR/DE/ES, da memoria docs_it_en).
- Cloudflare beacon già presente in tutti i 5 HTML toccati.
- Solo docs/landing: zero modifiche al codice, niente test, niente coupling impact.

## Test plan

- [ ] CI verde (anche se questo PR tocca solo `.md`/`.html`, niente Python).
- [ ] Rendering sezione roadmap su gh-pages dopo deploy.
- [ ] Link GitHub Discussions raggiungibile (verificato `has_discussions=true`).