### PR TITLE
docs+brand: Python >=3.12 install docs, EN landing brand, IT README link

### DIFF
--- a/README.it.md
+++ b/README.it.md
@@ -17,7 +17,7 @@ Registro finanziario personale unificato con pipeline ibrida deterministica + LL
 ---
 
 > 👋 **Utente finale — vuoi installare Spendif.ai?**
-> Vai alla [pagina Primo avvio](https://drake69.github.io/spendif-ai/getting-started.html) per la guida illustrata all'installazione e al primo avvio. Questo README è dedicato a sviluppatori e contributor.
+> Vai alla [pagina Primo avvio](https://drake69.github.io/spendif-ai/getting-started.it.html) per la guida illustrata all'installazione e al primo avvio. Questo README è dedicato a sviluppatori e contributor.
 
 ---
 

--- a/docs/installation_macos.it.md
+++ b/docs/installation_macos.it.md
@@ -15,7 +15,7 @@
 | macOS | 12 Monterey | 13 Ventura o successivo |
 | RAM | 8 GB | 16 GB (per LLM da 12B parametri) |
 | Disco | 5 GB liberi | 10 GB (modelli + dati) |
-| Python | 3.11 | 3.13 (installato dalla modalità `--brew`) |
+| Python | 3.12 | 3.13 (installato dalla modalità `--brew`) |
 | Xcode CLT | richiesto | richiesto |
 | Homebrew | opzionale | necessario solo per la modalità `--brew` |
 
@@ -71,7 +71,7 @@ manager basato su Rust) viene scaricato automaticamente se assente.
 **Pro:**
 - Nessun Homebrew richiesto — zero dipendenze oltre a `git` e `curl`
 - Setup più veloce (nessun bootstrap del package manager)
-- Funziona allo stesso modo su qualsiasi Python >= 3.11
+- Funziona allo stesso modo su qualsiasi Python >= 3.12
 
 **Contro:**
 - La versione di Python dipende da quella già installata
@@ -354,7 +354,7 @@ comando qui sopra.
 
 **Sintomo:**
 ```
-✖  Python 3.9 found, but >= 3.11 required.
+✖  Python 3.9 found, but >= 3.12 required.
 ```
 
 **Fix — opzione A:** usa la modalità Homebrew per ottenere Python 3.13:

--- a/docs/installation_macos.md
+++ b/docs/installation_macos.md
@@ -13,7 +13,7 @@
 | macOS | 12 Monterey | 13 Ventura or later |
 | RAM | 8 GB | 16 GB (for 12B parameter LLM) |
 | Disk | 5 GB free | 10 GB (models + data) |
-| Python | 3.11 | 3.13 (installed by `--brew` mode) |
+| Python | 3.12 | 3.13 (installed by `--brew` mode) |
 | Xcode CLT | required | required |
 | Homebrew | optional | needed only for `--brew` mode |
 
@@ -69,7 +69,7 @@ manager) is downloaded automatically if absent.
 **Pros:**
 - No Homebrew required — zero dependencies beyond `git` and `curl`
 - Faster setup (no package manager bootstrap)
-- Works identically on any Python >= 3.11
+- Works identically on any Python >= 3.12
 
 **Cons:**
 - Python version depends on what you already have installed
@@ -342,7 +342,7 @@ command above.
 
 **Symptom:**
 ```
-✖  Python 3.9 found, but >= 3.11 required.
+✖  Python 3.9 found, but >= 3.12 required.
 ```
 
 **Fix — option A:** use Homebrew mode to get Python 3.13:

--- a/docs/installazione.en.md
+++ b/docs/installazione.en.md
@@ -39,7 +39,7 @@ The configuration is saved in the database (`user_settings`) and persists across
 
 ## 🍎 Mac One-Click — Automatic installation (recommended)
 
-**Prerequisites:** macOS 12+, Python 3.11+, internet connection
+**Prerequisites:** macOS 12+, Python 3.12+, internet connection
 
 1. Download `install_spendifai.command` from the [repository](https://github.com/drake69/spendif-ai)
 2. **Double-click** the file in Finder
@@ -64,7 +64,7 @@ llama.cpp on Mac uses **Metal (Apple Silicon)** acceleration automatically. Insi
 
 ### Prerequisites
 
-- **Python >= 3.13** — check with `python3 --version`. On macOS: `brew install python@3.13`
+- **Python >= 3.12** — check with `python3 --version`. On macOS: `brew install python@3.13`
 - **Git**
 
 ### Step 1 — Clone the repository
@@ -161,7 +161,7 @@ Same procedure as Mac. llama.cpp automatically supports NVIDIA GPUs (CUDA) if dr
 
 ### Prerequisites
 
-- **Python >= 3.13** — check with `python3 --version`. On Ubuntu/Debian: `sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt install python3.13 python3.13-venv`
+- **Python >= 3.12** — check with `python3 --version`. On Ubuntu/Debian: `sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt install python3.13 python3.13-venv`
 - **Git** — `sudo apt install git`
 - **curl** — `sudo apt install curl`
 

--- a/docs/installazione.md
+++ b/docs/installazione.md
@@ -39,7 +39,7 @@ La configurazione viene salvata nel database (`user_settings`) e persiste tra i 
 
 ## 🍎 Mac One-Click — Installazione automatica (consigliata)
 
-**Prerequisiti:** macOS 12+, Python 3.11+, connessione internet
+**Prerequisiti:** macOS 12+, Python 3.12+, connessione internet
 
 1. Scarica `install_spendifai.command` dal [repository](https://github.com/drake69/spendif-ai)
 2. **Double-click** sul file in Finder
@@ -64,7 +64,7 @@ llama.cpp su Mac usa l'accelerazione **Metal (Apple Silicon)** automaticamente. 
 
 ### Prerequisiti
 
-- **Python >= 3.13** — verifica con `python3 --version`. Su macOS: `brew install python@3.13`
+- **Python >= 3.12** — verifica con `python3 --version`. Su macOS: `brew install python@3.13`
 - **Git**
 
 ### Step 1 — Clona il repository
@@ -161,7 +161,7 @@ Stessa procedura del Mac. llama.cpp supporta automaticamente GPU NVIDIA (CUDA) s
 
 ### Prerequisiti
 
-- **Python >= 3.13** — verifica con `python3 --version`. Su Ubuntu/Debian: `sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt install python3.13 python3.13-venv`
+- **Python >= 3.12** — verifica con `python3 --version`. Su Ubuntu/Debian: `sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt install python3.13 python3.13-venv`
 - **Git** — `sudo apt install git`
 - **curl** — `sudo apt install curl`
 

--- a/index.en.html
+++ b/index.en.html
@@ -746,7 +746,7 @@
   <div class="hero-badge">Open source · <strong>Offline-first</strong> · No subscription</div>
   <h1>Your <span class="accent">unified</span> bank ledger,<br>on your computer</h1>
   <p class="hero-sub">
-    Import files from all your banks. Spendify merges them, eliminates double-counting,
+    Import files from all your banks. Spendif.ai merges them, eliminates double-counting,
     classifies every transaction — and your data never leaves your disk.
   </p>
   <div class="hero-actions">
@@ -818,13 +818,13 @@
       <div class="step">
         <h3>Download files from your bank</h3>
         <p>Export movements files as CSV or XLSX from your bank's portal.
-        Works with any bank — Spendify automatically detects
+        Works with any bank — Spendif.ai automatically detects
         the format with no manual configuration.</p>
       </div>
       <div class="step">
-        <h3>Drag them into Spendify and click Process</h3>
+        <h3>Drag them into Spendif.ai and click Process</h3>
         <p>Select all files at once, even from different banks, even from different years.
-        Spendify detects the document type, corrects signs, eliminates double-counting
+        Spendif.ai detects the document type, corrects signs, eliminates double-counting
         between card and account, and classifies every transaction.</p>
       </div>
       <div class="step">
@@ -850,7 +850,7 @@
         <div class="tag">RF-03</div>
         <h3>Credit card–current account reconciliation</h3>
         <p>When the credit card charges the monthly amount to the current account,
-        Spendify recognises the relationship and removes the double-counting automatically.</p>
+        Spendif.ai recognises the relationship and removes the double-counting automatically.</p>
         <p style="margin-top:.75rem; color: var(--muted); font-size:.88rem;">
           Time window ±45 days · 3 matching phases:
           sliding window → subset sum for split amounts → partial reconciliation
@@ -860,7 +860,7 @@
         <div class="tag">RF-04</div>
         <h3>Internal transfer detection</h3>
         <p>A wire transfer from a current account to a savings account is neither an expense nor
-        income: it is an internal transfer. Spendify recognises it by comparing
+        income: it is an internal transfer. Spendif.ai recognises it by comparing
         amounts, dates, and account holder names in the descriptions — even if the two files
         were imported at different times.</p>
       </div>
@@ -899,14 +899,14 @@
       <div class="privacy-card">
         <div class="ico-big">🏠</div>
         <h3>Offline-first by default</h3>
-        <p>Spendify uses <strong>Ollama locally</strong> by default: an AI engine that runs
+        <p>Spendif.ai uses <strong>Ollama locally</strong> by default: an AI engine that runs
         on your computer, with no internet connection. Your movements files never
         leave your disk.</p>
       </div>
       <div class="privacy-card">
         <div class="ico-big">🛡️</div>
         <h3>Automatic PII redaction</h3>
-        <p>If you use OpenAI or Claude, Spendify automatically removes all
+        <p>If you use OpenAI or Claude, Spendif.ai automatically removes all
         identifying data before any remote call:</p>
         <div class="pii-chips">
           <span class="pii-chip">IBAN → &lt;ACCOUNT_ID&gt;</span>
@@ -934,9 +934,9 @@
 <!-- ── FOR WHO ───────────────────────────────────────────────────────────── -->
 <section id="per-chi">
   <div class="container">
-    <div class="section-label">Who Spendify is for</div>
+    <div class="section-label">Who Spendif.ai is for</div>
     <h2>Not for everyone. For those who want real control.</h2>
-    <p class="section-sub">Four profiles that find in Spendify something alternatives do not offer.</p>
+    <p class="section-sub">Four profiles that find in Spendif.ai something alternatives do not offer.</p>
 
     <div class="audience-grid fade-in">
       <div class="audience-card">
@@ -944,15 +944,15 @@
         <div>
           <h3>People with accounts at multiple banks</h3>
           <p>Current account + credit card + savings account + trading account?
-          Spendify unifies them all into a single ledger without having to do anything manually.</p>
+          Spendif.ai unifies them all into a single ledger without having to do anything manually.</p>
         </div>
       </div>
       <div class="audience-card">
         <div class="ico-circle">📊</div>
         <div>
           <h3>People who track their finances seriously</h3>
-          <p>If you use Excel for your expenses, Spendify can replace that routine:
-          you import the files once, Spendify unifies and classifies, you review
+          <p>If you use Excel for your expenses, Spendif.ai can replace that routine:
+          you import the files once, Spendif.ai unifies and classifies, you review
           only the exceptions.</p>
         </div>
       </div>
@@ -1318,11 +1318,11 @@
 <!-- ── FOOTER ─────────────────────────────────────────────────────────────── -->
 <footer>
   <p>
-    <strong>Spendify</strong> is open source —
+    <strong>Spendif.ai</strong> is open source —
     <a href="https://github.com/drake69/spendif-ai" target="_blank">github.com/drake69/spendif-ai</a>
   </p>
   <p class="disclaimer">
-    Spendify is not a cloud service. It is a program that runs on your computer.
+    Spendif.ai is not a cloud service. It is a program that runs on your computer.
     Your banking data is never sent to third-party servers, unless you explicitly choose
     a remote LLM backend — in that case, all identifying data is
     removed before transmission.


### PR DESCRIPTION
Small doc/brand fixes: align install docs to Python >=3.12 (AI-120), fix Spendify->Spendif.ai on the EN landing (AI-122), point IT README to getting-started.it.html (AI-123).