### PR TITLE
AI-149 deterministic sign-detection + AI-193 pipeline Debugger

### DIFF
--- a/app.py
+++ b/app.py
@@ -53,6 +53,11 @@ if _prompt_errors:
 DB_URL = os.getenv("SPENDIFAI_DB", "sqlite:///ledger.db")
 engine = create_tables(get_engine(DB_URL))
 
+# ── Dev mode (AI-193) ─────────────────────────────────────────────────────────
+# When SPENDIFAI_DEV_MODE=1 the developer-only pages (e.g. the pipeline
+# Debugger) become reachable. Never set in production builds.
+_DEV_MODE = os.getenv("SPENDIFAI_DEV_MODE") == "1"
+
 # ── Startup cleanup ───────────────────────────────────────────────────────────
 if "stale_jobs_reset" not in st.session_state:
     st.session_state["stale_jobs_reset"] = True
@@ -223,3 +228,7 @@ elif page == "checklist":
 elif page == "chat":
     from ui.chat_page import render_chat_page
     render_chat_page(engine)
+
+elif _DEV_MODE and page == "debugger":
+    from ui.debugger_page import render_debugger_page
+    render_debugger_page(engine)

--- a/benchmark/accuracy_groups.py
+++ b/benchmark/accuracy_groups.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 # Ordine: dal più recente al più vecchio.
 # (group_id, boundary_commit, descrizione)
 ACCURACY_GROUPS = [
+    ("G7", "a3639f7", "deterministic sign-detection by account-type (AI-149/AI-197)"),
     ("G6", "b3947a7", "real taxonomy_map + fix SyntheticHistoryCache"),
     ("G5", "c4a6768", "static rules JSON + NSI lookup"),
     ("G4", "4e912f8", "cleaner dedup + indexed batch"),
@@ -29,6 +30,15 @@ ACCURACY_GROUPS = [
 # Commit espliciti per ogni gruppo (short hash 7 char).
 # Commit non elencati → G0 (fallback).
 _GROUP_COMMITS: dict[str, str] = {}
+
+# G7 — AI-197: sign-detection deterministica per tipo conto (classifier+normalizer).
+# I commit precedenti del branch (debugger AI-193, chore .env) NON cambiano
+# l'accuratezza (UI/orchestrator/echo) → restano in G6.
+for _c in ["a3639f7"]:
+    _GROUP_COMMITS[_c] = "G7"
+
+for _c in ["2222109", "4921ae3"]:
+    _GROUP_COMMITS[_c] = "G6"
 
 for _c in [
     "0c1f61b", "a7a7990", "unknown", "7b6803f", "87aed75", "3373100", "0861ffe", "4160e64", "153de35", "acb405c", "d48ea72", "c3ca822", "084bdfb", "78ec3e8", "164bcac", "6eaba1f", "4bca4b4", "c3630c5",

--- a/benchmark/run_benchmark_full.sh
+++ b/benchmark/run_benchmark_full.sh
@@ -474,8 +474,11 @@ USE_LLAMA=false
 USE_OLLAMA=false
 USE_VLLM=false
 USE_VLLM_OFFLINE=false
-# --skip-llama skips only the install/download step, not the backend itself
-compgen -G "$MODELS_DIR"/*.gguf >/dev/null 2>&1 && USE_LLAMA=true
+# --skip-llama skips only the install/download step, not the backend itself.
+# Missing GGUF are fetched just-in-time in the run loop (step 4), so enable
+# llama.cpp whenever it isn't skipped — do NOT require models to pre-exist
+# (that aborted with "No active backends" on a fresh machine).
+[ "$SKIP_LLAMA" = false ] && USE_LLAMA=true
 [ "$SKIP_OLLAMA" = false ] && USE_OLLAMA=true
 [ "$SKIP_VLLM" = false ] && [ -n "$VLLM_MODEL" ] && USE_VLLM=true
 [ "$SKIP_VLLM_OFFLINE" = false ] && [ "$VLLM_OFFLINE_MODELS_COUNT" -gt 0 ] && USE_VLLM_OFFLINE=true

--- a/benchmark/run_benchmark_full.sh
+++ b/benchmark/run_benchmark_full.sh
@@ -358,7 +358,11 @@ PYEOF
 
     # No bulk download — models are downloaded just-in-time in the run loop (step 4).
     # This avoids saturating disk on machines with limited space.
-    GGUF_TOTAL=$(ls -1 "$MODELS_DIR"/*.gguf 2>/dev/null | wc -l | tr -d ' ')
+    # On a fresh machine MODELS_DIR may not exist and the glob matches nothing;
+    # guard so `set -euo pipefail` doesn't abort the whole run (the failing ls
+    # exits 2 → script died at step 3a before any model could be fetched).
+    mkdir -p "$MODELS_DIR"
+    GGUF_TOTAL=$( (ls -1 "$MODELS_DIR"/*.gguf 2>/dev/null || true) | wc -l | tr -d ' ')
     echo "[ok] $GGUF_TOTAL GGUF models already in $MODELS_DIR (others will be downloaded on demand)"
 else
     echo ""

--- a/core/classifier.py
+++ b/core/classifier.py
@@ -519,6 +519,12 @@ def classify_document(
     # Safety net: re-enforce invert_sign after merge (catches any LLM re-override).
     result = _apply_step0_invert_sign(result, source_name, account_type=account_type)
 
+    # AI-149: deterministic sign decision driven by the account-type prior.
+    # On single-amount-column files this OVERRIDES the LLM's sign_convention/
+    # invert_sign/ratios — the direction of the sign is an accounting fact, not
+    # a semantic guess. See documents/04_software_engineering/07_deterministic_pipeline.md.
+    result = _apply_account_type_sign_prior(result, df_raw, source_name, account_type=account_type)
+
     # Compute deterministic confidence score from merged result
     score = compute_confidence_score(result, header_certain=header_certain)
     result["confidence_score"] = score
@@ -1266,6 +1272,107 @@ def _apply_step0_invert_sign(
         )
         out["invert_sign"] = True
 
+    return out
+
+
+# ── AI-149: deterministic sign decision by account-type prior ───────────────────
+# Each account type carries a prior on the DOMINANT transaction direction, hence
+# the canonical sign that the dominant transactions should have (internal canon:
+# income positive, expenses negative).
+#   ⚠️ DRAFT — table reviewed jointly (see 07_deterministic_pipeline.md). `cash`
+#   and `bank_account` behaviour still to be re-validated.
+_EXPENSE_DOMINANT_TYPES = frozenset({"credit_card", "debit_card", "prepaid_card", "cash"})
+_INCOME_DOMINANT_TYPES = frozenset({"savings_account"})
+# bank_account → mixed → no prior (existing logic stays).
+
+
+def _expected_dominant_sign(type_str: str) -> int | None:
+    """+1 if dominant tx should be positive (income-dominant), -1 if negative
+    (expense-dominant), None when the type carries no reliable prior."""
+    t = (type_str or "").lower()
+    if t in _EXPENSE_DOMINANT_TYPES:
+        return -1
+    if t in _INCOME_DOMINANT_TYPES:
+        return +1
+    return None
+
+
+def _ordered_nonzero_amounts(df, amount_col: str) -> list[float]:
+    """Parse the amount column to signed floats in row order, dropping
+    unparseable and zero cells. Mirrors _inspect_neutral_column_sign parsing."""
+    if amount_col not in df.columns:
+        return []
+    vals = pd.to_numeric(
+        df[amount_col].astype(str)
+                      .str.replace(r"[€$£\s]", "", regex=True)
+                      .str.replace(",", ".", regex=False),
+        errors="coerce",
+    )
+    return [float(v) for v in vals.tolist() if pd.notna(v) and float(v) != 0.0]
+
+
+def _apply_account_type_sign_prior(
+    result: dict, df_raw, source_name: str, account_type: str | None = None
+) -> dict:
+    """Deterministic sign decision for SINGLE-amount-column files (AI-149).
+
+    Forces signed_single (S3), computes positive/negative ratios in Python (S2),
+    and decides invert_sign from the account-type prior + measured majority (S1)
+    or, with ≤2 movements / a tie, from the first non-zero tx (S0 — single billing
+    cycle; the last tx is only a coherence check). Bank accounts (no prior) keep
+    the existing logic.
+    """
+    out = dict(result)
+    amount_col = out.get("amount_col")
+    debit_col = out.get("debit_col")
+    credit_col = out.get("credit_col")
+
+    # Only single-amount-column layouts. Debit/credit two-column files are
+    # structural and handled upstream (Step 0.6).
+    if not amount_col or debit_col or credit_col:
+        return out
+
+    # S3 — single column ⇒ signed_single, never debit_positive/credit_negative.
+    if str(out.get("sign_convention", "")).lower() != "signed_single":
+        logger.info(
+            f"classify_document [{source_name}]: single amount column → "
+            f"forcing sign_convention=signed_single (was {out.get('sign_convention')})"
+        )
+        out["sign_convention"] = "signed_single"
+
+    # S2 — deterministic ratios from the data (also used for S0 first/last).
+    signed = _ordered_nonzero_amounts(df_raw, amount_col)
+    n = len(signed)
+    if n == 0:
+        return out
+    n_pos = sum(1 for v in signed if v > 0)
+    n_neg = n - n_pos
+    out["positive_ratio"] = round(n_pos / n, 4)
+    out["negative_ratio"] = round(n_neg / n, 4)
+
+    # Prior: user declaration (account_type) wins, else detected doc_type.
+    expected = _expected_dominant_sign(account_type) if account_type else None
+    if expected is None:
+        expected = _expected_dominant_sign(out.get("doc_type", ""))
+    if expected is None:
+        # No prior (bank_account/unknown) → leave invert_sign as decided upstream.
+        return out
+
+    # S1 (majority) when the sample is meaningful, else S0 (single-cycle guard).
+    if n >= 3 and n_pos != n_neg:
+        measured = +1 if n_pos > n_neg else -1
+        basis = "S1-majority"
+    else:
+        measured = +1 if signed[0] > 0 else -1   # first non-zero tx
+        basis = "S0-single-cycle"
+
+    out["invert_sign"] = (measured != expected)
+    logger.info(
+        f"classify_document [{source_name}]: sign prior [{basis}] "
+        f"type={account_type or out.get('doc_type')} n_pos={n_pos} n_neg={n_neg} "
+        f"measured={'+' if measured > 0 else '-'} expected={'+' if expected > 0 else '-'} "
+        f"→ invert_sign={out['invert_sign']} (ratios {out['positive_ratio']}/{out['negative_ratio']})"
+    )
     return out
 
 

--- a/core/normalizer.py
+++ b/core/normalizer.py
@@ -632,7 +632,10 @@ def apply_sign_convention(
     elif convention == SignConvention.debit_positive:
         debit = parse_amount(row.get(debit_col)) if debit_col else None
         credit = parse_amount(row.get(credit_col)) if credit_col else None
-        # If neither column parsed, fall back to amount_col (schema may have mismapped)
+        # S4 (AI-149): no debit/credit columns → this is really a single signed
+        # column. Return the amount as-is (signed_single semantics); invert_sign is
+        # applied separately by the caller. The classifier now forces signed_single
+        # in this case (S3), so reaching here means a stale/mismapped schema.
         if debit is None and credit is None:
             return parse_amount(row.get(amount_col)) if amount_col else None
         # Use abs() so the result is correct whether the bank stores values as

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -72,6 +72,53 @@ from support.logging import setup_logging
 logger = setup_logging()
 
 
+class _RecordingBackend:
+    """Transparent proxy around an LLMBackend that records every
+    ``complete_structured()`` call (prompt + raw response) into a shared sink.
+
+    Used only by the dev Debugger page (AI-193) to surface the raw LLM I/O of
+    each pipeline phase in clear. In production ``llm_trace`` is ``None`` and no
+    wrapping happens, so this has zero impact on normal imports.
+    """
+
+    def __init__(self, inner, phase: str, sink: list):
+        object.__setattr__(self, "_inner", inner)
+        object.__setattr__(self, "_phase", phase)
+        object.__setattr__(self, "_sink", sink)
+
+    def complete_structured(self, system_prompt, user_prompt, json_schema, temperature=0.0):
+        import time as _t
+        inner = object.__getattribute__(self, "_inner")
+        phase = object.__getattribute__(self, "_phase")
+        sink = object.__getattribute__(self, "_sink")
+        t0 = _t.monotonic()
+        result = None
+        error = None
+        try:
+            result = inner.complete_structured(system_prompt, user_prompt, json_schema, temperature)
+            return result
+        except Exception as exc:  # record then re-raise unchanged
+            error = repr(exc)
+            raise
+        finally:
+            sink.append({
+                "phase": phase,
+                "backend": getattr(inner, "name", "?"),
+                "model": getattr(inner, "model_id", ""),
+                "system_prompt": system_prompt,
+                "user_prompt": user_prompt,
+                "json_schema": json_schema,
+                "response": result,
+                "error": error,
+                "duration_ms": int((_t.monotonic() - t0) * 1000),
+            })
+
+    def __getattr__(self, name):
+        # Delegate everything else (name, model_id, is_remote, get_context_info,
+        # model_size_bytes, last_usage, …) to the wrapped backend.
+        return getattr(object.__getattribute__(self, "_inner"), name)
+
+
 @dataclass
 class ProcessingConfig:
     llm_backend: str = "local_llama_cpp"
@@ -597,8 +644,11 @@ def _normalize_df_with_schema(
         raw_date_acc = row.get(schema.date_accounting_col, "") if schema.date_accounting_col else None
         tx_date_acc = parse_date_safe(str(raw_date_acc), schema.date_format) if raw_date_acc else None
 
-        # Capture raw amount string(s) before parsing — used for the dedup hash
-        if schema.sign_convention in (SignConvention.debit_positive, SignConvention.credit_negative):
+        # Capture raw amount string(s) before parsing — used for the dedup hash.
+        # S4 (AI-149): branch on the ACTUAL presence of debit/credit columns, not
+        # on sign_convention. A single-amount-column file must echo amount_col,
+        # never the "<debit>|<credit>" form (which produced a bare "|").
+        if schema.debit_col or schema.credit_col:
             _d = str(row.get(schema.debit_col, "")) if schema.debit_col else ""
             _c = str(row.get(schema.credit_col, "")) if schema.credit_col else ""
             raw_amount_str = f"{_d}|{_c}"
@@ -788,6 +838,8 @@ def process_file(
     skip_rows_override: Optional[int] = None,  # user-confirmed skip_rows from UI; takes precedence over schema
     history_cache=None,  # Optional[HistoryCache] — pre-loaded history for batch categorization
     taxonomy_map: Optional[dict] = None,  # C-08-cascade: {osm_tag: (category, subcategory)} or None
+    account_type_override: Optional[str] = None,  # AI-193 debugger: force account_type, bypass Account lookup
+    llm_trace: Optional[list] = None,  # AI-193 debugger: sink for raw LLM prompt/response per phase
 ) -> ImportResult:
     """
     Process a single file through Flow 1 or Flow 2.
@@ -875,6 +927,14 @@ def process_file(
                 f"({getattr(config, f'{phase_name}_llm_backend', '') or 'cat_*'})"
             )
 
+    # AI-193 (dev Debugger): when a trace sink is provided, wrap each phase
+    # backend so every LLM prompt/response is recorded in clear. No-op in prod.
+    if llm_trace is not None:
+        classifier_backend = _RecordingBackend(classifier_backend, "classify", llm_trace)
+        cleaner_backend    = _RecordingBackend(cleaner_backend, "cleaner", llm_trace)
+        cat_backend        = _RecordingBackend(cat_backend, "categorizer", llm_trace)
+        footer_backend     = _RecordingBackend(footer_backend, "footer", llm_trace)
+
     # Load raw data — load_raw_dataframe detects skip_rows + header internally
     _progress(0.0, "header_detection")
     # skip_rows_override (from UI) takes precedence; fall back to cached schema value
@@ -956,7 +1016,12 @@ def process_file(
 
     # Resolve account_type from the Account table when user selected an account
     _account_type: str | None = None
-    if account_label_override and account_label_override.strip():
+    if account_type_override and account_type_override.strip():
+        # AI-193 debugger: caller forces the account_type directly, bypassing
+        # the Account-table lookup — lets the same file be traced as bank_account
+        # vs prepaid_card vs credit_card to diagnose sign-convention bugs (AI-149).
+        _account_type = account_type_override.strip()
+    elif account_label_override and account_label_override.strip():
         try:
             from db.models import Account, get_engine, get_session
             _session = get_session()

--- a/run_debug.sh
+++ b/run_debug.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# ──────────────────────────────────────────────────────────────────────────────
+# Spendif.ai — Avvio in MODALITÀ SVILUPPATORE (AI-193)
+#
+# Lancia l'app con SPENDIFAI_DEV_MODE già impostata, così in sidebar compare
+# la voce "🔬 Debugger" (pagina di trace pipeline, nessuna scrittura su DB).
+#
+# Uso:   ./run_debug.sh
+# Stop:  Ctrl-C
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+VENV_DIR="$SCRIPT_DIR/.venv"
+APP="$SCRIPT_DIR/app.py"
+PORT="${SPENDIFAI_DEBUG_PORT:-8599}"
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+    echo "[ERROR] venv non trovato in $VENV_DIR — esegui prima 'uv sync'." >&2
+    exit 1
+fi
+
+# La variabile che sblocca la pagina dev — già impostata qui.
+export SPENDIFAI_DEV_MODE=1
+
+echo "[INFO] Modalità sviluppatore attiva (SPENDIFAI_DEV_MODE=1)"
+echo "[INFO] Apri:  http://localhost:${PORT}  →  sidebar  →  🔬 Debugger"
+
+# Invochiamo streamlit come modulo via il python del venv: i wrapper in
+# .venv/bin/ (streamlit, uvicorn) hanno shebang assoluti che si rompono se la
+# cartella del progetto viene rinominata (es. Spendify → Spendif-ai).
+exec "$VENV_DIR/bin/python" -m streamlit run "$APP" \
+    --server.port "$PORT" \
+    --server.headless false \
+    --browser.gatherUsageStats false

--- a/services/import_service.py
+++ b/services/import_service.py
@@ -225,12 +225,23 @@ class ImportService:
         progress_callback=None,
         account_label_override: str | None = None,
         skip_rows_override: int | None = None,
+        account_type_override: str | None = None,
+        existing_tx_ids_checker=None,
+        llm_trace: list | None = None,
     ) -> ImportResult:
         """Run the full import pipeline for one file.
 
         Taxonomy and category rules are loaded from the DB internally.
         Duplicate detection uses a per-call session so no open session is needed
         from the caller.
+
+        AI-193 (dev Debugger) hooks, all optional and no-ops in normal imports:
+          account_type_override: force the account_type, bypassing the Account
+            lookup (reproduce AI-149 across account types on the same file).
+          existing_tx_ids_checker: override the duplicate checker — pass
+            ``lambda ids: set()`` to keep every sampled row (nothing pre-skipped).
+          llm_trace: sink list that collects the raw LLM prompt/response of each
+            phase (classify/cleaner/categorizer/footer).
         """
         nsi_svc = NsiTaxonomyService(self.engine)
         with self._session() as s:
@@ -254,11 +265,13 @@ class ImportService:
             user_rules=user_rules,
             known_schema=known_schema,
             progress_callback=progress_callback,
-            existing_tx_ids_checker=_existing_checker,
+            existing_tx_ids_checker=existing_tx_ids_checker or _existing_checker,
             account_label_override=account_label_override,
             skip_rows_override=skip_rows_override,
             history_cache=history_cache,
             taxonomy_map=taxonomy_map,
+            account_type_override=account_type_override,
+            llm_trace=llm_trace,
         )
 
     # ── Full-batch import (legacy) ─────────────────────────────────────────────

--- a/tests/test_classifier_phase0.py
+++ b/tests/test_classifier_phase0.py
@@ -778,3 +778,62 @@ class TestClassifyDocument:
         with patch("core.classifier.call_with_fallback", return_value=(bad_result, "mock")):
             result = classify_document(df, None)  # type: ignore
         assert result is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AI-149: deterministic sign decision by account-type prior
+# ─────────────────────────────────────────────────────────────────────────────
+class TestAccountTypeSignPrior:
+
+    @staticmethod
+    def _apply(amounts, doc_type, account_type=None, debit_col=None, credit_col=None):
+        from core.classifier import _apply_account_type_sign_prior
+        df = pd.DataFrame({"Importo": [str(a) for a in amounts]})
+        res = {"amount_col": "Importo", "debit_col": debit_col, "credit_col": credit_col,
+               "doc_type": doc_type, "sign_convention": "debit_positive", "invert_sign": False}
+        return _apply_account_type_sign_prior(res, df, "test", account_type=account_type)
+
+    def test_expected_dominant_sign_map(self):
+        from core.classifier import _expected_dominant_sign
+        assert _expected_dominant_sign("credit_card") == -1
+        assert _expected_dominant_sign("debit_card") == -1
+        assert _expected_dominant_sign("prepaid_card") == -1
+        assert _expected_dominant_sign("cash") == -1
+        assert _expected_dominant_sign("savings_account") == +1
+        assert _expected_dominant_sign("bank_account") is None
+        assert _expected_dominant_sign("") is None
+
+    def test_card_expenses_positive_inverts(self):
+        # AI-149 regression: amex with expenses stored positive (majority +)
+        out = self._apply([50, 30, 1000, -80], "credit_card")
+        assert out["sign_convention"] == "signed_single"
+        assert out["invert_sign"] is True
+        assert out["positive_ratio"] == 0.75 and out["negative_ratio"] == 0.25
+
+    def test_card_expenses_already_negative_no_invert(self):
+        out = self._apply([-97, -50, 2038], "credit_card")
+        assert out["invert_sign"] is False
+
+    def test_ratios_always_sum_to_one(self):
+        out = self._apply([50, 30, 1000, -80], "credit_card")
+        assert round(out["positive_ratio"] + out["negative_ratio"], 6) == 1.0
+
+    def test_savings_opposite_prior(self):
+        # deposits positive → no invert
+        assert self._apply([100, 200, -30], "savings_account")["invert_sign"] is False
+        # deposits stored negative → invert
+        assert self._apply([-100, -200, 30], "savings_account")["invert_sign"] is True
+
+    def test_bank_account_no_prior_keeps_invert(self):
+        out = self._apply([500, -30, -40], "bank_account")
+        assert out["invert_sign"] is False  # unchanged from input
+
+    def test_s0_single_cycle_first_tx_decides(self):
+        # ≤2 movements → first non-zero tx; card, first positive → invert
+        assert self._apply([50, -80], "credit_card")["invert_sign"] is True
+        # known edge: payment (negative) listed first → no invert
+        assert self._apply([-80, 50], "credit_card")["invert_sign"] is False
+
+    def test_debit_credit_columns_untouched(self):
+        out = self._apply([50, 30], "bank_account", debit_col="Dare", credit_col="Avere")
+        assert out["sign_convention"] == "debit_positive"  # not a single-column file

--- a/ui/debugger_page.py
+++ b/ui/debugger_page.py
@@ -1,0 +1,406 @@
+"""Dev-only pipeline Debugger page (AI-193).
+
+Trace the full import pipeline (header → classify → footer → extraction →
+cleaner → categorizer) on a small sample of a file, IN CLEAR and WITHOUT
+writing anything to the DB. Built to diagnose pipeline bugs such as AI-149
+(Satispay/Amex sign inversion) without git revert or temporary prints.
+
+Gated behind the SPENDIFAI_DEV_MODE=1 environment variable (see app.py /
+sidebar.py): it never appears in production. Labels are hardcoded Italian on
+purpose — this is an internal developer tool, not a user-facing feature.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+
+import streamlit as st
+
+from services.import_service import ImportService
+
+# Ordered for a stable selectbox (frozenset VALID_ACCOUNT_TYPES has no order).
+_ACCOUNT_TYPES = [
+    "bank_account", "credit_card", "debit_card",
+    "prepaid_card", "savings_account", "cash",
+]
+
+# Broad emoji / pictograph ranges — used to flag descriptions the cleaner
+# should have stripped (Satispay 'Tipo' column carries 🏬/🛡️/🏦).
+_EMOJI_RE = re.compile(
+    "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U0001F300-\U0001F9FF←-⇿⬀-⯿️]"
+)
+
+
+def _is_dev_mode() -> bool:
+    return os.getenv("SPENDIFAI_DEV_MODE") == "1"
+
+
+def _to_float(val):
+    try:
+        return float(val)
+    except (TypeError, ValueError):
+        return None
+
+
+def _sign_flipped(raw_amount, amount) -> bool:
+    r, a = _to_float(raw_amount), _to_float(amount)
+    if r is None or a is None or r == 0 or a == 0:
+        return False
+    return (r > 0) != (a > 0)
+
+
+def render_debugger_page(engine) -> None:
+    if not _is_dev_mode():
+        st.warning("Pagina disponibile solo in modalità sviluppatore (SPENDIFAI_DEV_MODE=1).")
+        st.stop()
+
+    st.header("🔬 Debugger pipeline")
+    st.caption(
+        "Trace step-by-step di tutte le fasi fino alla categorizzazione inclusa. "
+        "**Nessuna scrittura sul DB** — il file viene solo analizzato."
+    )
+
+    svc = ImportService(engine)
+
+    # ── Input controls ────────────────────────────────────────────────────────
+    uploaded = st.file_uploader(
+        "File da tracciare (CSV / XLSX)", type=["csv", "xlsx", "xls"], key="dbg_uploader"
+    )
+    col1, col2 = st.columns(2)
+    with col1:
+        account_choice = st.selectbox(
+            "Simula account_type (solo dev)",
+            ["(come decide il sistema)"] + _ACCOUNT_TYPES,
+            help="NON è una scelta utente: in un import normale l'account_type è un "
+            "attributo fisso dell'account selezionato e il segno lo deduce il classifier. "
+            "Qui puoi forzarlo SOLO per diagnostica: vedere cosa produrrebbe la pipeline se "
+            "trattasse lo stesso file come tipo X, e isolare dove i segni si invertono (AI-149). "
+            "Lascia il default per osservare il comportamento reale del sistema.",
+        )
+    with col2:
+        n_sample = st.number_input(
+            "Campione (numero record)", min_value=1, max_value=500, value=20, step=1
+        )
+
+    run = st.button("▶ Esegui trace", type="primary", disabled=uploaded is None)
+
+    if run and uploaded is not None:
+        account_type_override = None if account_choice.startswith("(come decide") else account_choice
+        raw_bytes = uploaded.getvalue()
+        trace: list = []
+        config = svc.build_config(test_mode=True)
+        config.test_mode_rows = int(n_sample)
+        with st.spinner("Esecuzione pipeline (nessun salvataggio)…"):
+            try:
+                result = svc.process_file_single(
+                    raw_bytes=raw_bytes,
+                    filename=uploaded.name,
+                    config=config,
+                    account_type_override=account_type_override,
+                    existing_tx_ids_checker=lambda ids: set(),  # keep every sampled row
+                    llm_trace=trace,
+                )
+            except Exception as exc:  # noqa: BLE001 — surface anything in clear
+                st.session_state.pop("dbg_result", None)
+                st.error(f"Pipeline interrotta da un'eccezione: {exc!r}")
+                st.exception(exc)
+                return
+        st.session_state["dbg_result"] = result
+        st.session_state["dbg_trace"] = trace
+        st.session_state["dbg_meta"] = {
+            "filename": uploaded.name,
+            "account_type_override": account_type_override,
+            "confidence_threshold": config.confidence_threshold,
+            "sample_n": int(n_sample),
+        }
+
+    result = st.session_state.get("dbg_result")
+    if result is None:
+        st.info("Carica un file e premi **Esegui trace** per vedere il flusso completo.")
+        return
+
+    trace = st.session_state.get("dbg_trace", [])
+    meta = st.session_state.get("dbg_meta", {})
+    schema = result.doc_schema
+    threshold = meta.get("confidence_threshold", 0.80)
+
+    _render_phase_summary(result, schema, meta)
+    _render_transaction_trace(result, schema, threshold)
+    _render_llm_io(trace)
+    _render_export(result, schema, trace, meta)
+
+
+# ── Phase summary (global, in pipeline order) ───────────────────────────────────
+
+def _render_phase_summary(result, schema, meta) -> None:
+    st.subheader("Passaggi pipeline (in ordine di esecuzione)")
+    st.caption(f"Timings per fase (ms): {result.phase_durations_ms}")
+
+    # PASSO 1 — Caricamento & header detection
+    with st.expander("PASSO 1 — Caricamento & header detection", expanded=True):
+        st.json({
+            "flow_usato": result.flow_used,
+            "batch_sha256": result.batch_sha256,
+            "campione_richiesto": meta.get("sample_n"),
+            "righe_totali_file": result.total_file_rows,
+            "righe_header_scartate": result.header_rows_skipped,
+            "available_columns": result.available_columns,
+            "sheet": getattr(schema, "sheet_name", None) if schema else None,
+            "delimiter": getattr(schema, "delimiter", None) if schema else None,
+            "encoding": getattr(schema, "encoding", None) if schema else None,
+            "has_borders": getattr(schema, "has_borders", None) if schema else None,
+            "skip_rows": getattr(schema, "skip_rows", None) if schema else None,
+        })
+
+    # PASSO 2 — Classify / Phase 0
+    with st.expander("PASSO 2 — Classify (Phase 0 / schema dedotto)", expanded=True):
+        st.caption("Prompt e risposta grezzi del classifier: sezione «I/O LLM», fase `classify`.")
+        if schema is None:
+            st.warning(f"Nessuno schema. needs_schema_review={result.needs_schema_review}")
+        else:
+            sd = schema.model_dump() if hasattr(schema, "model_dump") else dict(schema)
+            st.json({
+                "needs_schema_review": result.needs_schema_review,
+                "account_type_forzato_dev": meta.get("account_type_override"),
+                "doc_type": str(sd.get("doc_type")),
+                "sign_convention": str(sd.get("sign_convention")),
+                "invert_sign": sd.get("invert_sign"),
+                "confidence": str(sd.get("confidence")),
+                "confidence_score": sd.get("confidence_score"),
+                "normalization_case_id": sd.get("normalization_case_id"),
+                "date_col": sd.get("date_col"),
+                "date_accounting_col": sd.get("date_accounting_col"),
+                "amount_col": sd.get("amount_col"),
+                "debit_col": sd.get("debit_col"),
+                "credit_col": sd.get("credit_col"),
+                "description_col": sd.get("description_col"),
+                "description_cols": sd.get("description_cols"),
+                "currency_col": sd.get("currency_col"),
+                "default_currency": sd.get("default_currency"),
+                "positive_ratio": sd.get("positive_ratio"),
+                "negative_ratio": sd.get("negative_ratio"),
+                "internal_transfer_patterns": sd.get("internal_transfer_patterns"),
+                "footer_patterns": sd.get("footer_patterns"),
+                "semantic_evidence": sd.get("semantic_evidence"),
+            })
+
+    # PASSO 3 — Footer stripping (3 fasi)
+    with st.expander("PASSO 3 — Footer stripping (deterministico → pattern → LLM → IQR)"):
+        st.caption("Le 3 fasi di footer-strip non espongono conteggi singoli in ImportResult; "
+                   "le eventuali chiamate LLM sono nella sezione «I/O LLM», fase `footer`. "
+                   "I footer_patterns dedotti sono nel PASSO 2.")
+        st.write(f"Righe unite (merge intra-file): **{result.merged_count}**")
+
+    # PASSO 4 — Estrazione / normalizzazione + sign convention
+    with st.expander("PASSO 4 — Estrazione / normalizzazione (sign_convention + invert_sign)"):
+        st.write(f"Transazioni estratte: **{len(result.transactions)}**")
+        st.write(f"Righe unite (merge): **{result.merged_count}**")
+        if schema is not None:
+            sd = schema.model_dump() if hasattr(schema, "model_dump") else dict(schema)
+            st.caption(f"Applicati: sign_convention=`{sd.get('sign_convention')}`, "
+                       f"invert_sign=`{sd.get('invert_sign')}` → effetto sui segni visibile "
+                       "nella tabella per-transazione (colonna `→ amount`).")
+        if result.skipped_rows:
+            rows = [{"row_index": sr.row_index, "reason": sr.reason, **sr.raw_values}
+                    for sr in result.skipped_rows]
+            st.write(f"Righe scartate in normalizzazione: **{len(rows)}**")
+            st.dataframe(rows, width="stretch")
+        else:
+            st.caption("Nessuna riga scartata in normalizzazione.")
+
+    # PASSO 5 — Dedup (pre-LLM)
+    with st.expander("PASSO 5 — Dedup transazioni già importate (pre-LLM)"):
+        st.write(f"Già presenti su DB (saltate prima dell'LLM): **{result.skipped_count}**")
+        st.write(f"File interamente duplicato: **{result.skipped_duplicate}**")
+        st.caption("Nel debugger il checker duplicati è forzato a vuoto → "
+                   "nessuna riga del campione viene pre-scartata.")
+
+    # PASSO 6 — Cleaning descrizioni
+    with st.expander("PASSO 6 — Cleaning descrizioni (estrazione controparte)"):
+        st.caption("Prima→dopo per ogni tx nella tabella (colonne `raw_description` → `→ description`). "
+                   "Prompt/risposta grezzi: sezione «I/O LLM», fase `cleaner`.")
+
+    # PASSO 7 — Giroconti / transfer detection
+    with st.expander("PASSO 7 — Rilevazione giroconti & transfer links"):
+        st.write(f"Giroconti rilevati (owner-name + keyword pass): **{result.internal_transfer_count}**")
+        if result.transfer_links:
+            st.write(f"Transfer links: **{len(result.transfer_links)}**")
+            st.dataframe(result.transfer_links, width="stretch")
+        else:
+            st.caption("Nessun transfer link.")
+
+    # PASSO 8 — Riconciliazione carta (RF-03)
+    with st.expander("PASSO 8 — Riconciliazione settlement carta (RF-03)"):
+        if result.reconciliations:
+            st.write(f"Riconciliazioni: **{len(result.reconciliations)}**")
+            st.dataframe(result.reconciliations, width="stretch")
+        else:
+            st.caption("Nessuna riconciliazione carta.")
+
+    # PASSO 9 — Categorizzazione
+    with st.expander("PASSO 9 — Categorizzazione"):
+        st.caption("Esito per tx nella tabella (category/subcategory/confidence/source/model). "
+                   "Prompt/risposta grezzi: sezione «I/O LLM», fase `categorizer`.")
+
+    # Errori pipeline
+    if result.errors:
+        st.error("Errori riportati dalla pipeline:")
+        st.json(result.errors)
+
+
+# ── Per-transaction trace (cleaner + categorizer in clear) ──────────────────────
+
+def _render_transaction_trace(result, schema, threshold) -> None:
+    st.subheader("Tabella per transazione (estrazione → cleaning → giroconti → categorizzazione)")
+
+    table = []
+    for tx in result.transactions:
+        raw_desc = tx.get("raw_description") or ""
+        clean_desc = tx.get("description") or ""
+        raw_amount = tx.get("raw_amount")
+        amount = tx.get("amount")
+        flags = []
+        if _sign_flipped(raw_amount, amount):
+            flags.append("⚠segno-invertito")
+        if (tx.get("category_source") or "") == "fallback":
+            flags.append("⚠fallback")
+        if tx.get("to_review"):
+            flags.append("⚠to-review")
+        if _EMOJI_RE.search(clean_desc):
+            flags.append("⚠emoji-residua")
+        table.append({
+            "raw_description": raw_desc,
+            "raw_amount": str(raw_amount),
+            "→ description": clean_desc,
+            "→ amount": str(amount),
+            "date": str(tx.get("date")),
+            "tx_type": tx.get("tx_type"),
+            "giroconto": tx.get("transfer_pair_id") or "",
+            "transfer_conf": tx.get("transfer_confidence"),
+            "reconciled": tx.get("reconciled"),
+            "keyword": tx.get("keyword_matched") or "",
+            "category": tx.get("category"),
+            "subcategory": tx.get("subcategory"),
+            "conf": tx.get("category_confidence"),
+            "source": tx.get("category_source"),
+            "model": tx.get("category_model"),
+            "anomalie": " ".join(flags),
+        })
+
+    st.dataframe(table, width="stretch", height=min(560, 80 + 36 * len(table)))
+
+    anomalies = [r for r in table if r["anomalie"]]
+    if anomalies:
+        st.warning(f"{len(anomalies)} transazioni con anomalie evidenziate (vedi colonna *anomalie*).")
+    else:
+        st.success("Nessuna anomalia evidenziata sul campione.")
+
+    with st.expander("Dettaglio per transazione (4 blocchi: input → Phase0 → cleaner → categorizer)"):
+        sd = schema.model_dump() if (schema is not None and hasattr(schema, "model_dump")) else {}
+        for i, tx in enumerate(result.transactions):
+            flipped = _sign_flipped(tx.get("raw_amount"), tx.get("amount"))
+            head = f"#{i+1} · {(tx.get('description') or tx.get('raw_description') or '')[:60]} · {tx.get('amount')}"
+            if flipped:
+                head = "⚠ " + head
+            with st.expander(head):
+                st.markdown("**Input raw**")
+                st.json({"raw_description": tx.get("raw_description"),
+                         "raw_amount": str(tx.get("raw_amount")),
+                         "date": str(tx.get("date")),
+                         "currency": tx.get("currency")})
+                st.markdown("**Phase 0 (schema applicato)**")
+                st.json({"sign_convention": str(sd.get("sign_convention")),
+                         "invert_sign": sd.get("invert_sign"),
+                         "doc_type": str(sd.get("doc_type"))})
+                st.markdown("**Cleaner**")
+                st.json({"description": tx.get("description"),
+                         "amount_con_segno": str(tx.get("amount")),
+                         "segno_invertito_vs_raw": flipped,
+                         "tx_type": tx.get("tx_type")})
+                st.markdown("**Giroconti / riconciliazione**")
+                st.json({"transfer_pair_id": tx.get("transfer_pair_id"),
+                         "transfer_confidence": tx.get("transfer_confidence"),
+                         "keyword_matched": tx.get("keyword_matched"),
+                         "reconciled": tx.get("reconciled")})
+                st.markdown("**Categorizer**")
+                st.json({"category": tx.get("category"),
+                         "subcategory": tx.get("subcategory"),
+                         "category_confidence": tx.get("category_confidence"),
+                         "category_source": tx.get("category_source"),
+                         "category_model": tx.get("category_model"),
+                         "to_review": tx.get("to_review")})
+
+
+# ── Raw LLM I/O per phase ───────────────────────────────────────────────────────
+
+def _render_llm_io(trace) -> None:
+    st.subheader("I/O LLM grezzo (prompt + risposta), per fase")
+    if not trace:
+        st.caption("Nessuna chiamata LLM registrata (schema in cache, regole deterministiche, "
+                   "o backend non LLM per le fasi).")
+        return
+    # Group by phase, preserving pipeline order.
+    order = ["classify", "footer", "cleaner", "categorizer"]
+    by_phase: dict[str, list] = {}
+    for call in trace:
+        by_phase.setdefault(call.get("phase", "?"), []).append(call)
+    phases = [p for p in order if p in by_phase] + [p for p in by_phase if p not in order]
+
+    for phase in phases:
+        calls = by_phase[phase]
+        st.markdown(f"**Fase `{phase}` — {len(calls)} chiamata/e LLM**")
+        for j, call in enumerate(calls):
+            label = f"#{j+1} · {call.get('backend')} ({call.get('model')}) · {call.get('duration_ms')}ms"
+            if call.get("error"):
+                label = "⚠ " + label
+            with st.expander(label):
+                if call.get("error"):
+                    st.error(f"Errore: {call['error']}")
+                st.markdown("**▸ System prompt**")
+                st.code(call.get("system_prompt") or "", language="text")
+                st.markdown("**▸ User prompt (inviato al modello)**")
+                st.code(call.get("user_prompt") or "", language="text")
+                st.markdown("**▸ JSON schema richiesto**")
+                st.code(json.dumps(call.get("json_schema"), ensure_ascii=False, indent=2, default=str),
+                        language="json")
+                st.markdown("**▸ Raw response (parsed dict)**")
+                st.code(json.dumps(call.get("response"), ensure_ascii=False, indent=2, default=str),
+                        language="json")
+
+
+# ── Export ──────────────────────────────────────────────────────────────────────
+
+def _render_export(result, schema, trace, meta) -> None:
+    st.subheader("Export")
+    payload = {
+        "meta": meta,
+        "flow_used": result.flow_used,
+        "batch_sha256": result.batch_sha256,
+        "needs_schema_review": result.needs_schema_review,
+        "schema": schema.model_dump() if (schema is not None and hasattr(schema, "model_dump")) else None,
+        "phase_durations_ms": result.phase_durations_ms,
+        "totals": {
+            "transactions": len(result.transactions),
+            "skipped_count": result.skipped_count,
+            "merged_count": result.merged_count,
+            "internal_transfer_count": result.internal_transfer_count,
+            "header_rows_skipped": result.header_rows_skipped,
+            "total_file_rows": result.total_file_rows,
+        },
+        "skipped_rows": [
+            {"row_index": sr.row_index, "reason": sr.reason, "raw_values": sr.raw_values}
+            for sr in result.skipped_rows
+        ],
+        "reconciliations": result.reconciliations,
+        "transfer_links": result.transfer_links,
+        "errors": result.errors,
+        "transactions": result.transactions,
+        "llm_trace": trace,
+    }
+    st.download_button(
+        "⬇ Scarica trace completo (JSON)",
+        data=json.dumps(payload, ensure_ascii=False, indent=2, default=str),
+        file_name=f"debug_trace_{meta.get('filename', 'file')}.json",
+        mime="application/json",
+    )

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -1,3 +1,5 @@
+import os
+
 import streamlit as st
 
 from ui.i18n import t
@@ -72,6 +74,19 @@ def render_sidebar() -> str:
             else:
                 st.session_state["page"] = key
                 st.rerun()
+
+    # Dev-only entry (AI-193): hardcoded label, shown only when SPENDIFAI_DEV_MODE=1.
+    if os.getenv("SPENDIFAI_DEV_MODE") == "1":
+        is_active = st.session_state["page"] == "debugger"
+        if st.sidebar.button(
+            "🔬 Debugger",
+            key="nav_debugger",
+            width="stretch",
+            type="primary" if is_active else "secondary",
+            help="Dev tool: trace pipeline su un campione, nessuna scrittura DB",
+        ):
+            st.session_state["page"] = "debugger"
+            st.rerun()
 
     _render_build_info()
     return st.session_state["page"]


### PR DESCRIPTION
## Sintesi
Risolve **AI-149** (segni invertiti su import carte/Satispay) alla radice e aggiunge il dev tool **AI-193** che ha permesso la diagnosi.

## AI-149 — sign-detection deterministica per tipo conto
Su file a colonna importo singola l'LLM poteva scegliere `debit_positive` e **inventare** le ratio (es. `0.71+0.71`), invertendo tutti i segni. Il segno torna a essere un **fatto contabile** calcolato in Python:
- **S3**: colonna singola ⇒ `signed_single` (mai `debit_positive`/`credit_negative`).
- **S2**: `positive/negative_ratio` contate dal dato (somma 1), non più stimate dall'LLM.
- **S1**: prior per tipo conto — carte/cash (spese, dominante negativo), risparmio (entrate, dominante positivo) → `invert_sign = (segno_misurato ≠ atteso)`.
- **S0**: con ≤2 movimenti o parità, decide la prima tx (ciclo singolo); l'ultima è solo verifica di coerenza.
- `bank_account`: logica attuale (nessun prior forte).
- **S4**: hardening echo `raw_amount` + fallback `apply_sign_convention`.

✅ Validato E2E su 2 export AMEX + Satispay (auto-detect e tipo forzato). 8 test nuovi; suite classifier/normalizer/import verde.
⚠️ La tabella prior è una **bozza** (`cash`/`bank_account` da rivalidare). Gate benchmark + `accuracy_groups.py` ancora da eseguire.

## AI-193 — pagina Debugger pipeline (solo dev)
Gated da `SPENDIFAI_DEV_MODE=1`. Traccia tutte le fasi su un campione **senza scrivere su DB**: riepilogo per fase, tabella per-tx (raw→clean, importo firmato, categoria/sorgente, flag anomalie), **I/O LLM grezzo per fase**, export JSON.

## Igiene
- `.env` rimosso dall'indice (era tracciato pre-gitignore, solo placeholder) + `.coding_agent/` ignorato.

## Spec
`documents/04_software_engineering/07_deterministic_pipeline.md` (repo docs, branch `geppi-rasnovich`).