### PR TITLE
fix(deps): bump starlette 1.0.0 → 1.1.0 (PYSEC-2026-161)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2221,15 +2221,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Unblocks CI on main by bumping `starlette` past the vulnerable 1.0.0.

- **CVE**: PYSEC-2026-161 — fix available in starlette 1.0.1+
- **Resolved version**: 1.1.0 (latest compatible with fastapi + streamlit pins)
- **Affected layers**: none functional. `starlette` is transitive (fastapi + streamlit), not directly imported in our code.
- **Scope**: only `uv.lock`, 3 lines.

Reference: failed run [26328275525](https://github.com/drake69/spendify/actions/runs/26328275525) on main (commit 75e5df0). `pip-audit` step exit code 1 on `starlette 1.0.0 / PYSEC-2026-161 / Fix Versions 1.0.1`.

## Test plan

- [ ] CI green on this PR (pip-audit unblocked, all other gates already passing)
- [ ] No transitive dependency surprises (verified: `git diff uv.lock` touches only the `starlette` block, 3 lines changed)
- [ ] Smoke test locally: `uv sync` succeeds and `uv run pytest -x` stays green