### PR TITLE
fix(desktop): nascondi Deploy button / toolbar Streamlit

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,7 +1,7 @@
 # Streamlit client config.
-# toolbarMode = "minimal" nasconde la toolbar in alto a destra (bottone "Deploy"
-# + menu sviluppatore): irrilevante/confusionaria in un'app desktop nativa.
-# Applicato globalmente a tutte le pagine, indipendente dai selettori CSS che
-# cambiano tra le release di Streamlit.
+# toolbarMode = "viewer": nasconde le voci da SVILUPPATORE (bottone "Deploy",
+# Clear cache, Record, Developer options) ma TIENE il menu utente ☰ con
+# Settings -> Tema (dark/light/system), Print, About. "minimal" invece toglieva
+# anche il tema. Applicato globalmente, indipendente dai selettori CSS.
 [client]
-toolbarMode = "minimal"
+toolbarMode = "viewer"

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,7 @@
+# Streamlit client config.
+# toolbarMode = "minimal" nasconde la toolbar in alto a destra (bottone "Deploy"
+# + menu sviluppatore): irrilevante/confusionaria in un'app desktop nativa.
+# Applicato globalmente a tutte le pagine, indipendente dai selettori CSS che
+# cambiano tra le release di Streamlit.
+[client]
+toolbarMode = "minimal"

--- a/app.py
+++ b/app.py
@@ -123,8 +123,9 @@ if not _cfg_check.is_onboarding_done() or _in_step6:
             padding-top: 2rem;
             padding-bottom: 4rem;
         }
-        /* Streamlit injects a small "Manage app" button — hide it too */
-        .stDeployButton { display: none !important; }
+        /* Streamlit injects a small "Manage app"/"Deploy" button — hide it too.
+           Both the legacy class and the current testid (Streamlit rinomina spesso). */
+        .stDeployButton, [data-testid="stAppDeployButton"] { display: none !important; }
         </style>
     """, unsafe_allow_html=True)
 

--- a/desktop/launcher.py
+++ b/desktop/launcher.py
@@ -493,6 +493,9 @@ def _start_streamlit(port: int, app_dir: Path) -> subprocess.Popen:
     env = os.environ.copy()
     env["STREAMLIT_BROWSER_GATHER_USAGE_STATS"] = "false"
     env["STREAMLIT_GLOBAL_DEVELOPMENT_MODE"] = "false"
+    # Nasconde la toolbar Streamlit (bottone "Deploy" + menu dev): app desktop.
+    # Via env così vale anche nel bundle, dove .streamlit/config.toml può non esserci.
+    env["STREAMLIT_CLIENT_TOOLBAR_MODE"] = "minimal"
 
     popen_kwargs = {"env": env, "cwd": str(app_dir)}
     if sys.platform != "win32":

--- a/desktop/launcher.py
+++ b/desktop/launcher.py
@@ -493,9 +493,10 @@ def _start_streamlit(port: int, app_dir: Path) -> subprocess.Popen:
     env = os.environ.copy()
     env["STREAMLIT_BROWSER_GATHER_USAGE_STATS"] = "false"
     env["STREAMLIT_GLOBAL_DEVELOPMENT_MODE"] = "false"
-    # Nasconde la toolbar Streamlit (bottone "Deploy" + menu dev): app desktop.
+    # Nasconde le voci sviluppatore della toolbar (Deploy, ecc.) ma TIENE il menu
+    # utente con Settings->Tema. "viewer" (non "minimal", che toglieva anche il tema).
     # Via env così vale anche nel bundle, dove .streamlit/config.toml può non esserci.
-    env["STREAMLIT_CLIENT_TOOLBAR_MODE"] = "minimal"
+    env["STREAMLIT_CLIENT_TOOLBAR_MODE"] = "viewer"
 
     popen_kwargs = {"env": env, "cwd": str(app_dir)}
     if sys.platform != "win32":


### PR DESCRIPTION
Il pulsante Deploy della toolbar Streamlit non ha senso in un'app desktop. Nascosto via config.toml (toolbarMode=minimal), env nel launcher (per il bundle), e CSS aggiornato al testid corrente (stAppDeployButton).