### PR TITLE
Landing SEO + GEO: tags, sitemap, robots, llms.txt (9 locales)

### DIFF
--- a/index.de.html
+++ b/index.de.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Ihr einheitliches Bankbuch, auf Ihrem Computer</title>
-  <meta name="description" content="Spendify fasst Kontobewegungen verschiedener Banken automatisch in einem einzigen Hauptbuch zusammen — keine Duplikate, keine Abonnements, keine Datenweitergabe." />
-  <meta property="og:title" content="Spendify — Ihr einheitliches Bankbuch" />
+  <title>Spendif.ai — Ihr einheitliches Bankbuch, auf Ihrem Computer</title>
+  <meta name="description" content="Spendif.ai fasst Kontobewegungen verschiedener Banken automatisch in einem einzigen Hauptbuch zusammen — keine Duplikate, keine Abonnements, keine Datenweitergabe." />
+  <meta property="og:title" content="Spendif.ai — Ihr einheitliches Bankbuch" />
   <meta property="og:description" content="Ein persönliches Open-Source-Finanzbuch, das auf Ihrem Computer läuft. Ihre Daten bleiben Ihre." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.de.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="de_DE" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Ihr einheitliches Bankbuch" />
+  <meta name="twitter:description" content="Spendif.ai fasst Kontobewegungen verschiedener Banken automatisch in einem einzigen Hauptbuch zusammen — keine Duplikate, keine Abonnements, keine Datenweitergabe." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai fasst Kontobewegungen verschiedener Banken automatisch in einem einzigen Hauptbuch zusammen — keine Duplikate, keine Abonnements, keine Datenweitergabe.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "de",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.en.html
+++ b/index.en.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Your unified bank ledger, on your computer</title>
-  <meta name="description" content="Spendify automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
-  <meta property="og:title" content="Spendify — Your unified bank ledger" />
+  <title>Spendif.ai — Your unified bank ledger, on your computer</title>
+  <meta name="description" content="Spendif.ai automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
+  <meta property="og:title" content="Spendif.ai — Your unified bank ledger" />
   <meta property="og:description" content="An open source personal financial ledger that runs on your computer. Your data stays yours." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Your unified bank ledger" />
+  <meta name="twitter:description" content="Spendif.ai automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai automatically aggregates movements files from different banks into a single ledger — no duplicates, no subscriptions, no sending your data to anyone.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "en",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.es.html
+++ b/index.es.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Su libro de cuentas bancario unificado, en su ordenador</title>
-  <meta name="description" content="Spendify agrega automáticamente los archivos de movimientos de diferentes bancos en un solo libro de cuentas — sin duplicados, sin suscripciones, sin enviar sus datos a nadie." />
-  <meta property="og:title" content="Spendify — Su libro de cuentas bancario unificado" />
+  <title>Spendif.ai — Su libro de cuentas bancario unificado, en su ordenador</title>
+  <meta name="description" content="Spendif.ai agrega automáticamente los archivos de movimientos de diferentes bancos en un solo libro de cuentas — sin duplicados, sin suscripciones, sin enviar sus datos a nadie." />
+  <meta property="og:title" content="Spendif.ai — Su libro de cuentas bancario unificado" />
   <meta property="og:description" content="Un libro de cuentas financiero personal de código abierto que se ejecuta en su ordenador. Sus datos siguen siendo suyos." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.es.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="es_ES" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Su libro de cuentas bancario unificado" />
+  <meta name="twitter:description" content="Spendif.ai agrega automáticamente los archivos de movimientos de diferentes bancos en un solo libro de cuentas — sin duplicados, sin suscripciones, sin enviar sus datos a nadie." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai agrega automáticamente los archivos de movimientos de diferentes bancos en un solo libro de cuentas — sin duplicados, sin suscripciones, sin enviar sus datos a nadie.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "es",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.fr.html
+++ b/index.fr.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Votre registre bancaire unifié, sur votre ordinateur</title>
-  <meta name="description" content="Spendify agrège automatiquement les fichiers de mouvements de différentes banques en un registre unique — sans doublons, sans abonnement, sans envoyer vos données à quiconque." />
-  <meta property="og:title" content="Spendify — Votre registre bancaire unifié" />
+  <title>Spendif.ai — Votre registre bancaire unifié, sur votre ordinateur</title>
+  <meta name="description" content="Spendif.ai agrège automatiquement les fichiers de mouvements de différentes banques en un registre unique — sans doublons, sans abonnement, sans envoyer vos données à quiconque." />
+  <meta property="og:title" content="Spendif.ai — Votre registre bancaire unifié" />
   <meta property="og:description" content="Un registre financier personnel open source qui tourne sur votre ordinateur. Vos données restent les vôtres." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="fr_FR" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Votre registre bancaire unifié" />
+  <meta name="twitter:description" content="Spendif.ai agrège automatiquement les fichiers de mouvements de différentes banques en un registre unique — sans doublons, sans abonnement, sans envoyer vos données à quiconque." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai agrège automatiquement les fichiers de mouvements de différentes banques en un registre unique — sans doublons, sans abonnement, sans envoyer vos données à quiconque.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "fr",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,60 @@
   <meta property="og:description" content="Un registro finanziario personale open source che gira sul tuo computer. I tuoi dati restano tuoi." />
   <meta property="og:type" content="website" />
 
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — I tuoi movimenti unificati" />
+  <meta name="twitter:description" content="Spendif.ai aggrega automaticamente i movimenti di banche diverse in un unico ledger, senza duplicati, senza abbonamenti, senza inviare i tuoi dati a nessuno." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai aggrega automaticamente i movimenti di banche diverse in un unico ledger, senza duplicati, senza abbonamenti, senza inviare i tuoi dati a nessuno.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "it",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
+
   <!-- Vemetric Analytics -->
   <script>
     window.vmtrcq = window.vmtrcq || [];

--- a/index.ja.html
+++ b/index.ja.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — あなたのコンピュータで動く、統合銀行台帳</title>
-  <meta name="description" content="Spendifyは複数の銀行の取引ファイルを自動的に1つの台帳に集約します — 重複なし、サブスクリプションなし、データを誰にも送信しません。" />
-  <meta property="og:title" content="Spendify — あなたの統合銀行台帳" />
+  <title>Spendif.ai — あなたのコンピュータで動く、統合銀行台帳</title>
+  <meta name="description" content="Spendif.aiは複数の銀行の取引ファイルを自動的に1つの台帳に集約します — 重複なし、サブスクリプションなし、データを誰にも送信しません。" />
+  <meta property="og:title" content="Spendif.ai — あなたの統合銀行台帳" />
   <meta property="og:description" content="あなたのコンピュータ上で動作するオープンソースの個人向け家計台帳。データはあなたのものです。" />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="ja_JP" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — あなたの統合銀行台帳" />
+  <meta name="twitter:description" content="Spendif.aiは複数の銀行の取引ファイルを自動的に1つの台帳に集約します — 重複なし、サブスクリプションなし、データを誰にも送信しません。" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.aiは複数の銀行の取引ファイルを自動的に1つの台帳に集約します — 重複なし、サブスクリプションなし、データを誰にも送信しません。",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "ja",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.nl.html
+++ b/index.nl.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Je geünificeerde rekeningoverzicht, op je eigen computer</title>
-  <meta name="description" content="Spendify voegt automatisch transactiebestanden van verschillende banken samen tot één overzicht — geen duplicaten, geen abonnementen, geen verzending van je gegevens naar wie dan ook." />
-  <meta property="og:title" content="Spendify — Je geünificeerde rekeningoverzicht" />
+  <title>Spendif.ai — Je geünificeerde rekeningoverzicht, op je eigen computer</title>
+  <meta name="description" content="Spendif.ai voegt automatisch transactiebestanden van verschillende banken samen tot één overzicht — geen duplicaten, geen abonnementen, geen verzending van je gegevens naar wie dan ook." />
+  <meta property="og:title" content="Spendif.ai — Je geünificeerde rekeningoverzicht" />
   <meta property="og:description" content="Een open source persoonlijk financieel grootboek dat draait op je eigen computer. Je gegevens blijven van jou." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="nl_NL" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Je geünificeerde rekeningoverzicht" />
+  <meta name="twitter:description" content="Spendif.ai voegt automatisch transactiebestanden van verschillende banken samen tot één overzicht — geen duplicaten, geen abonnementen, geen verzending van je gegevens naar wie dan ook." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai voegt automatisch transactiebestanden van verschillende banken samen tot één overzicht — geen duplicaten, geen abonnementen, geen verzending van je gegevens naar wie dan ook.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "nl",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.pl.html
+++ b/index.pl.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Twoja ujednolicona księga bankowa, na Twoim komputerze</title>
-  <meta name="description" content="Spendify automatycznie agreguje pliki z transakcjami z różnych banków w jedną księgę — bez duplikatów, bez subskrypcji, bez wysyłania danych komukolwiek." />
-  <meta property="og:title" content="Spendify — Twoja ujednolicona księga bankowa" />
+  <title>Spendif.ai — Twoja ujednolicona księga bankowa, na Twoim komputerze</title>
+  <meta name="description" content="Spendif.ai automatycznie agreguje pliki z transakcjami z różnych banków w jedną księgę — bez duplikatów, bez subskrypcji, bez wysyłania danych komukolwiek." />
+  <meta property="og:title" content="Spendif.ai — Twoja ujednolicona księga bankowa" />
   <meta property="og:description" content="Otwartoźródłowa osobista księga finansowa działająca na Twoim komputerze. Twoje dane pozostają Twoje." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="pl_PL" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pt_PT" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Twoja ujednolicona księga bankowa" />
+  <meta name="twitter:description" content="Spendif.ai automatycznie agreguje pliki z transakcjami z różnych banków w jedną księgę — bez duplikatów, bez subskrypcji, bez wysyłania danych komukolwiek." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai automatycznie agreguje pliki z transakcjami z różnych banków w jedną księgę — bez duplikatów, bez subskrypcji, bez wysyłania danych komukolwiek.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "pl",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/index.pt.html
+++ b/index.pt.html
@@ -3,11 +3,65 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Spendify — Seu extrato bancário unificado, no seu computador</title>
-  <meta name="description" content="Spendify agrega automaticamente arquivos de movimentações de diferentes bancos em um único extrato — sem duplicatas, sem assinaturas, sem enviar seus dados a ninguém." />
-  <meta property="og:title" content="Spendify — Seu extrato bancário unificado" />
+  <title>Spendif.ai — Seu extrato bancário unificado, no seu computador</title>
+  <meta name="description" content="Spendif.ai agrega automaticamente arquivos de movimentações de diferentes bancos em um único extrato — sem duplicatas, sem assinaturas, sem enviar seus dados a ninguém." />
+  <meta property="og:title" content="Spendif.ai — Seu extrato bancário unificado" />
   <meta property="og:description" content="Um extrato financeiro pessoal open source que roda no seu computador. Seus dados continuam sendo seus." />
   <meta property="og:type" content="website" />
+
+<!-- SEO/GEO (managed) -->
+  <link rel="canonical" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/" />
+  <link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html" />
+  <link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html" />
+  <link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html" />
+  <link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html" />
+  <link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html" />
+  <link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html" />
+  <link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html" />
+  <meta name="robots" content="index,follow" />
+  <meta property="og:url" content="https://drake69.github.io/spendif-ai/index.pt.html" />
+  <meta property="og:site_name" content="Spendif.ai" />
+  <meta property="og:locale" content="pt_PT" />
+  <meta property="og:locale:alternate" content="it_IT" />
+  <meta property="og:locale:alternate" content="en_US" />
+  <meta property="og:locale:alternate" content="de_DE" />
+  <meta property="og:locale:alternate" content="es_ES" />
+  <meta property="og:locale:alternate" content="fr_FR" />
+  <meta property="og:locale:alternate" content="ja_JP" />
+  <meta property="og:locale:alternate" content="nl_NL" />
+  <meta property="og:locale:alternate" content="pl_PL" />
+  <!-- TODO og:image: manca un'immagine social 1200x630; aggiungere e referenziare qui + twitter:image -->
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Spendif.ai — Seu extrato bancário unificado" />
+  <meta name="twitter:description" content="Spendif.ai agrega automaticamente arquivos de movimentações de diferentes bancos em um único extrato — sem duplicatas, sem assinaturas, sem enviar seus dados a ninguém." />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "Spendif.ai",
+    "applicationCategory": "FinanceApplication",
+    "operatingSystem": "Windows, macOS, Linux",
+    "description": "Spendif.ai agrega automaticamente arquivos de movimentações de diferentes bancos em um único extrato — sem duplicatas, sem assinaturas, sem enviar seus dados a ninguém.",
+    "url": "https://drake69.github.io/spendif-ai/",
+    "inLanguage": "pt",
+    "isAccessibleForFree": true,
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "EUR"
+    },
+    "license": "https://github.com/drake69/spendif-ai/blob/main/LICENSE",
+    "author": {
+      "@type": "Organization",
+      "name": "Spendif.ai",
+      "url": "https://github.com/drake69/spendif-ai"
+    }
+  }
+  </script>
+  <!-- /SEO/GEO -->
 
   <!-- Vemetric Analytics -->
   <script>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,28 @@
+# Spendif.ai
+
+> Spendif.ai is a free, open-source personal-finance ledger that runs entirely on your own computer. It aggregates transaction exports from many different banks into one unified ledger — removing duplicates, reconciling card-vs-account movements, detecting internal transfers, and categorising spending with a hybrid deterministic + local-LLM pipeline. Your data never leaves your machine.
+
+Spendif.ai is desktop-first (macOS, Windows, Linux) with an optional companion mobile app for cash tracking only. It is built for people who keep multiple bank accounts and want real control over their money without subscriptions, cloud accounts, or sending their financial data to third parties.
+
+## What it does
+
+- **Unified ledger**: import CSV/XLSX movement files from any bank; the format is detected automatically.
+- **Idempotent deduplication**: re-importing the same file never creates duplicate transactions.
+- **Card–account reconciliation**: a card charge and its matching current-account debit are recognised as one movement, not two.
+- **Internal transfer detection**: money moved between your own accounts does not distort spending totals.
+- **Hybrid categorisation**: a local LLM proposes categories, deterministic rules seal the result; corrections become reusable rules.
+- **Privacy by design**: offline-first, automatic PII redaction before any hosted-LLM call, a single portable local SQLite database (`~/.spendifai/ledger.db`).
+
+## Key facts
+
+- License: open source (see the repository LICENSE).
+- Price: free, no subscription.
+- Platforms: Windows, macOS, Linux (desktop). Data stored locally under `~/.spendifai/`.
+- LLM: works with a bundled local model (llama.cpp / GGUF) or optional hosted providers, always with local PII redaction.
+
+## Links
+
+- Website: https://drake69.github.io/spendif-ai/
+- Source code: https://github.com/drake69/spendif-ai
+- Downloads / releases: https://github.com/drake69/spendif-ai/releases
+- License: https://github.com/drake69/spendif-ai/blob/main/LICENSE

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,15 @@
+# Spendif.ai landing — robots
+User-agent: *
+Allow: /
+
+# AI / generative-engine crawlers are welcome (GEO)
+User-agent: GPTBot
+Allow: /
+User-agent: PerplexityBot
+Allow: /
+User-agent: Google-Extended
+Allow: /
+User-agent: ClaudeBot
+Allow: /
+
+Sitemap: https://drake69.github.io/spendif-ai/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.en.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.de.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.es.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.fr.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.ja.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.nl.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.pl.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+  <url>
+    <loc>https://drake69.github.io/spendif-ai/index.pt.html</loc>
+    <lastmod>2026-07-29</lastmod>
+    <xhtml:link rel="alternate" hreflang="it" href="https://drake69.github.io/spendif-ai/"/>
+    <xhtml:link rel="alternate" hreflang="en" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+    <xhtml:link rel="alternate" hreflang="de" href="https://drake69.github.io/spendif-ai/index.de.html"/>
+    <xhtml:link rel="alternate" hreflang="es" href="https://drake69.github.io/spendif-ai/index.es.html"/>
+    <xhtml:link rel="alternate" hreflang="fr" href="https://drake69.github.io/spendif-ai/index.fr.html"/>
+    <xhtml:link rel="alternate" hreflang="ja" href="https://drake69.github.io/spendif-ai/index.ja.html"/>
+    <xhtml:link rel="alternate" hreflang="nl" href="https://drake69.github.io/spendif-ai/index.nl.html"/>
+    <xhtml:link rel="alternate" hreflang="pl" href="https://drake69.github.io/spendif-ai/index.pl.html"/>
+    <xhtml:link rel="alternate" hreflang="pt" href="https://drake69.github.io/spendif-ai/index.pt.html"/>
+    <xhtml:link rel="alternate" hreflang="x-default" href="https://drake69.github.io/spendif-ai/index.en.html"/>
+  </url>
+</urlset>


### PR DESCRIPTION
## Sommario
Le landing gh-pages avevano SEO minimo e **zero GEO** (segnali per i motori generativi AI). Aggiunto su tutte e 9 le lingue + file site-level.

### Per pagina (9 locale)
- `link canonical` + `hreflang` (9 + x-default), `meta robots`
- Open Graph completo (`og:url`, `og:site_name`, `og:locale` + alternates)
- Twitter card (summary)
- **JSON-LD `SoftwareApplication`** (schema.org) — dati strutturati per search + generative engines

### File site-level (nuovi)
- `sitemap.xml` — multilingua con `xhtml:link` alternates (9 URL)
- `robots.txt` — consente crawler AI (GPTBot, PerplexityBot, ClaudeBot, Google-Extended), punta al sitemap
- `llms.txt` — descrizione prodotto per crawler LLM (**GEO**)

### Brand fix
`Spendify` → `Spendif.ai` in `<title>` e meta description delle 8 pagine tradotte (corpo testo lasciato a un pass separato).

## Scelte deliberate
- **No FAQPage schema**: nessuna sezione FAQ visibile → aggiungerlo violerebbe le structured-data guidelines. Follow-up: sezione FAQ visibile + schema.
- **og:image = TODO**: manca un asset social 1200×630. `twitter:card=summary` nel frattempo.
- URL = host Pages reale `drake69.github.io/spendif-ai/`.

## Test
- JSON-LD di tutti e 9 i file: parse-valido, `@type=SoftwareApplication`, `name=Spendif.ai`
- `sitemap.xml`: XML ben formato (9 url)
- Iniezione idempotente (marker `SEO/GEO (managed)`), 1 canonical + 10 hreflang per file