### PR TITLE
fix(llm): translate llama_decode return codes into actionable user messages

### DIFF
--- a/core/llm_backends.py
+++ b/core/llm_backends.py
@@ -1004,10 +1004,10 @@ class LlamaCppBackend(LLMBackend):
             n_available = n_ctx - n_input
             if n_available < _MIN_OUTPUT_TOKENS:
                 raise LLMValidationError(
-                    f"LlamaCppBackend: prompt troppo lungo ({n_input} token) per "
-                    f"context window ({n_ctx}). Disponibili solo {n_available} token "
-                    f"per l'output (minimo {_MIN_OUTPUT_TOKENS}). "
-                    f"Ridurre batch_size o aumentare n_ctx."
+                    f"LlamaCppBackend: prompt too long ({n_input} tokens) for "
+                    f"the current context window ({n_ctx}). Only {n_available} tokens "
+                    f"left for the output (minimum {_MIN_OUTPUT_TOKENS}). "
+                    f"Reduce batch_size or increase n_ctx in LLM Settings."
                 )
             effective_max_tokens = min(_MAX_TOKENS_DEFAULT, n_available)
 
@@ -1034,12 +1034,35 @@ class LlamaCppBackend(LLMBackend):
         except (json.JSONDecodeError, KeyError, TypeError) as exc:
             raise LLMValidationError(f"LlamaCppBackend error: {exc}") from exc
         except Exception as exc:
-            # Catch llama_cpp runtime errors (OOM, model errors, etc.)
+            # Catch llama_cpp runtime errors (OOM, decode errors, ...) and
+            # surface an actionable message — the bare repr leaks
+            # implementation details ("llama_decode returned -3") that mean
+            # nothing to the user.
             error_msg = str(exc)
-            if "out of memory" in error_msg.lower() or "oom" in error_msg.lower():
+            lower = error_msg.lower()
+            if "out of memory" in lower or "oom" in lower:
                 raise LLMValidationError(
-                    f"LlamaCppBackend: memoria insufficiente. "
-                    f"Prova un modello più piccolo o riduci n_ctx. Dettaglio: {exc}"
+                    f"LlamaCppBackend: not enough memory. Try a smaller model or "
+                    f"lower n_ctx in LLM Settings. Detail: {exc}"
+                ) from exc
+            # llama.cpp returns the integer status from llama_decode().
+            # `-3` is documented as "context full / KV cache overflow":
+            # the prompt plus the planned output exceed n_ctx.
+            #     https://github.com/ggerganov/llama.cpp/blob/master/include/llama.h
+            if "llama_decode" in lower and "-3" in error_msg:
+                raise LLMValidationError(
+                    f"LlamaCppBackend: KV cache overflow — the prompt exceeded "
+                    f"the current context window ({self._llm.n_ctx()} tokens). "
+                    f"Increase n_ctx in LLM Settings, or pick a model with a "
+                    f"larger context window. Detail: {exc}"
+                ) from exc
+            # `-2` is the generic decode failure (often follow-up to OOM or
+            # malformed grammar). Surface it with a hint so the user knows
+            # it's recoverable by retrying / reducing input.
+            if "llama_decode" in lower and "-2" in error_msg:
+                raise LLMValidationError(
+                    f"LlamaCppBackend: decode failed (input/grammar issue). "
+                    f"Try a shorter prompt or a different model. Detail: {exc}"
                 ) from exc
             raise LLMValidationError(f"LlamaCppBackend error: {exc}") from exc
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -73,3 +73,114 @@ class TestOllamaBackend:
         with patch.object(b._requests, "post", return_value=mock_resp):
             with pytest.raises(LLMValidationError):
                 b.complete_structured("sys", "user", {})
+
+
+class TestLlamaCppErrorTranslation:
+    """The LlamaCppBackend's `except Exception` must turn raw llama.cpp
+    return codes into actionable user-facing messages — the bare
+    `llama_decode returned -3` leaks implementation details and gives
+    the user no clue what to do next."""
+
+    def _make_backend_stub(self, n_ctx_value: int = 4096):
+        """Build a LlamaCppBackend instance without loading a real model.
+
+        We monkey-patch __init__ so we can attach a fake `self._llm` that
+        only needs `tokenize`, `n_ctx`, `create_completion`."""
+        from core.llm_backends import LlamaCppBackend
+        from unittest.mock import MagicMock
+
+        backend = LlamaCppBackend.__new__(LlamaCppBackend)
+        backend._model_path = "/tmp/fake.gguf"
+        backend._llm = MagicMock()
+        backend._llm.tokenize = lambda b: [0] * 100  # 100 input tokens
+        backend._llm.n_ctx = lambda: n_ctx_value
+        backend._set_usage = lambda *a, **kw: None
+        return backend
+
+    def test_llama_decode_minus_3_becomes_kv_overflow_message(self):
+        """The -3 return code is mapped to a KV-cache-overflow message."""
+        from core.llm_backends import LlamaCppBackend, LLMValidationError
+        import pytest
+
+        backend = self._make_backend_stub(n_ctx_value=4096)
+        # Simulate the llama-cpp-python error
+        def _boom(**_kwargs):
+            raise RuntimeError("llama_decode returned -3")
+        backend._llm.create_completion = _boom
+
+        # Stub the prompt rendering to keep this test independent of
+        # the (large) chat-template machinery.
+        backend._render_prompt = lambda *a, **kw: "x"
+
+        with pytest.raises(LLMValidationError) as ei:
+            backend.complete_structured(
+                system_prompt="sys", user_prompt="usr",
+                json_schema={"type": "object", "properties": {}, "required": []},
+            )
+        msg = str(ei.value).lower()
+        assert "kv cache" in msg, msg
+        assert "context window" in msg, msg
+        assert "4096" in str(ei.value), "the current n_ctx should be surfaced"
+        # The original llama_decode text is kept in the Detail tail.
+        assert "llama_decode returned -3" in str(ei.value)
+
+    def test_llama_decode_minus_2_becomes_decode_failed_message(self):
+        """The -2 return code is mapped to a generic decode-failure message
+        with a hint to retry/shorten the prompt."""
+        from core.llm_backends import LlamaCppBackend, LLMValidationError
+        import pytest
+
+        backend = self._make_backend_stub()
+        def _boom(**_kwargs):
+            raise RuntimeError("llama_decode returned -2")
+        backend._llm.create_completion = _boom
+        backend._render_prompt = lambda *a, **kw: "x"
+
+        with pytest.raises(LLMValidationError) as ei:
+            backend.complete_structured(
+                system_prompt="sys", user_prompt="usr",
+                json_schema={"type": "object", "properties": {}, "required": []},
+            )
+        msg = str(ei.value).lower()
+        assert "decode failed" in msg, msg
+        assert "shorter prompt" in msg or "different model" in msg, msg
+
+    def test_oom_message_in_english(self):
+        """The OOM branch was previously in Italian; verify the new
+        English copy reaches the user."""
+        from core.llm_backends import LlamaCppBackend, LLMValidationError
+        import pytest
+
+        backend = self._make_backend_stub()
+        def _boom(**_kwargs):
+            raise RuntimeError("ggml_metal_graph_compute: command buffer 0 failed with status 5 - Out of memory")
+        backend._llm.create_completion = _boom
+        backend._render_prompt = lambda *a, **kw: "x"
+
+        with pytest.raises(LLMValidationError) as ei:
+            backend.complete_structured(
+                system_prompt="sys", user_prompt="usr",
+                json_schema={"type": "object", "properties": {}, "required": []},
+            )
+        msg = str(ei.value).lower()
+        assert "not enough memory" in msg, msg
+        assert "smaller model" in msg or "lower n_ctx" in msg, msg
+
+    def test_unknown_runtime_error_still_wrapped(self):
+        """A runtime error that doesn't match any known pattern must still
+        be wrapped in LLMValidationError (not propagate as RuntimeError)."""
+        from core.llm_backends import LlamaCppBackend, LLMValidationError
+        import pytest
+
+        backend = self._make_backend_stub()
+        def _boom(**_kwargs):
+            raise RuntimeError("model file corrupted")
+        backend._llm.create_completion = _boom
+        backend._render_prompt = lambda *a, **kw: "x"
+
+        with pytest.raises(LLMValidationError) as ei:
+            backend.complete_structured(
+                system_prompt="sys", user_prompt="usr",
+                json_schema={"type": "object", "properties": {}, "required": []},
+            )
+        assert "model file corrupted" in str(ei.value)


### PR DESCRIPTION
## Summary

User report from Settings → "Test LLM" on the categorizer: the call failed with

```
LlamaCppBackend error: llama_decode returned -3
```

`-3` is documented in `llama.h` as KV cache overflow — the prompt plus the planned output exceeded `n_ctx`. Spendif.ai caps n_ctx at `16 384` by default (`DEFAULT_N_CTX_CAP`) for memory safety even on models with a larger native context window (Gemma-12B = 32 K, Qwen-3.5 = 128 K), so a rich-taxonomy test prompt can hit the ceiling.

The bare error leaks implementation details and gives the user no hint what to do next.

## Fix

In `core/llm_backends.py:LlamaCppBackend.complete_structured`:

- New branch in `except Exception` for `"llama_decode returned -3"` → **"KV cache overflow — the prompt exceeded the current context window (N tokens). Increase n_ctx in LLM Settings or pick a model with a larger context window."** Includes the current `n_ctx()` value.
- New branch for `"llama_decode returned -2"` (generic decode failure) → suggests a shorter prompt or a different model.
- Pre-existing OOM and "max_tokens < 0" messages were in Italian; both rewritten in English to honour the Repository-English-only rule from `SW_ENGINEERING_BLUEPRINT §11`.

## What this does NOT change

- The default n_ctx cap (`DEFAULT_N_CTX_CAP = 16 384`) is **not** lifted. KV cache scales linearly with context length, and pushing the cap to the model's native max breaks 16 GB Macs running Gemma-12B Q4. The "raise the cap" trade-off is tracked as potential future work.
- The categorizer cascade (NSI / history / LLM) is unchanged. This PR is observability-only.

## Test plan

- [x] 4 new cases in `tests/test_backends.py::TestLlamaCppErrorTranslation` cover `-3`, `-2`, OOM and the catch-all branch, using a `MagicMock` `self._llm` so no real model is loaded.
- [x] Suite locally: 77/77 green.
- [x] `coupling_check --strict` → 0 violations.
- [ ] CI ubuntu / macos / windows on Python 3.13.
- [ ] Manual smoke: trigger Test LLM with a model whose `n_ctx` is artificially low to provoke `-3` → user sees the new message.

Closes AI-87