### PR TITLE
feat(home): Home Dashboard — income trend + income→expense Sankey

### DIFF
--- a/app.py
+++ b/app.py
@@ -74,8 +74,16 @@ st.markdown("""
 <style>
     .block-container { padding-top: 1rem !important; padding-bottom: 0.5rem !important; }
     header[data-testid="stHeader"] { height: 2rem !important; }
-    .stMainBlockContainer { padding-top: 0.5rem !important; }
-    h1, h2, h3 { margin-top: 0.3rem !important; margin-bottom: 0.3rem !important; }
+    /* Need a bit of breathing room at the top of the main container,
+       otherwise tall glyphs and emojis (e.g. the 📨 in "📨 Import")
+       get clipped because Streamlit ships overflow:hidden on the
+       block container. */
+    .stMainBlockContainer { padding-top: 1.25rem !important; }
+    h1, h2, h3 {
+        margin-top: 0.5rem !important;
+        margin-bottom: 0.4rem !important;
+        line-height: 1.35 !important;
+    }
     .stDataFrame, .stDataEditor { margin-top: 0.2rem !important; }
     div[data-testid="stExpander"] { margin-top: 0.3rem !important; }
 </style>

--- a/app.py
+++ b/app.py
@@ -147,7 +147,11 @@ from ui.sidebar import render_sidebar
 page = render_sidebar()
 
 # ── Route ─────────────────────────────────────────────────────────────────────
-if page == "import":
+if page == "home":
+    from ui.home_page import render_home_page
+    render_home_page(engine)
+
+elif page == "import":
     from ui.upload_page import render_upload_page
     render_upload_page(engine)
 

--- a/services/transaction_service.py
+++ b/services/transaction_service.py
@@ -36,6 +36,26 @@ class TransactionService:
         with self._session() as s:
             return s.query(Transaction.id).limit(1).first() is not None
 
+    def get_recent_for_home(self, since_iso: str) -> list[tuple]:
+        """Return rows since *since_iso* with only the columns the Home
+        dashboard needs. Tuple shape: (date, amount, tx_type, category,
+        subcategory, reconciled). Keeps the UI off of `db/` imports per
+        the coupling rule — the UI converts to DataFrame.
+        """
+        with self._session() as s:
+            return (
+                s.query(
+                    Transaction.date,
+                    Transaction.amount,
+                    Transaction.tx_type,
+                    Transaction.category,
+                    Transaction.subcategory,
+                    Transaction.reconciled,
+                )
+                .filter(Transaction.date >= since_iso)
+                .all()
+            )
+
     def update_category(self, tx_id: str, category: str, subcategory: str) -> bool:
         with self._session() as s:
             result = repository.update_transaction_category(s, tx_id, category, subcategory)

--- a/tests/test_home_page.py
+++ b/tests/test_home_page.py
@@ -1,0 +1,209 @@
+"""Tests for ui/home_page.py — pure helpers around the dashboard.
+
+We don't test the Streamlit render branches (st.plotly_chart, st.button,
+…) — those follow the project policy of leaving Streamlit-widget code to
+the runtime. Coverage focuses on the deterministic data-shaping helpers
+that drive the charts: `_load_transactions`, `_build_sankey_data`,
+`_twelve_months_ago`.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+
+import pandas as pd
+import pytest
+from sqlalchemy import create_engine
+
+from db.models import Transaction, create_tables, get_session
+from ui.home_page import (
+    _build_sankey_data,
+    _load_transactions,
+    _twelve_months_ago,
+)
+
+
+@pytest.fixture
+def engine():
+    eng = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    create_tables(eng)
+    return eng
+
+
+def _make_tx(tx_id, date_iso, amount, *, tx_type="expense",
+             category=None, subcategory=None, reconciled=False):
+    return Transaction(
+        id=tx_id, date=date_iso, amount=Decimal(str(amount)),
+        currency="EUR", description="x", source_file="f.csv",
+        doc_type="bank_statement", account_label="BancaX",
+        tx_type=tx_type, category=category, subcategory=subcategory,
+        reconciled=reconciled, to_review=False,
+    )
+
+
+def _seed(engine, rows):
+    with get_session(engine) as s:
+        for r in rows:
+            s.add(r)
+        s.commit()
+
+
+# ── _twelve_months_ago ────────────────────────────────────────────────────────
+
+class TestTwelveMonthsAgo:
+
+    def test_handles_standard_date(self):
+        # 2026-05-15 → 2025-05-15
+        got = _twelve_months_ago(date(2026, 5, 15))
+        assert got == date(2025, 5, 15)
+
+    def test_feb29_falls_back_to_365_days(self):
+        # 2024-02-29 → 2023 has no Feb 29 → fallback to 365 days earlier
+        got = _twelve_months_ago(date(2024, 2, 29))
+        assert got == date(2024, 2, 29) - timedelta(days=365)
+
+
+# ── _load_transactions ───────────────────────────────────────────────────────
+
+class TestLoadTransactions:
+
+    def test_empty_db_returns_empty_dataframe(self, engine):
+        df = _load_transactions(engine)
+        assert isinstance(df, pd.DataFrame)
+        assert df.empty
+        assert list(df.columns) == ["date", "amount", "tx_type", "category", "subcategory", "reconciled"]
+
+    def test_clamps_to_12_months(self, engine):
+        """Rows older than 12 months are filtered out at the SQL level."""
+        # since = today - 365 days, so 400 days ago is well outside
+        old_date = (date.today() - timedelta(days=400)).isoformat()
+        recent_date = (date.today() - timedelta(days=30)).isoformat()
+        _seed(engine, [
+            _make_tx("a" * 24, old_date, -50, category="Vecchio"),
+            _make_tx("b" * 24, recent_date, -50, category="Recente"),
+        ])
+        df = _load_transactions(engine)
+        assert len(df) == 1
+        assert df.iloc[0]["category"] == "Recente"
+
+    def test_returns_floats_for_amount(self, engine):
+        """SQLAlchemy Numeric returns Decimal; the dataframe converts to float."""
+        _seed(engine, [
+            _make_tx("a" * 24, (date.today() - timedelta(days=30)).isoformat(),
+                     "-12.34", category="Alimentari"),
+        ])
+        df = _load_transactions(engine)
+        assert df.iloc[0]["amount"] == pytest.approx(-12.34)
+        assert isinstance(df.iloc[0]["amount"], float)
+
+
+# ── _build_sankey_data ───────────────────────────────────────────────────────
+
+class TestBuildSankeyData:
+
+    def _df(self, *rows):
+        return pd.DataFrame(
+            list(rows),
+            columns=["date", "amount", "tx_type", "category", "subcategory", "reconciled"],
+        )
+
+    def test_no_income_no_expenses_returns_none(self):
+        empty = self._df()
+        assert _build_sankey_data(empty) is None
+
+    def test_income_only_marks_surplus(self):
+        """Only income, zero expenses → surplus = total income, Unknown is
+        a target node consuming the whole flow."""
+        df = self._df(
+            (pd.Timestamp("2026-01-15"), 1000.0, "income", "Stipendio", None, False),
+        )
+        out = _build_sankey_data(df)
+        assert out is not None
+        assert out["unknown_kind"] == "surplus"
+        # Total flow value into Unknown == total income
+        from ui.home_page import _t as _t_for_test
+        unk_label = _t_for_test("home.charts.unknown")
+        unk_idx = out["nodes"].index(unk_label)
+        flow_to_unknown = sum(
+            v for s, t, v in zip(out["link_source"], out["link_target"], out["link_value"])
+            if t == unk_idx
+        )
+        assert flow_to_unknown == 1000.0
+
+    def test_surplus_when_income_gt_expense(self):
+        df = self._df(
+            (pd.Timestamp("2026-01-15"), 1000.0, "income", "Stipendio", None, False),
+            (pd.Timestamp("2026-01-20"), -300.0, "expense", "Alimentari", "Spesa", False),
+        )
+        out = _build_sankey_data(df)
+        from ui.home_page import _t as _t_for_test
+        unk_label = _t_for_test("home.charts.unknown")
+        assert out["unknown_kind"] == "surplus"
+        unk_idx = out["nodes"].index(unk_label)
+        # Surplus = 1000 - 300 = 700 → income → unknown link
+        surplus_flow = next(
+            v for s, t, v in zip(out["link_source"], out["link_target"], out["link_value"])
+            if t == unk_idx and s == 0
+        )
+        assert surplus_flow == 700.0
+
+    def test_deficit_when_expense_gt_income(self):
+        """Expenses larger than income → Unknown is a *source* feeding the
+        missing budget into the "Total income" node."""
+        df = self._df(
+            (pd.Timestamp("2026-01-15"), 100.0, "income", "Stipendio", None, False),
+            (pd.Timestamp("2026-01-20"), -300.0, "expense", "Alimentari", "Spesa", False),
+        )
+        out = _build_sankey_data(df)
+        from ui.home_page import _t as _t_for_test
+        unk_label = _t_for_test("home.charts.unknown")
+        assert out["unknown_kind"] == "deficit"
+        unk_idx = out["nodes"].index(unk_label)
+        # Deficit = 200 → unknown → income node flow
+        deficit_flow = next(
+            v for s, t, v in zip(out["link_source"], out["link_target"], out["link_value"])
+            if s == unk_idx and t == 0
+        )
+        assert deficit_flow == 200.0
+
+    def test_parity_omits_unknown_node(self):
+        """income == expense → no surplus, no deficit → Unknown is omitted."""
+        df = self._df(
+            (pd.Timestamp("2026-01-15"), 500.0, "income", "Stipendio", None, False),
+            (pd.Timestamp("2026-01-20"), -500.0, "expense", "Alimentari", "Spesa", False),
+        )
+        out = _build_sankey_data(df)
+        from ui.home_page import _t as _t_for_test
+        unk_label = _t_for_test("home.charts.unknown")
+        assert out["unknown_kind"] == "parity"
+        # Unknown label may still appear (if it was already a category name) but
+        # there must be NO link involving it as source or target.
+        if unk_label in out["nodes"]:
+            unk_idx = out["nodes"].index(unk_label)
+            assert not any(s == unk_idx or t == unk_idx
+                           for s, t in zip(out["link_source"], out["link_target"]))
+
+    def test_internal_in_is_not_counted_as_income(self):
+        """internal_in (giroconto) is not real income; the surplus calc must
+        ignore it."""
+        df = self._df(
+            # internal_in 5000 should be ignored
+            (pd.Timestamp("2026-01-10"), 5000.0, "internal_in", "Giroconto", None, False),
+            (pd.Timestamp("2026-01-15"), 100.0, "income", "Stipendio", None, False),
+            (pd.Timestamp("2026-01-20"), -200.0, "expense", "Alimentari", "Spesa", False),
+        )
+        out = _build_sankey_data(df)
+        # 100 income, 200 expense → deficit 100, NOT a surplus from the 5000
+        assert out["unknown_kind"] == "deficit"
+
+    def test_reconciled_transactions_excluded(self):
+        """Reconciled rows (already settled by card reconciliation) must not
+        be double-counted."""
+        df = self._df(
+            (pd.Timestamp("2026-01-15"), 500.0, "income", "Stipendio", None, False),
+            (pd.Timestamp("2026-01-20"), -200.0, "expense", "Alimentari", "Spesa", True),  # reconciled
+            (pd.Timestamp("2026-01-21"), -50.0, "expense", "Trasporti", "ATM", False),
+        )
+        out = _build_sankey_data(df)
+        # Expected expense = 50, income = 500 → surplus 450
+        assert out["unknown_kind"] == "surplus"

--- a/ui/home_page.py
+++ b/ui/home_page.py
@@ -1,0 +1,285 @@
+"""Home page — landing dashboard with income trend + income→expense Sankey.
+
+Two charts, rolling 12-month window:
+
+  1. Stacked bar of monthly income (categories stacked, only `income` tx_type;
+     `internal_in` excluded — transfers between own accounts are not income).
+  2. Sankey from "Total income" through expense categories down to
+     subcategories, plus a "Sconosciuto" node that absorbs the surplus
+     (or supplies the deficit) so the chart balances.
+
+Empty state shows up when the `transaction` table is empty; in production
+the routing in app.py keeps the user on Import in that case, but defending
+the direct-URL access is cheap.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+from services.transaction_service import TransactionService
+from ui.i18n import t
+
+
+# ── i18n helper (alias to keep call sites short) ────────────────────────────
+def _t(key: str, **kwargs):
+    return t(key, **kwargs)
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+_ROLLING_DAYS = 365  # rolling 12-month window
+_INCOME_TYPE = "income"
+_EXPENSE_TYPE = "expense"
+
+
+# ── Data loading ─────────────────────────────────────────────────────────────
+
+def _twelve_months_ago(today: Optional[date] = None) -> date:
+    """Return today minus 12 months. Uses replace(year=year-1) when possible,
+    falling back to a 365-day delta for Feb-29 corner case."""
+    today = today or date.today()
+    try:
+        return today.replace(year=today.year - 1)
+    except ValueError:
+        # Feb 29 in a leap year
+        return today - timedelta(days=_ROLLING_DAYS)
+
+
+def _load_transactions(engine, since: Optional[date] = None) -> pd.DataFrame:
+    """Load all transactions from `since` (default: 12 months ago) into a
+    DataFrame. Returns an empty DataFrame with the right schema if the
+    table is empty. Delegates the query to TransactionService to keep
+    `ui/` out of `db/` (coupling rule)."""
+    since = since or _twelve_months_ago()
+    rows = TransactionService(engine).get_recent_for_home(since.isoformat())
+    if not rows:
+        return pd.DataFrame(columns=["date", "amount", "tx_type", "category", "subcategory", "reconciled"])
+
+    df = pd.DataFrame(rows, columns=["date", "amount", "tx_type", "category", "subcategory", "reconciled"])
+    df["date"] = pd.to_datetime(df["date"], errors="coerce")
+    df["amount"] = df["amount"].apply(lambda v: float(v) if v is not None else 0.0)
+    df["reconciled"] = df["reconciled"].astype(bool)
+    return df
+
+
+# ── Empty state ──────────────────────────────────────────────────────────────
+
+def _render_empty_state() -> None:
+    st.info(_t("home.empty_state.message"))
+    if st.button(_t("home.empty_state.cta"), key="_home_empty_cta"):
+        st.session_state["page"] = "import"
+        st.rerun()
+
+
+# ── Chart 1: Stacked bar — income by month ───────────────────────────────────
+
+def _render_income_stacked_bar(df: pd.DataFrame) -> None:
+    """Render the monthly-income stacked bar. *df* is the rolling-12-months
+    slice; we filter to `tx_type == 'income'` + `amount > 0` + not reconciled."""
+    import plotly.graph_objects as go
+
+    inc = df[
+        (df["tx_type"] == _INCOME_TYPE)
+        & (df["amount"] > 0)
+        & (~df["reconciled"])
+    ].copy()
+
+    if inc.empty:
+        st.caption(_t("home.charts.no_income"))
+        return
+
+    inc["category"] = inc["category"].fillna(_t("home.charts.uncategorised"))
+    inc["month"] = inc["date"].dt.to_period("M").dt.to_timestamp()
+
+    pivot = (
+        inc.groupby(["month", "category"])["amount"]
+        .sum()
+        .unstack(fill_value=0.0)
+        .sort_index()
+    )
+
+    fig = go.Figure()
+    for cat in pivot.columns:
+        fig.add_bar(
+            name=str(cat),
+            x=pivot.index,
+            y=pivot[cat].values,
+        )
+    fig.update_layout(
+        barmode="stack",
+        title=_t("home.charts.income_title"),
+        xaxis_title=_t("home.charts.month"),
+        yaxis_title=_t("home.charts.amount"),
+        legend_title_text=_t("home.charts.category"),
+        height=420,
+        margin=dict(l=40, r=40, t=60, b=40),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+# ── Chart 2: Sankey — income → expense category → subcategory ────────────────
+
+def _build_sankey_data(df: pd.DataFrame) -> Optional[dict]:
+    """Build node/link arrays for the Sankey. Returns None if there is no
+    income AND no expense (chart pointless), otherwise dict with keys:
+        nodes: list[str]
+        link_source: list[int]
+        link_target: list[int]
+        link_value:  list[float]
+        unknown_kind: 'surplus' | 'deficit' | 'parity'  (informational)
+    """
+    inc_df = df[
+        (df["tx_type"] == _INCOME_TYPE)
+        & (df["amount"] > 0)
+        & (~df["reconciled"])
+    ]
+    exp_df = df[
+        (df["tx_type"] == _EXPENSE_TYPE)
+        & (~df["reconciled"])
+    ].copy()
+
+    total_income = float(inc_df["amount"].sum())
+    # Expense amounts are negative; we work with abs() for chart legibility.
+    exp_df["abs_amount"] = exp_df["amount"].abs()
+    total_expense = float(exp_df["abs_amount"].sum())
+
+    if total_income == 0.0 and total_expense == 0.0:
+        return None
+
+    # ── Node layout ──────────────────────────────────────────────────────────
+    income_label = _t("home.charts.income_total")
+    unknown_label = _t("home.charts.unknown")
+    uncat_cat_label = _t("home.charts.uncategorised")
+    uncat_sub_label = _t("home.charts.uncategorised_sub")
+
+    nodes: list[str] = [income_label]  # 0 = income source
+    node_idx: dict[str, int] = {income_label: 0}
+
+    def _node(label: str) -> int:
+        if label not in node_idx:
+            node_idx[label] = len(nodes)
+            nodes.append(label)
+        return node_idx[label]
+
+    link_source: list[int] = []
+    link_target: list[int] = []
+    link_value: list[float] = []
+
+    # Expense category aggregation (with "uncategorised" fallback).
+    exp_df["category"] = exp_df["category"].fillna(uncat_cat_label)
+    exp_df["subcategory"] = exp_df["subcategory"].fillna(uncat_sub_label)
+    cat_totals = exp_df.groupby("category")["abs_amount"].sum().to_dict()
+
+    # Link income → each expense category.
+    for cat, amount in cat_totals.items():
+        if amount <= 0:
+            continue
+        cat_idx = _node(f"{cat}")
+        link_source.append(0)
+        link_target.append(cat_idx)
+        link_value.append(amount)
+
+    # Link expense category → subcategory.
+    subcat_totals = (
+        exp_df.groupby(["category", "subcategory"])["abs_amount"].sum().reset_index()
+    )
+    for _, row in subcat_totals.iterrows():
+        amount = float(row["abs_amount"])
+        if amount <= 0:
+            continue
+        cat_idx = _node(f"{row['category']}")
+        sub_idx = _node(f"{row['subcategory']} ({row['category']})")
+        link_source.append(cat_idx)
+        link_target.append(sub_idx)
+        link_value.append(amount)
+
+    # ── Unknown node: surplus → target, deficit → source ────────────────────
+    delta = total_income - total_expense
+    if delta > 0:
+        # Surplus: income flows partly to Unknown.
+        unknown_idx = _node(unknown_label)
+        link_source.append(0)
+        link_target.append(unknown_idx)
+        link_value.append(delta)
+        unknown_kind = "surplus"
+    elif delta < 0:
+        # Deficit: Unknown supplies the missing budget.
+        unknown_idx = _node(unknown_label)
+        # Each category currently gets its abs amount from income (0). Re-balance:
+        # Unknown is an extra source; we model it as a separate flow that goes
+        # collectively to a virtual "expense pool". Simplest: Unknown → income_label
+        # is unsound; Sankey needs Unknown → each category for the deficit slice.
+        # We instead add a synthetic flow Unknown → income_label so the balance
+        # math reads cleanly (the total entering "income" equals total expenses).
+        link_source.append(unknown_idx)
+        link_target.append(0)
+        link_value.append(-delta)
+        unknown_kind = "deficit"
+    else:
+        unknown_kind = "parity"
+
+    return {
+        "nodes": nodes,
+        "link_source": link_source,
+        "link_target": link_target,
+        "link_value": link_value,
+        "unknown_kind": unknown_kind,
+    }
+
+
+def _render_sankey(data: dict) -> None:
+    import plotly.graph_objects as go
+
+    fig = go.Figure(
+        go.Sankey(
+            node=dict(
+                label=data["nodes"],
+                pad=14, thickness=18,
+            ),
+            link=dict(
+                source=data["link_source"],
+                target=data["link_target"],
+                value=data["link_value"],
+            ),
+        )
+    )
+    fig.update_layout(
+        title=_t("home.charts.sankey_title"),
+        height=520,
+        margin=dict(l=10, r=10, t=60, b=10),
+    )
+    st.plotly_chart(fig, use_container_width=True)
+
+
+# ── Entry point ──────────────────────────────────────────────────────────────
+
+def render_home_page(engine) -> None:
+    st.title(_t("home.title"))
+
+    if not TransactionService(engine).has_transactions():
+        _render_empty_state()
+        return
+
+    today = date.today()
+    since = _twelve_months_ago(today)
+    st.caption(_t("home.range_caption",
+                  date_from=since.strftime("%d/%m/%Y"),
+                  date_to=today.strftime("%d/%m/%Y")))
+    st.divider()
+
+    df = _load_transactions(engine, since=since)
+
+    if df.empty:
+        # has_transactions said True but the rolling window is empty (all old).
+        st.info(_t("home.charts.no_income"))
+        return
+
+    _render_income_stacked_bar(df)
+    sankey = _build_sankey_data(df)
+    if sankey is not None:
+        _render_sankey(sankey)

--- a/ui/i18n/de.json
+++ b/ui/i18n/de.json
@@ -837,5 +837,22 @@
   "onboarding.first_import.skip_help": "Landet auf der Startseite, du kannst jederzeit importieren",
   "onboarding.first_import.step_label": "Erster Import",
   "upload.empty_state.title": "📥 Noch keine Transaktionen",
-  "upload.empty_state.caption": "Lade unten deinen ersten Kontoauszug (CSV oder XLSX) hoch, um zu starten. Spendif.ai analysiert die Transaktionen und sortiert sie in die Kategorien, die du beim Setup gewählt hast."
+  "upload.empty_state.caption": "Lade unten deinen ersten Kontoauszug (CSV oder XLSX) hoch, um zu starten. Spendif.ai analysiert die Transaktionen und sortiert sie in die Kategorien, die du beim Setup gewählt hast.",
+  "nav.home": "🏠 Startseite",
+  "nav.home.desc": "Übersicht über Einnahmen, Ausgaben und Flüsse der letzten 12 Monate",
+  "home.title": "🏠 Spendif.ai — Startseite",
+  "home.subtitle": "Übersicht über Einnahmen, Ausgaben und Restbetrag",
+  "home.range_caption": "Letzte 12 Monate — vom {date_from} bis zum {date_to}",
+  "home.empty_state.message": "Wir warten auf deine Daten. Lade deine ersten Kontoauszüge auf der Import-Seite hoch.",
+  "home.empty_state.cta": "→ Zu Import",
+  "home.charts.income_title": "Einnahmen pro Monat",
+  "home.charts.sankey_title": "Fluss Einnahmen → Ausgaben",
+  "home.charts.month": "Monat",
+  "home.charts.amount": "Betrag (€)",
+  "home.charts.category": "Kategorie",
+  "home.charts.income_total": "Gesamteinnahmen",
+  "home.charts.unknown": "Unbekannt",
+  "home.charts.uncategorised": "Ohne Kategorie",
+  "home.charts.uncategorised_sub": "Ohne Unterkategorie",
+  "home.charts.no_income": "Keine klassifizierten Einnahmen zum Anzeigen"
 }

--- a/ui/i18n/en.json
+++ b/ui/i18n/en.json
@@ -837,5 +837,22 @@
   "onboarding.first_import.skip_help": "Lands on the Home, you can import any time",
   "onboarding.first_import.step_label": "First import",
   "upload.empty_state.title": "📥 No transactions yet",
-  "upload.empty_state.caption": "Upload your first bank statement (CSV or XLSX) below to get started. Spendif.ai will parse the transactions and sort them into the categories you picked during setup."
+  "upload.empty_state.caption": "Upload your first bank statement (CSV or XLSX) below to get started. Spendif.ai will parse the transactions and sort them into the categories you picked during setup.",
+  "nav.home": "🏠 Home",
+  "nav.home.desc": "Income, expenses and flow overview for the last 12 months",
+  "home.title": "🏠 Spendif.ai — Home",
+  "home.subtitle": "Income, expenses and remainder overview",
+  "home.range_caption": "Last 12 months — from {date_from} to {date_to}",
+  "home.empty_state.message": "Waiting for your data. Upload your first statements from the Import page.",
+  "home.empty_state.cta": "→ Go to Import",
+  "home.charts.income_title": "Income by month",
+  "home.charts.sankey_title": "Income → expense flow",
+  "home.charts.month": "Month",
+  "home.charts.amount": "Amount (€)",
+  "home.charts.category": "Category",
+  "home.charts.income_total": "Total income",
+  "home.charts.unknown": "Unknown",
+  "home.charts.uncategorised": "Uncategorised",
+  "home.charts.uncategorised_sub": "Uncategorised",
+  "home.charts.no_income": "No classified income to display"
 }

--- a/ui/i18n/es.json
+++ b/ui/i18n/es.json
@@ -837,5 +837,22 @@
   "onboarding.first_import.skip_help": "Aterriza en el Inicio, puedes importar en cualquier momento",
   "onboarding.first_import.step_label": "Primer import",
   "upload.empty_state.title": "📥 Sin transacciones importadas",
-  "upload.empty_state.caption": "Carga tu primer extracto bancario (CSV o XLSX) debajo para empezar. Spendif.ai analiza las transacciones y las organiza en las categorías que elegiste durante la configuración."
+  "upload.empty_state.caption": "Carga tu primer extracto bancario (CSV o XLSX) debajo para empezar. Spendif.ai analiza las transacciones y las organiza en las categorías que elegiste durante la configuración.",
+  "nav.home": "🏠 Inicio",
+  "nav.home.desc": "Resumen de ingresos, gastos y flujos de los últimos 12 meses",
+  "home.title": "🏠 Spendif.ai — Inicio",
+  "home.subtitle": "Resumen de ingresos, gastos y excedente",
+  "home.range_caption": "Últimos 12 meses — del {date_from} al {date_to}",
+  "home.empty_state.message": "Estamos esperando tus datos. Carga tus primeros extractos desde la página Importar.",
+  "home.empty_state.cta": "→ Ir a Importar",
+  "home.charts.income_title": "Ingresos por mes",
+  "home.charts.sankey_title": "Flujo ingresos → gastos",
+  "home.charts.month": "Mes",
+  "home.charts.amount": "Importe (€)",
+  "home.charts.category": "Categoría",
+  "home.charts.income_total": "Ingresos totales",
+  "home.charts.unknown": "Desconocido",
+  "home.charts.uncategorised": "Sin categoría",
+  "home.charts.uncategorised_sub": "Sin subcategoría",
+  "home.charts.no_income": "Sin ingresos clasificados para mostrar"
 }

--- a/ui/i18n/fr.json
+++ b/ui/i18n/fr.json
@@ -837,5 +837,22 @@
   "onboarding.first_import.skip_help": "Atterrit sur l'Accueil, vous pouvez importer à tout moment",
   "onboarding.first_import.step_label": "Premier import",
   "upload.empty_state.title": "📥 Aucune transaction importée",
-  "upload.empty_state.caption": "Chargez votre premier relevé bancaire (CSV ou XLSX) ci-dessous pour commencer. Spendif.ai analyse les transactions et les classe dans les catégories choisies lors de la configuration."
+  "upload.empty_state.caption": "Chargez votre premier relevé bancaire (CSV ou XLSX) ci-dessous pour commencer. Spendif.ai analyse les transactions et les classe dans les catégories choisies lors de la configuration.",
+  "nav.home": "🏠 Accueil",
+  "nav.home.desc": "Aperçu des revenus, dépenses et flux des 12 derniers mois",
+  "home.title": "🏠 Spendif.ai — Accueil",
+  "home.subtitle": "Aperçu des revenus, dépenses et solde restant",
+  "home.range_caption": "12 derniers mois — du {date_from} au {date_to}",
+  "home.empty_state.message": "Nous attendons vos données. Chargez vos premiers relevés depuis la page Import.",
+  "home.empty_state.cta": "→ Aller à Import",
+  "home.charts.income_title": "Revenus par mois",
+  "home.charts.sankey_title": "Flux revenus → dépenses",
+  "home.charts.month": "Mois",
+  "home.charts.amount": "Montant (€)",
+  "home.charts.category": "Catégorie",
+  "home.charts.income_total": "Revenus totaux",
+  "home.charts.unknown": "Inconnu",
+  "home.charts.uncategorised": "Sans catégorie",
+  "home.charts.uncategorised_sub": "Sans sous-catégorie",
+  "home.charts.no_income": "Aucun revenu classé à afficher"
 }

--- a/ui/i18n/it.json
+++ b/ui/i18n/it.json
@@ -837,5 +837,22 @@
   "onboarding.first_import.skip_help": "Atterra sulla Home, puoi importare in qualunque momento",
   "onboarding.first_import.step_label": "Primo import",
   "upload.empty_state.title": "📥 Nessuna transazione importata",
-  "upload.empty_state.caption": "Carica il tuo primo estratto bancario (CSV o XLSX) qui sotto per iniziare. Spendif.ai analizza le transazioni e le organizza nelle categorie che hai scelto durante il setup."
+  "upload.empty_state.caption": "Carica il tuo primo estratto bancario (CSV o XLSX) qui sotto per iniziare. Spendif.ai analizza le transazioni e le organizza nelle categorie che hai scelto durante il setup.",
+  "nav.home": "🏠 Home",
+  "nav.home.desc": "Riepilogo entrate, uscite e flussi degli ultimi 12 mesi",
+  "home.title": "🏠 Spendif.ai — Home",
+  "home.subtitle": "Riepilogo entrate, uscite e residuo",
+  "home.range_caption": "Ultimi 12 mesi — dal {date_from} al {date_to}",
+  "home.empty_state.message": "Stiamo aspettando i tuoi dati. Carica i primi estratti conto dalla pagina Import.",
+  "home.empty_state.cta": "→ Vai a Import",
+  "home.charts.income_title": "Entrate per mese",
+  "home.charts.sankey_title": "Flusso entrate → uscite",
+  "home.charts.month": "Mese",
+  "home.charts.amount": "Importo (€)",
+  "home.charts.category": "Categoria",
+  "home.charts.income_total": "Entrate totali",
+  "home.charts.unknown": "Sconosciuto",
+  "home.charts.uncategorised": "Senza categoria",
+  "home.charts.uncategorised_sub": "Senza sottocategoria",
+  "home.charts.no_income": "Nessuna entrata classificata da mostrare"
 }

--- a/ui/onboarding_page.py
+++ b/ui/onboarding_page.py
@@ -280,18 +280,22 @@ def _step0_language(cfg_svc: SettingsService, lang_options: list[tuple[str, str]
     # so the default onboarding stays a single visible question.
     _country_labels = _sorted_country_labels()
     _fallback_label = _country_label("IT")
-    _cur_country_label = st.session_state.get("_ob_country_select", _fallback_label)
-    if _cur_country_label not in _country_labels:
-        # Stale label from a previous language → reset to auto-suggestion.
-        _cur_country_label = _country_label(st.session_state[_K_COUNTRY])
-        st.session_state["_ob_country_select"] = _cur_country_label
+    # Source of truth for the selectbox: st.session_state["_ob_country_select"].
+    # We pre-seed it here when it's missing or stale (e.g. coming from a
+    # different language, so the cached label is no longer in the options
+    # list). Passing ONLY `key=` to st.selectbox below keeps Streamlit from
+    # warning "default value AND session_state value set at the same time".
+    _stored = st.session_state.get("_ob_country_select")
+    if _stored not in _country_labels:
+        st.session_state["_ob_country_select"] = _country_label(
+            st.session_state.get(_K_COUNTRY, "IT")
+        )
     _auto_country = _country_label(st.session_state[_K_COUNTRY])
     with st.expander(t("onboarding.step0.country_expander", country=_auto_country), expanded=False):
         st.caption(t("onboarding.step0.country_caption"))
         selected_country_label = st.selectbox(
             t("onboarding.step0.country"),
             _country_labels,
-            index=_country_labels.index(_cur_country_label),
             key="_ob_country_select",
             label_visibility="collapsed",
         )

--- a/ui/onboarding_page.py
+++ b/ui/onboarding_page.py
@@ -824,9 +824,10 @@ def _step6_first_import(cfg_svc: SettingsService, lang: str) -> None:
             key="_ob_fi_skip",
             help=t("onboarding.first_import.skip_help"),
         ):
-            # Home page does not exist yet — land on Import for now.
-            # Switch to "home" when the Home page is implemented.
-            _exit_onboarding(target_page="import")
+            # Home page exists now; "skip" lands the user there. Its empty
+            # state shows a CTA back to Import — coherent with the routing
+            # already managed by app.py's has_transactions() guard.
+            _exit_onboarding(target_page="home")
 
 
 def _persist_choices(

--- a/ui/onboarding_page.py
+++ b/ui/onboarding_page.py
@@ -563,7 +563,10 @@ def _step3_taxonomy(cfg_svc: SettingsService, lang: str) -> None:
                             label_visibility="collapsed",
                         )
                         sub["name"] = sc2.text_input(
-                            "",
+                            # Non-empty label hidden via label_visibility —
+                            # Streamlit warns ("disallowed in the future")
+                            # if the label is an empty string.
+                            t("taxonomy.rename_subcategory"),
                             value=sub["name"],
                             key=f"{key_prefix}_subname_{idx}_{s_idx}",
                             label_visibility="collapsed",

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -5,6 +5,7 @@ from ui.components.update_checker import render_update_warning
 
 # Navigation entries: (i18n_key_suffix, page_key)
 _NAV_KEYS = [
+    ("home",            "home"),
     ("import",          "import"),
     ("history",         "history"),
     ("ledger",          "ledger"),


### PR DESCRIPTION
## Summary

Implements the Home Dashboard spec ([AI-63 / 10_home_dashboard_spec.md](documents/04_software_engineering/10_home_dashboard_spec.md)). 

**Two charts on a rolling 12-month window:**

1. **Monthly-income stacked bar** — categories stacked. Filters: `tx_type='income'`, `amount > 0`, `reconciled = false`. `internal_in` (giroconti tra conti propri) **non** è reddito → escluso.
2. **Sankey flow** entrate → uscite categoria → sottocategoria, con un nodo **"Sconosciuto"** che:
   - in **surplus** (income > expense) raccoglie la differenza come target di flusso da Total Income
   - in **deficit** (expense > income) fornisce la differenza come source verso Total Income
   - in **parità** è omesso

## Routing

- `ui/sidebar.py`: `("home", "home")` come **prima** entry di `_NAV_KEYS`.
- `app.py`: route `if page == "home": …`.
- `ui/onboarding_page.py`: step 6 "Lo faccio dopo" ora → `page="home"` (era TODO inline da AI-66). L'empty-state in Home redirige a Import se non ci sono transazioni — coerente con il routing AI-70 che usa `has_transactions()` per il default page.

## Coupling

Il data loading è in `TransactionService.get_recent_for_home(since_iso)`. `ui/home_page.py` non importa nulla da `db/`. Local `tools/coupling_check.py --strict --json` → **0 violazioni**.

## i18n

17 nuove chiavi `nav.home.*` + `home.title/subtitle/range_caption/empty_state.*/charts.*` × 5 lingue (856 chiavi totali, parity invariata).

## Test plan

- [x] `tests/test_home_page.py` — 12 cases:
  - `_twelve_months_ago`: standard date, Feb-29 fallback.
  - `_load_transactions`: empty DB, rolling-12-months clamp, float cast.
  - `_build_sankey_data`: empty → None, income-only=surplus, surplus/deficit/parity branches, `internal_in` escluso, `reconciled` escluso.
- [x] Suite locale: 89/89 verde.
- [x] Coupling: 0 violazioni.
- [ ] CI ubuntu/macos/windows verde su Python 3.13.
- [ ] codecov/patch — coverage attesa ~75% (Streamlit-widget render branches non testati per policy progetto).

## Out of scope

- Drill-down al click su nodi/barre (Analytics resta il deep-dive).
- Filtri persona/conto/contesto (deep-dive su Analytics).
- KPI numerici sopra ai grafici (saldo, top category, MoM/YoY).
- Export charts.

Closes AI-63