### PR TITLE
fix(coupling): decouple UI from db/core + repair the coupling CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,11 @@ jobs:
         # Exit 1 if a file not in the baseline has violations,
         # or if a file in the baseline exceeds its max_violations.
         # The JSON is saved for the following steps.
-        run: uv run python tools/coupling_check.py --strict --json | tee coupling_report.json
+        # set -o pipefail is REQUIRED: without it the pipe returns tee's exit
+        # code (always 0), so a failing check would never fail the job.
+        run: |
+          set -o pipefail
+          uv run python tools/coupling_check.py --strict --json | tee coupling_report.json
         # The job fails if the command exits with code 1.
         # continue-on-error: false  ← default, explicit for clarity
 

--- a/services/app_info.py
+++ b/services/app_info.py
@@ -1,0 +1,18 @@
+"""Application build metadata, exposed to the UI via the service layer.
+
+Keeps the UI decoupled from `core.*`: the `core._build_info` module is generated
+at build time, so the `from core` import lives here (service layer, allowed) and
+the UI consumes `get_build_info()` instead.
+"""
+
+
+def get_build_info() -> tuple[str, str]:
+    """Return (version, build_time).
+
+    Falls back to ("dev", "dev") when running from source (no frozen build stamp).
+    """
+    try:
+        from core._build_info import BUILD_TIME, BUILD_VERSION
+    except ImportError:
+        return "dev", "dev"
+    return BUILD_VERSION, BUILD_TIME

--- a/tests/test_app_info.py
+++ b/tests/test_app_info.py
@@ -1,0 +1,23 @@
+"""Tests for services/app_info.py — build metadata exposed to the UI."""
+from __future__ import annotations
+
+import sys
+
+
+def test_get_build_info_returns_string_tuple():
+    from services.app_info import get_build_info
+
+    version, build_time = get_build_info()
+    assert isinstance(version, str)
+    assert isinstance(build_time, str)
+    assert version and build_time
+
+
+def test_get_build_info_falls_back_to_dev(monkeypatch):
+    # Force the optional core._build_info import to fail (source checkout, no
+    # frozen build stamp) and assert the graceful ("dev", "dev") fallback.
+    monkeypatch.setitem(sys.modules, "core._build_info", None)
+
+    from services.app_info import get_build_info
+
+    assert get_build_info() == ("dev", "dev")

--- a/ui/llm_models_page.py
+++ b/ui/llm_models_page.py
@@ -631,19 +631,13 @@ def render_llm_models_page(engine) -> None:
 def _render_correction_benchmark(engine) -> None:
     """Live implicit benchmark derived from user category corrections."""
     import pandas as pd
-    from db import repository
-    from sqlalchemy.orm import sessionmaker
+    from services.transaction_service import TransactionService
 
     st.markdown(f"**{t('llm_models.benchmark.title')}**")
     st.caption(t("llm_models.benchmark.caption"))
 
     try:
-        _Session = sessionmaker(bind=engine, expire_on_commit=False)
-        s = _Session()
-        try:
-            rows = repository.get_correction_benchmark(s)
-        finally:
-            s.close()
+        rows = TransactionService(engine).get_correction_benchmark()
     except Exception:
         st.caption(t("llm_models.benchmark.unavailable"))
         return

--- a/ui/sidebar.py
+++ b/ui/sidebar.py
@@ -93,14 +93,13 @@ def render_sidebar() -> str:
 
 
 def _render_build_info() -> None:
-    try:
-        from core._build_info import BUILD_TIME, BUILD_VERSION
-    except ImportError:
-        BUILD_TIME, BUILD_VERSION = "dev", "dev"
-    if BUILD_TIME == "dev":
+    from services.app_info import get_build_info
+
+    build_version, build_time = get_build_info()
+    if build_time == "dev":
         return
     st.sidebar.markdown(
         f"<div style='text-align:center;color:#666;font-size:11px;margin-top:8px'>"
-        f"v{BUILD_VERSION} · {BUILD_TIME}</div>",
+        f"v{build_version} · {build_time}</div>",
         unsafe_allow_html=True,
     )


### PR DESCRIPTION
## Problema
Il coupling gate (UI ↔ Service) **non bloccava**: la CI faceva `coupling_check.py --strict --json | tee …`, e il `| tee` restituiva l'exit di tee (0), non del check. Così 2 violazioni pre-esistenti (#139, #140) sono passate.

## Fix
- **ui/llm_models_page.py**: `TransactionService.get_correction_benchmark()` al posto di `from db import repository` + sessionmaker.
- **ui/sidebar.py**: nuovo `services/app_info.py` con `get_build_info()`; il `from core._build_info` si sposta nel service layer.
- **ci.yml**: `set -o pipefail` → il gate ora fa fallire davvero il job.

## Verifica
`coupling_check.py --strict` → exit 0 (PASS). py_compile OK. Zero import core/db in ui/.