### PR TITLE
docs: align product version to 0.1.0 (README + pyproject) + stale-ref fixes

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -1,4 +1,4 @@
-# Spendif.ai v3.0
+# Spendif.ai
 
 [![CI](https://github.com/drake69/spendif-ai/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/drake69/spendif-ai/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/drake69/spendif-ai/graph/badge.svg)](https://codecov.io/gh/drake69/spendif-ai)
@@ -27,7 +27,7 @@ Registro finanziario personale unificato con pipeline ibrida deterministica + LL
 - **Pipeline ibrida**: normalizer deterministico + classifier LLM + categorizer a cascata
 - **LLM multi-backend** con circuit breaker: llama.cpp (default per desktop), Ollama, OpenAI, Claude — interazione diretta tramite SDK, senza LangChain
 - **Launcher desktop nativo**: pywebview + PyInstaller → DMG / MSIX / .deb / .rpm
-- **UI Streamlit articolata in una quindicina di pagine**, i18n IT+EN completo (760+ chiavi di traduzione)
+- **UI Streamlit articolata in 17 pagine**, i18n IT+EN completo (760+ chiavi di traduzione)
 
 ## Cosa è implementato
 
@@ -54,7 +54,7 @@ Una di queste ti servirebbe? Segnalacelo su [GitHub Discussions](https://github.
 
 ```bash
 git clone https://github.com/drake69/spendif-ai.git
-cd spendify
+cd spendif-ai
 uv sync --extra desktop
 
 # LLM locale (scelta dello sviluppatore — l'installer desktop gestisce
@@ -144,7 +144,7 @@ Diagramma completo e Flusso 1 vs Flusso 2 → [docs/architecture.it.md](docs/arc
 
 ```
 sw_artifacts/
-├── app.py                  # Entry point Streamlit (onboarding gate + ~15 pagine)
+├── app.py                  # Entry point Streamlit (onboarding gate + 17 pagine)
 ├── core/                   # Pipeline: orchestrator, normalizer, classifier, categorizer, sanitizer, llm_backends
 ├── services/               # Facade layer per l'UI; async runner; settings; import
 ├── ui/                     # Pagine Streamlit + i18n + widgets

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spendif.ai v3.0
+# Spendif.ai
 
 [![CI](https://github.com/drake69/spendif-ai/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/drake69/spendif-ai/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/drake69/spendif-ai/graph/badge.svg)](https://codecov.io/gh/drake69/spendif-ai)
@@ -27,7 +27,7 @@ Unified personal finance ledger with a hybrid deterministic + LLM pipeline. Aggr
 - **Hybrid pipeline**: deterministic normalizer + LLM classifier + categorizer cascade
 - **Multi-backend LLM** with circuit breaker: llama.cpp (default for desktop), Ollama, OpenAI, Claude — direct SDK use, no LangChain
 - **Native desktop launcher**: pywebview + PyInstaller → DMG / MSIX / .deb / .rpm
-- **14-page Streamlit UI**, full IT+EN i18n (760+ translation keys)
+- **17-page Streamlit UI**, full IT+EN i18n (760+ translation keys)
 
 ## What's implemented
 
@@ -54,7 +54,7 @@ Would one of these help you? Tell us in [GitHub Discussions](https://github.com/
 
 ```bash
 git clone https://github.com/drake69/spendif-ai.git
-cd spendify
+cd spendif-ai
 uv sync --extra desktop
 
 # Local LLM (developer choice — the desktop installer handles this automatically):
@@ -102,7 +102,7 @@ Full diagram and Flow 1 vs Flow 2 → [docs/architecture.md](docs/architecture.m
 
 ```
 sw_artifacts/
-├── app.py                  # Streamlit entry point (onboarding gate + 14 pages)
+├── app.py                  # Streamlit entry point (onboarding gate + 17 pages)
 ├── core/                   # Pipeline: orchestrator, normalizer, classifier, categorizer, sanitizer, llm_backends
 ├── services/               # Facade layer for UI; async runner; settings; import
 ├── ui/                     # Streamlit pages + i18n + widgets

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "spendif-ai"
-version = "3.0.0"
+version = "0.1.0"
 description = "Unified personal finance ledger with hybrid LLM pipeline"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -2101,7 +2101,7 @@ wheels = [
 
 [[package]]
 name = "spendif-ai"
-version = "3.0.0"
+version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
README diceva **Spendif.ai v3.0** ma la versione rilasciata è **0.1.0**. Allineato ovunque: titoli README (tolto v3.0), `pyproject` 3.0.0→0.1.0 (uv.lock rigenerato). Più due fix di refuso: `cd spendify`→`cd spendif-ai` e conteggio pagine 14/~15 → **17**. Il `developer_guide` 'Version: 3.0' è la revisione del documento, non toccata.