### PR TITLE
feat(pages): direct installer downloads on getting-started (all langs)

### DIFF
--- a/getting-started.de.html
+++ b/getting-started.de.html
@@ -100,35 +100,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Für dein System herunterladen</h2>
-      <p>Die offiziellen Installer werden als Assets jedes <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a> veröffentlicht. Wähle das passende Format für dein Betriebssystem.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG herunterladen</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG herunterladen</a>
           <div class="dl-notes">macOS 12 Monterey oder neuer. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX herunterladen</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX herunterladen</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + vertrauenswürdiges Zertifikat in der Pre-Alpha erforderlich.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb herunterladen</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb herunterladen</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm herunterladen</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm herunterladen</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -257,5 +256,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendif-ai" target="_blank">Quellcode auf GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.en.html
+++ b/getting-started.en.html
@@ -173,14 +173,13 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Download for your system</h2>
-      <p>Official installers are published as assets on each <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Pick the format for your OS.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download DMG</a>
           <div class="dl-notes">macOS 12 Monterey or later. Apple Silicon + Intel.</div>
         </div>
 
@@ -188,7 +187,7 @@
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + trusted cert needed during pre-alpha.</div>
         </div>
 
@@ -196,7 +195,7 @@
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
 
@@ -204,7 +203,7 @@
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Download .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -362,5 +361,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendif-ai" target="_blank">Source on GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.es.html
+++ b/getting-started.es.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Descarga para tu sistema</h2>
-      <p>Los instaladores oficiales se publican como activos de cada <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Elige el formato adecuado para tu SO.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar DMG</a>
           <div class="dl-notes">macOS 12 Monterey o superior. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + cert de confianza requeridos en la fase pre-alfa.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Descargar .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -256,5 +255,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendif-ai" target="_blank">Código fuente en GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.fr.html
+++ b/getting-started.fr.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Téléchargez pour votre système</h2>
-      <p>Les installeurs officiels sont publiés en tant qu'assets de chaque <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Choisissez le format adapté à votre OS.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger DMG</a>
           <div class="dl-notes">macOS 12 Monterey ou supérieur. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + certificat de confiance requis pendant la pré-alpha.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Télécharger .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -256,5 +255,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · Licence MIT · <a href="https://github.com/drake69/spendif-ai" target="_blank">Code source sur GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.html
+++ b/getting-started.html
@@ -182,7 +182,6 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Scarica per il tuo sistema</h2>
-      <p>Gli installer ufficiali sono pubblicati come asset di ogni <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Scegli il formato adatto al tuo OS.</p>
 
       <div class="dl-grid">
         <!-- macOS -->
@@ -190,7 +189,7 @@
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank" rel="noopener">Scarica DMG</a>
           <div class="dl-notes">macOS 12 Monterey o superiore. Apple Silicon + Intel.</div>
         </div>
 
@@ -199,7 +198,7 @@
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + cert trusted richiesti per la fase pre-alpha.</div>
         </div>
 
@@ -208,7 +207,7 @@
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
 
@@ -217,7 +216,7 @@
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Scarica .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -384,5 +383,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendif-ai" target="_blank">Source on GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.ja.html
+++ b/getting-started.ja.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>お使いの OS 用にダウンロード</h2>
-      <p>公式インストーラーは各 <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a> のアセットとして公開されています。OS に合ったフォーマットを選んでください。</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG をダウンロード</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG をダウンロード</a>
           <div class="dl-notes">macOS 12 Monterey 以降。Apple Silicon + Intel 対応。</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX をダウンロード</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX をダウンロード</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11。プレアルファ期間中はサイドロード + 信頼された証明書が必要です。</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb をダウンロード</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb をダウンロード</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+。</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm をダウンロード</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm をダウンロード</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+。</div>
         </div>
       </div>
@@ -242,5 +241,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT License · <a href="https://github.com/drake69/spendif-ai" target="_blank">GitHub のソースコード</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.nl.html
+++ b/getting-started.nl.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Download voor jouw systeem</h2>
-      <p>De officiële installers worden gepubliceerd als assets van elke <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Kies het juiste formaat voor je OS.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG downloaden</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">DMG downloaden</a>
           <div class="dl-notes">macOS 12 Monterey of nieuwer. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX downloaden</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">MSIX downloaden</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + vertrouwd certificaat vereist in de pre-alpha-fase.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb downloaden</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.deb downloaden</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm downloaden</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">.rpm downloaden</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -242,5 +241,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · MIT-licentie · <a href="https://github.com/drake69/spendif-ai" target="_blank">Broncode op GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.pl.html
+++ b/getting-started.pl.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Pobierz dla swojego systemu</h2>
-      <p>Oficjalne instalatory są publikowane jako zasoby każdego <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Wybierz format odpowiedni dla Twojego systemu.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz DMG</a>
           <div class="dl-notes">macOS 12 Monterey lub nowszy. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. W fazie pre-alfa wymagany sideload + zaufany certyfikat.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Pobierz .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -242,5 +241,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · Licencja MIT · <a href="https://github.com/drake69/spendif-ai" target="_blank">Kod źródłowy na GitHubie</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>

--- a/getting-started.pt.html
+++ b/getting-started.pt.html
@@ -99,35 +99,34 @@
     </section>
     <section id="download">
       <h2><span class="step-num">1</span>Baixe para o seu sistema</h2>
-      <p>Os instaladores oficiais são publicados como assets de cada <a href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">GitHub Release</a>. Escolha o formato adequado para o seu SO.</p>
 
       <div class="dl-grid">
         <div class="dl-card">
           <div class="os-icon">🍎</div>
           <h3>macOS</h3>
           <div class="ext">SpendifAi-*.dmg</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar DMG</a>
+          <a id="dl-mac" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar DMG</a>
           <div class="dl-notes">macOS 12 Monterey ou superior. Apple Silicon + Intel.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🪟</div>
           <h3>Windows</h3>
           <div class="ext">SpendifAi-*.msix</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar MSIX</a>
+          <a id="dl-win" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar MSIX</a>
           <div class="dl-notes">Windows 10 1809+ / Windows 11. Sideload + certificado confiável necessários na fase pre-alpha.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🐧</div>
           <h3>Debian / Ubuntu</h3>
           <div class="ext">spendifai_*_amd64.deb</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar .deb</a>
+          <a id="dl-deb" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar .deb</a>
           <div class="dl-notes">Ubuntu 22.04+, Debian 12+, Mint 21+.</div>
         </div>
         <div class="dl-card">
           <div class="os-icon">🎩</div>
           <h3>Fedora / RHEL</h3>
           <div class="ext">spendifai-*.rpm</div>
-          <a class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar .rpm</a>
+          <a id="dl-rpm" class="dl-btn" href="https://github.com/drake69/spendif-ai/releases/latest" target="_blank">Baixar .rpm</a>
           <div class="dl-notes">Fedora 40+, RHEL 9+, Rocky / Alma 9+.</div>
         </div>
       </div>
@@ -242,5 +241,34 @@
   <footer>
     <p>© 2026 Luigi Corsaro · Spendif.ai · Licença MIT · <a href="https://github.com/drake69/spendif-ai" target="_blank">Código-fonte no GitHub</a></p>
   </footer>
+  <!-- Direct-download: resolve the latest release assets and point each OS button at its file -->
+  <script>
+  (function () {
+    var MATCH = {
+      'dl-mac': function (n) { return /\.dmg$/i.test(n); },
+      'dl-win': function (n) { return /\.msix$/i.test(n); },
+      'dl-deb': function (n) { return /_amd64\.deb$/i.test(n); },
+      'dl-rpm': function (n) { return /\.rpm$/i.test(n); }
+    };
+    fetch('https://api.github.com/repos/drake69/spendif-ai/releases/latest', { headers: { 'Accept': 'application/vnd.github+json' } })
+      .then(function (r) { return r.ok ? r.json() : Promise.reject(r.status); })
+      .then(function (rel) {
+        var assets = (rel && rel.assets) || [];
+        Object.keys(MATCH).forEach(function (id) {
+          var el = document.getElementById(id);
+          if (!el) return;
+          for (var i = 0; i < assets.length; i++) {
+            if (MATCH[id](assets[i].name)) {
+              el.href = assets[i].browser_download_url;
+              el.setAttribute('download', '');
+              el.removeAttribute('target');
+              break;
+            }
+          }
+        });
+      })
+      .catch(function () { /* keep the releases-page fallback href */ });
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
OS download buttons now trigger a direct file download of the latest release asset (resolved via GitHub API), instead of linking to the releases page. Graceful fallback to the releases page if the API is unreachable. Removes the redundant pointer text under the download heading. All 9 language variants.