### PR TITLE
feat(settings): expose DB info (kind, location, size) in the Settings page

### DIFF
--- a/services/settings_service.py
+++ b/services/settings_service.py
@@ -121,6 +121,62 @@ class SettingsService:
             s.commit()
             return count
 
+    # ── DB info ──────────────────────────────────────────────────────────────
+
+    def get_db_info(self) -> dict:
+        """Return a small dict describing where the app's data lives.
+
+        Used by the Settings page to give the user a clear answer to
+        "where is my data?" — file path for SQLite, host/port/db for a
+        hosted server. Passwords are never returned.
+
+        Keys returned:
+            dialect:       sqlalchemy dialect ('sqlite', 'postgresql', ...)
+            kind:          'file' | 'memory' | 'server'
+            display_label: human-friendly label, untranslated key suggestion
+            location:      file path (file) or 'host:port/db' (server)
+            file_size_mb:  float, only for kind='file' if the file exists
+            file_exists:   bool, only for kind='file'
+            user:          server user (no password), only for kind='server'
+        """
+        from pathlib import Path
+
+        url = self.engine.url
+        dialect = (url.get_dialect().name if hasattr(url, "get_dialect") else url.drivername or "").lower()
+        info: dict = {"dialect": dialect}
+
+        if dialect == "sqlite":
+            db_path = url.database or ""
+            if not db_path or db_path == ":memory:":
+                info.update({
+                    "kind": "memory",
+                    "display_label": "SQLite (in-memory)",
+                    "location": ":memory:",
+                })
+            else:
+                p = Path(db_path).expanduser().resolve()
+                info.update({
+                    "kind": "file",
+                    "display_label": "SQLite (local file)",
+                    "location": str(p),
+                    "file_exists": p.is_file(),
+                    "file_size_mb": (p.stat().st_size / (1024 * 1024)) if p.is_file() else 0.0,
+                })
+        else:
+            # Hosted DB (PostgreSQL, MySQL, MSSQL, …)
+            host = url.host or ""
+            port = url.port
+            db = url.database or ""
+            user = url.username or ""
+            loc = f"{host}{':' + str(port) if port else ''}/{db}" if host else db
+            info.update({
+                "kind": "server",
+                "display_label": f"{dialect.capitalize()} (hosted server)",
+                "location": loc,
+                "user": user,
+            })
+        return info
+
     # ── Bulk settings save ────────────────────────────────────────────────────
 
     def set_bulk(self, settings: dict[str, str]) -> None:

--- a/tests/test_service_settings.py
+++ b/tests/test_service_settings.py
@@ -196,3 +196,65 @@ def test_get_default_taxonomy_full_preview_includes_subcategories(svc):
         assert "category" in e0
         assert "subcategories" in e0
         assert isinstance(e0["subcategories"], list)
+
+
+# ── get_db_info ──────────────────────────────────────────────────────────────
+
+def test_get_db_info_sqlite_memory():
+    """In-memory SQLite reports kind='memory'."""
+    from sqlalchemy import create_engine
+    eng = create_engine("sqlite:///:memory:")
+    svc = SettingsService(eng)
+    info = svc.get_db_info()
+    assert info["dialect"] == "sqlite"
+    assert info["kind"] == "memory"
+    assert info["location"] == ":memory:"
+    assert info["display_label"].startswith("SQLite")
+
+
+def test_get_db_info_sqlite_file(tmp_path):
+    """File-based SQLite reports kind='file' with resolved path + size."""
+    from sqlalchemy import create_engine
+    db_path = tmp_path / "ledger.db"
+    eng = create_engine(f"sqlite:///{db_path}")
+    # Force file creation by running a no-op DDL
+    with eng.connect() as conn:
+        from sqlalchemy import text
+        conn.execute(text("CREATE TABLE _probe (id INTEGER)"))
+        conn.commit()
+    svc = SettingsService(eng)
+    info = svc.get_db_info()
+    assert info["kind"] == "file"
+    assert info["dialect"] == "sqlite"
+    assert info["location"].endswith("ledger.db")
+    assert info["file_exists"] is True
+    assert info["file_size_mb"] >= 0.0
+
+
+def test_get_db_info_sqlite_file_missing(tmp_path):
+    """Engine pointing to a non-existing file reports file_exists=False."""
+    from sqlalchemy import create_engine
+    db_path = tmp_path / "nope.db"
+    eng = create_engine(f"sqlite:///{db_path}")
+    svc = SettingsService(eng)
+    info = svc.get_db_info()
+    assert info["kind"] == "file"
+    assert info["file_exists"] is False
+    assert info["file_size_mb"] == 0.0
+
+
+def test_get_db_info_hosted_postgres_strips_password():
+    """A PostgreSQL URL reports kind='server' with host:port/db and user, no password."""
+    from sqlalchemy.engine.url import make_url
+    from unittest.mock import MagicMock
+    fake_engine = MagicMock()
+    fake_engine.url = make_url("postgresql://alice:supersecret@db.example.com:5432/finance")
+    svc = SettingsService(fake_engine)
+    info = svc.get_db_info()
+    assert info["kind"] == "server"
+    assert info["dialect"] == "postgresql"
+    assert info["location"] == "db.example.com:5432/finance"
+    assert info["user"] == "alice"
+    # Password must NOT leak anywhere
+    for v in info.values():
+        assert "supersecret" not in str(v)

--- a/ui/i18n/de.json
+++ b/ui/i18n/de.json
@@ -854,5 +854,13 @@
   "home.charts.unknown": "Unbekannt",
   "home.charts.uncategorised": "Ohne Kategorie",
   "home.charts.uncategorised_sub": "Ohne Unterkategorie",
-  "home.charts.no_income": "Keine klassifizierten Einnahmen zum Anzeigen"
+  "home.charts.no_income": "Keine klassifizierten Einnahmen zum Anzeigen",
+  "settings.db_info.title": "🗄️ Datenbank",
+  "settings.db_info.caption": "Wo deine Daten leben. Alle Transaktionen, Einstellungen und Regeln werden hier gespeichert.",
+  "settings.db_info.type": "Typ",
+  "settings.db_info.path": "Dateipfad",
+  "settings.db_info.address": "Serveradresse",
+  "settings.db_info.size": "Größe",
+  "settings.db_info.user": "Benutzer",
+  "settings.db_info.file_missing": "Datei fehlt — wird beim nächsten Start neu erstellt"
 }

--- a/ui/i18n/en.json
+++ b/ui/i18n/en.json
@@ -854,5 +854,13 @@
   "home.charts.unknown": "Unknown",
   "home.charts.uncategorised": "Uncategorised",
   "home.charts.uncategorised_sub": "Uncategorised",
-  "home.charts.no_income": "No classified income to display"
+  "home.charts.no_income": "No classified income to display",
+  "settings.db_info.title": "🗄️ Database",
+  "settings.db_info.caption": "Where your data lives. All transactions, settings and rules are stored here.",
+  "settings.db_info.type": "Type",
+  "settings.db_info.path": "File path",
+  "settings.db_info.address": "Server address",
+  "settings.db_info.size": "Size",
+  "settings.db_info.user": "User",
+  "settings.db_info.file_missing": "File missing — will be recreated on next launch"
 }

--- a/ui/i18n/es.json
+++ b/ui/i18n/es.json
@@ -854,5 +854,13 @@
   "home.charts.unknown": "Desconocido",
   "home.charts.uncategorised": "Sin categoría",
   "home.charts.uncategorised_sub": "Sin subcategoría",
-  "home.charts.no_income": "Sin ingresos clasificados para mostrar"
+  "home.charts.no_income": "Sin ingresos clasificados para mostrar",
+  "settings.db_info.title": "🗄️ Base de datos",
+  "settings.db_info.caption": "Donde viven tus datos. Todas las transacciones, ajustes y reglas se guardan aquí.",
+  "settings.db_info.type": "Tipo",
+  "settings.db_info.path": "Ruta del archivo",
+  "settings.db_info.address": "Dirección del servidor",
+  "settings.db_info.size": "Tamaño",
+  "settings.db_info.user": "Usuario",
+  "settings.db_info.file_missing": "Archivo no encontrado — se recreará en el próximo arranque"
 }

--- a/ui/i18n/fr.json
+++ b/ui/i18n/fr.json
@@ -854,5 +854,13 @@
   "home.charts.unknown": "Inconnu",
   "home.charts.uncategorised": "Sans catégorie",
   "home.charts.uncategorised_sub": "Sans sous-catégorie",
-  "home.charts.no_income": "Aucun revenu classé à afficher"
+  "home.charts.no_income": "Aucun revenu classé à afficher",
+  "settings.db_info.title": "🗄️ Base de données",
+  "settings.db_info.caption": "Où vivent vos données. Toutes les transactions, paramètres et règles sont stockés ici.",
+  "settings.db_info.type": "Type",
+  "settings.db_info.path": "Chemin du fichier",
+  "settings.db_info.address": "Adresse du serveur",
+  "settings.db_info.size": "Taille",
+  "settings.db_info.user": "Utilisateur",
+  "settings.db_info.file_missing": "Fichier introuvable — sera recréé au prochain lancement"
 }

--- a/ui/i18n/it.json
+++ b/ui/i18n/it.json
@@ -854,5 +854,13 @@
   "home.charts.unknown": "Sconosciuto",
   "home.charts.uncategorised": "Senza categoria",
   "home.charts.uncategorised_sub": "Senza sottocategoria",
-  "home.charts.no_income": "Nessuna entrata classificata da mostrare"
+  "home.charts.no_income": "Nessuna entrata classificata da mostrare",
+  "settings.db_info.title": "🗄️ Database",
+  "settings.db_info.caption": "Dove vivono i tuoi dati. Tutte le transazioni, le impostazioni e le regole sono salvate qui.",
+  "settings.db_info.type": "Tipo",
+  "settings.db_info.path": "Percorso file",
+  "settings.db_info.address": "Indirizzo server",
+  "settings.db_info.size": "Dimensione",
+  "settings.db_info.user": "Utente",
+  "settings.db_info.file_missing": "File non trovato — verrà ricreato al prossimo avvio"
 }

--- a/ui/settings_page.py
+++ b/ui/settings_page.py
@@ -534,6 +534,43 @@ def render_settings_page(engine):
 
     st.divider()
 
+    # ── Database info ─────────────────────────────────────────────────────────
+    st.subheader(t("settings.db_info.title"))
+    st.caption(t("settings.db_info.caption"))
+    _db_info = cfg_svc.get_db_info()
+    _info_col_a, _info_col_b = st.columns([1, 2], vertical_alignment="center")
+    with _info_col_a:
+        st.markdown(f"**{t('settings.db_info.type')}**")
+    with _info_col_b:
+        st.markdown(_db_info["display_label"])
+    _info_col_a, _info_col_b = st.columns([1, 2], vertical_alignment="center")
+    with _info_col_a:
+        _location_label = (
+            t("settings.db_info.path") if _db_info["kind"] == "file" else t("settings.db_info.address")
+        )
+        st.markdown(f"**{_location_label}**")
+    with _info_col_b:
+        # Use code formatting so long paths / connection strings stay
+        # readable on narrow viewports and the user can click-copy.
+        st.code(_db_info["location"], language=None)
+    if _db_info["kind"] == "file":
+        _info_col_a, _info_col_b = st.columns([1, 2], vertical_alignment="center")
+        with _info_col_a:
+            st.markdown(f"**{t('settings.db_info.size')}**")
+        with _info_col_b:
+            if _db_info.get("file_exists"):
+                st.markdown(f"{_db_info['file_size_mb']:.1f} MB")
+            else:
+                st.markdown(f"⚠️ {t('settings.db_info.file_missing')}")
+    elif _db_info["kind"] == "server" and _db_info.get("user"):
+        _info_col_a, _info_col_b = st.columns([1, 2], vertical_alignment="center")
+        with _info_col_a:
+            st.markdown(f"**{t('settings.db_info.user')}**")
+        with _info_col_b:
+            st.markdown(_db_info["user"])
+
+    st.divider()
+
     # ── Schema cache ──────────────────────────────────────────────────────────
     st.subheader(t("settings.schema_cache_title"))
     st.caption(t("settings.schema_cache_caption"))


### PR DESCRIPTION
## Summary

Show the user where the app's data actually lives, right in the Settings page. No more guessing whether the DMG bundle wrote `~/.spendifai/ledger.db`, used an in-memory DB by mistake or — once the hosted-LLM redaction work lands — is pointing at a remote PostgreSQL.

## What changed

### Backend

`SettingsService.get_db_info()` parses `engine.url` and returns:

| Key | Always | For `file` | For `server` |
|---|---|---|---|
| `dialect` | ✓ | | |
| `kind` (`file` / `memory` / `server`) | ✓ | | |
| `display_label` (e.g. "SQLite (local file)") | ✓ | | |
| `location` (path or `host:port/database`) | ✓ | | |
| `file_exists` | | ✓ | |
| `file_size_mb` | | ✓ | |
| `user` (connection user, no password) | | | ✓ |

**Passwords never leak.** A dedicated test feeds `postgresql://alice:supersecret@…` and asserts the secret is absent from every returned value.

### UI

New `🗄️ Database` block in `ui/settings_page.py`, placed right above Schema cache. Three or four `vertical_alignment="center"` rows for type / location / size or user; the location uses `st.code(...)` so long paths and connection strings stay readable on narrow viewports and can be click-copied. A missing file is flagged with ⚠️ and "will be recreated on next launch".

### i18n

8 new keys (`settings.db_info.{title,caption,type,path,address,size,user,file_missing}`) × 5 languages → 864 total, parity preserved.

### Tests

4 new cases in `tests/test_service_settings.py`:

- SQLite in-memory → `kind="memory"`, location `:memory:`
- SQLite file (creates the file via DDL) → `kind="file"`, size > 0
- SQLite file missing → `file_exists=False`, size 0.0
- PostgreSQL hosted → `kind="server"`, `host:port/db`, user surfaces, **password redaction guard**

Local suite: 84/84 green. `coupling_check --strict` reports 0 violations.

## Test plan

- [x] `pytest tests/test_service_settings.py` (4 new + existing) — green
- [x] Coupling check — 0 violations
- [ ] CI ubuntu / macos / windows on Python 3.13 — green
- [ ] Manual smoke: open Settings, scroll to "Database", verify the location is shown correctly for the current install