### PR TITLE
fix(analytics): correct Vemetric snippet — broken CDN URL returned 404

### DIFF
--- a/getting-started.de.html
+++ b/getting-started.de.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Drei Schritte: herunterladen, installieren, erster Start. Alles offline, keine Cloud." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.en.html
+++ b/getting-started.en.html
@@ -10,7 +10,11 @@
 
   <!-- Cloudflare Web Analytics -->
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.es.html
+++ b/getting-started.es.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Tres pasos: descargar, instalar, primer inicio. Todo offline, sin cuenta." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.fr.html
+++ b/getting-started.fr.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Trois étapes : télécharger, installer, premier lancement. Tout en local, pas de cloud." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.html
+++ b/getting-started.html
@@ -10,7 +10,11 @@
 
   <!-- Cloudflare Web Analytics -->
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.ja.html
+++ b/getting-started.ja.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="ダウンロード、インストール、初回起動の 3 ステップ。すべてオフライン、クラウド不要。" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.nl.html
+++ b/getting-started.nl.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Drie stappen: downloaden, installeren, eerste start. Alles offline, geen account." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.pl.html
+++ b/getting-started.pl.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Trzy kroki: pobierz, zainstaluj, pierwsze uruchomienie. Wszystko offline, bez chmury." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/getting-started.pt.html
+++ b/getting-started.pt.html
@@ -9,7 +9,11 @@
   <meta property="og:description" content="Três passos: baixar, instalar, primeira execução. Tudo offline, sem nuvem." />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.de.html
+++ b/index.de.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.en.html
+++ b/index.en.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.es.html
+++ b/index.es.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.fr.html
+++ b/index.fr.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.html
+++ b/index.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.ja.html
+++ b/index.ja.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.nl.html
+++ b/index.nl.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.pl.html
+++ b/index.pl.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }

--- a/index.pt.html
+++ b/index.pt.html
@@ -10,7 +10,11 @@
   <meta property="og:type" content="website" />
 
   <!-- Vemetric Analytics -->
-  <script defer src="https://cdn.vemetric.com/latest/vemetric.min.js" data-token="o10JyrtkgQ8RAn1q"></script>
+  <script>
+    window.vmtrcq = window.vmtrcq || [];
+    window.vmtrc = window.vmtrc || function (){window.vmtrcq.push(Array.prototype.slice.call(arguments))};
+  </script>
+  <script defer src="https://cdn.vemetric.com/main.js" id="vmtrc-scr" data-token="o10JyrtkgQ8RAn1q"></script>
 
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }


### PR DESCRIPTION
## Problem
Vemetric dashboard shows no data for the published GitHub Pages site.

Root cause: the installed script tag points to `https://cdn.vemetric.com/latest/vemetric.min.js`, which returns **HTTP 404**. The script never loads, so no pageview/event is ever sent. The project token (`o10JyrtkgQ8RAn1q`) was correct.

## Fix
Replaced the snippet on all 18 public HTML pages (`index*.html` + `getting-started*.html`, 9 locales) with the official one from the [Vemetric docs](https://vemetric.com/docs/sdks/html-script):

- correct src: `https://cdn.vemetric.com/main.js` (verified HTTP 200)
- required `id="vmtrc-scr"`
- queue-init inline script (`window.vmtrcq`/`window.vmtrc`)

`desktop/splash.html` intentionally untouched (local app splash, not a published page).

## Verification
- `curl -sI https://cdn.vemetric.com/main.js` → 200, `text/javascript`
- All 18 files contain exactly one occurrence of the new snippet; token unchanged
- Note: Vemetric does not track from `localhost` — data will appear only after merge, from visits to the live domain